### PR TITLE
Upgrade jacoco from 0.7.9 to 0.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.9</version>
+				<version>0.8.1</version>
 				<configuration>
 					<append>true</append>
 					<includes>com.github.cameltooling.*</includes>


### PR DESCRIPTION
notable features:
- more accurate coverage
- Java 9 and 10 supports

Signed-off-by: Aurélien Pupier <apupier@redhat.com>