### PR TITLE
Upgrade AssertJ from 3.8.0 to 3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<lsp4j.version>0.3.0</lsp4j.version>
 		<slf4j.version>1.7.6</slf4j.version>
 		<junit.version>4.12</junit.version>
-		<assertj.version>3.8.0</assertj.version>
+		<assertj.version>3.9.1</assertj.version>
 		<camel.version>2.21.0</camel.version>
 	</properties>
 


### PR DESCRIPTION
it provides several Java 8 specific sugar features

Signed-off-by: Aurélien Pupier <apupier@redhat.com>