### PR TITLE
Fix sonar code smell

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/AbstractLanguageServer.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/AbstractLanguageServer.java
@@ -77,7 +77,7 @@ public abstract class AbstractLanguageServer {
 		if (parentProcessId == 0) {
 			LOGGER.info("Waiting for a client connection...");
 		} else {
-			LOGGER.info("Checking for client process pid: {0}", parentProcessId);
+			LOGGER.info("Checking for client process pid: {}", parentProcessId);
 		}
 		
 		if (parentProcessId == 0) return true;
@@ -129,7 +129,7 @@ public abstract class AbstractLanguageServer {
 	 * @param processId	the process id
 	 */
 	protected synchronized void setParentProcessId(long processId) {
-		LOGGER.info("Setting client pid to {0}", processId);
+		LOGGER.info("Setting client pid to {}", processId);
 		parentProcessId = processId;
 	}
 	

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -77,106 +77,106 @@ public class CamelTextDocumentService implements TextDocumentService {
 	
 	@Override
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(TextDocumentPositionParams completionRequest) {
-		LOGGER.info("completion: " + completionRequest.getTextDocument().getUri());
+		LOGGER.info("completion: {}", completionRequest.getTextDocument().getUri());
 		TextDocumentItem textDocumentItem = openedDocuments.get(completionRequest.getTextDocument().getUri());
 		return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(completionRequest.getPosition()).thenApply(Either::forLeft);
 	}
 
 	@Override
 	public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
-		LOGGER.info("resolveCompletionItem: " + unresolved.getDetail());
+		LOGGER.info("resolveCompletionItem: {}", unresolved.getDetail());
 		return CompletableFuture.completedFuture(unresolved);
 	}
 
 	@Override
 	public CompletableFuture<Hover> hover(TextDocumentPositionParams position) {
-		LOGGER.info("hover: " + position.getTextDocument());
+		LOGGER.info("hover: {}", position.getTextDocument());
 		TextDocumentItem textDocumentItem = openedDocuments.get(position.getTextDocument().getUri());
 		return new HoverProcessor(textDocumentItem, camelCatalog).getHover(position.getPosition());
 	}
 
 	@Override
 	public CompletableFuture<SignatureHelp> signatureHelp(TextDocumentPositionParams position) {
-		LOGGER.info("signatureHelp: " + position.getTextDocument());
+		LOGGER.info("signatureHelp: {}", position.getTextDocument());
 		return CompletableFuture.completedFuture(null);
 	}
 
 	@Override
 	public CompletableFuture<List<? extends Location>> definition(TextDocumentPositionParams position) {
-		LOGGER.info("definition: " + position.getTextDocument());
+		LOGGER.info("definition: {}", position.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
-		LOGGER.info("references: " + params.getTextDocument());
+		LOGGER.info("references: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(TextDocumentPositionParams position) {
-		LOGGER.info("documentHighlight: " + position.getTextDocument());
+		LOGGER.info("documentHighlight: {}", position.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<List<? extends SymbolInformation>> documentSymbol(DocumentSymbolParams params) {
-		LOGGER.info("documentSymbol: " + params.getTextDocument());
+		LOGGER.info("documentSymbol: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<List<? extends Command>> codeAction(CodeActionParams params) {
-		LOGGER.info("codeAction: " + params.getTextDocument());
+		LOGGER.info("codeAction: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
-		LOGGER.info("codeLens: " + params.getTextDocument());
+		LOGGER.info("codeLens: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<CodeLens> resolveCodeLens(CodeLens unresolved) {
-		LOGGER.info("resolveCodeLens: " + unresolved.getCommand().getCommand());
+		LOGGER.info("resolveCodeLens: {}", unresolved.getCommand().getCommand());
 		return CompletableFuture.completedFuture(null);
 	}
 
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
-		LOGGER.info("formatting: " + params.getTextDocument());
+		LOGGER.info("formatting: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
-		LOGGER.info("rangeFormatting: " + params.getTextDocument());
+		LOGGER.info("rangeFormatting: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(DocumentOnTypeFormattingParams params) {
-		LOGGER.info("onTypeFormatting: " + params.getTextDocument());
+		LOGGER.info("onTypeFormatting: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
-		LOGGER.info("rename: " + params.getTextDocument());
+		LOGGER.info("rename: {}", params.getTextDocument());
 		return CompletableFuture.completedFuture(null);
 	}
 
 	@Override
 	public void didOpen(DidOpenTextDocumentParams params) {
 		TextDocumentItem textDocument = params.getTextDocument();
-		LOGGER.info("didOpen: {0}", textDocument);
+		LOGGER.info("didOpen: {}", textDocument);
 		openedDocuments.put(textDocument.getUri(), textDocument);
 	}
 
 	@Override
 	public void didChange(DidChangeTextDocumentParams params) {
-		LOGGER.info("didChange: " + params.getTextDocument());
+		LOGGER.info("didChange: {}", params.getTextDocument());
 		List<TextDocumentContentChangeEvent> contentChanges = params.getContentChanges();
 		TextDocumentItem textDocumentItem = openedDocuments.get(params.getTextDocument().getUri());
 		if (!contentChanges.isEmpty()) {
@@ -186,13 +186,13 @@ public class CamelTextDocumentService implements TextDocumentService {
 
 	@Override
 	public void didClose(DidCloseTextDocumentParams params) {
-		LOGGER.info("didClose: " + params.getTextDocument());
+		LOGGER.info("didClose: {}", params.getTextDocument());
 		openedDocuments.remove(params.getTextDocument().getUri());
 	}
 
 	@Override
 	public void didSave(DidSaveTextDocumentParams params) {
-		LOGGER.info("didSave: " + params.getTextDocument());
+		LOGGER.info("didSave: {}", params.getTextDocument());
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelWorkspaceService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelWorkspaceService.java
@@ -38,19 +38,19 @@ public class CamelWorkspaceService implements WorkspaceService {
 
 	@Override
 	public CompletableFuture<List<? extends SymbolInformation>> symbol(WorkspaceSymbolParams params) {
-		LOGGER.info("SERVER: symbolQuery: " + params.getQuery());
+		LOGGER.info("SERVER: symbolQuery: {}", params.getQuery());
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override
 	public void didChangeConfiguration(DidChangeConfigurationParams params) {
 		Object settings = params.getSettings();
-		LOGGER.info("SERVER: changeConfig: settings -> {0}", settings);
+		LOGGER.info("SERVER: changeConfig: settings -> {}", settings);
 	}
 
 	@Override
 	public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
 		List<FileEvent> settings = params.getChanges();
-		LOGGER.info("SERVER: changeWatchedFiles: size -> {0}", settings.size());
+		LOGGER.info("SERVER: changeWatchedFiles: size -> {}", settings.size());
 	}
 }


### PR DESCRIPTION
- use {} instead of {0} whcih is the correct usage with slf4j logger
- use parameters for log methods which avoids creating String in case
the level of log is not enabled

Signed-off-by: Aurélien Pupier <apupier@redhat.com>