### PR TITLE
#73 - support DocumentSymbol for Camel routes

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
@@ -80,6 +80,7 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 		capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
 		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".","?","&", "\"", "=")));
 		capabilities.setHoverProvider(Boolean.TRUE);
+		capabilities.setDocumentSymbolProvider(Boolean.TRUE);
 		return capabilities;
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -56,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
+import com.github.cameltooling.lsp.internal.documentsymbol.DocumentSymbolProcessor;
 import com.github.cameltooling.lsp.internal.hover.HoverProcessor;
 
 /**
@@ -122,7 +123,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 	@Override
 	public CompletableFuture<List<? extends SymbolInformation>> documentSymbol(DocumentSymbolParams params) {
 		LOGGER.info("documentSymbol: {}", params.getTextDocument());
-		return CompletableFuture.completedFuture(Collections.emptyList());
+		return new DocumentSymbolProcessor(openedDocuments.get(params.getTextDocument().getUri())).getDocumentSymbols();
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessor.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.documentsymbol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.camel.parser.helper.XmlLineNumberParser;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelper;
+
+public class DocumentSymbolProcessor {
+	
+	private static final String ATTRIBUTE_ID = "id";
+	private static final Logger LOGGER = LoggerFactory.getLogger(DocumentSymbolProcessor.class);
+	private TextDocumentItem textDocumentItem;
+	private ParserFileHelper parserFileHelper = new ParserFileHelper();
+
+	public DocumentSymbolProcessor(TextDocumentItem textDocumentItem) {
+		this.textDocumentItem = textDocumentItem;
+	}
+
+	public CompletableFuture<List<? extends SymbolInformation>> getDocumentSymbols() {
+		return CompletableFuture.supplyAsync(() -> {
+			try {
+				NodeList routeNodes = parserFileHelper.getRouteNodes(textDocumentItem);
+				if (routeNodes != null) {
+					return convertToSymbolInformation(routeNodes);
+				}
+			} catch (Exception e) {
+				LOGGER.error("Cannot determine document symbols", e);
+			}
+			return Collections.emptyList();
+		});
+	}
+
+	private List<SymbolInformation> convertToSymbolInformation(NodeList routeNodes) {
+		List<SymbolInformation> res = new ArrayList<>();
+		for (int i = 0; i < routeNodes.getLength(); i++) {
+			Node routeNode = routeNodes.item(i);
+			Position startPosition = new Position(retrieveIntUserData(routeNode, XmlLineNumberParser.LINE_NUMBER), retrieveIntUserData(routeNode, XmlLineNumberParser.COLUMN_NUMBER));
+			Position endPosition = new Position(retrieveIntUserData(routeNode, XmlLineNumberParser.LINE_NUMBER_END), retrieveIntUserData(routeNode, XmlLineNumberParser.COLUMN_NUMBER_END));
+			Range range = new Range(startPosition, endPosition);
+			Location location = new Location(textDocumentItem.getUri(), range);
+			String displayNameOfSymbol = computeDisplayNameOfSymbol(routeNode);
+			res.add(new SymbolInformation(displayNameOfSymbol, SymbolKind.Field, location));
+		}
+		return res;
+	}
+
+	private String computeDisplayNameOfSymbol(Node routeNode) {
+		Node routeIdAttribute = routeNode.getAttributes().getNamedItem(ATTRIBUTE_ID);
+		String displayNameOfSymbol;
+		if (routeIdAttribute != null) {
+			displayNameOfSymbol = routeIdAttribute.getNodeValue();
+		} else {
+			displayNameOfSymbol = "<no id>";
+		}
+		return displayNameOfSymbol;
+	}
+
+	private int retrieveIntUserData(Node node, String userData) {
+		return Integer.parseInt((String)node.getUserData(userData)) -1;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelper.java
@@ -36,6 +36,7 @@ import org.xml.sax.SAXException;
 
 public class ParserFileHelper {
 	
+	private static final String ATTRIBUTE_ROUTE = "route";
 	private static final String NAMESPACEURI_CAMEL_BLUEPRINT = "http://camel.apache.org/schema/blueprint";
 	private static final String NAMESPACEURI_CAMEL_SPRING = "http://camel.apache.org/schema/spring";
 	private static final List<String> CAMEL_NODES_TAG = Arrays.asList("to", "from");
@@ -121,6 +122,14 @@ public class ParserFileHelper {
 			}
 		}
 		return false;
+	}
+
+	public NodeList getRouteNodes(TextDocumentItem textDocumentItem) throws Exception {
+		if (hasElementFromCamelNamespace(textDocumentItem)) {
+			Document parsedXml = XmlLineNumberParser.parseXml(new ByteArrayInputStream(textDocumentItem.getText().getBytes(StandardCharsets.UTF_8)));
+			return parsedXml.getElementsByTagName(ATTRIBUTE_ROUTE);
+		}
+		return null;
 	}
 	
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.MessageActionItem;
@@ -25,6 +26,7 @@ import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
@@ -102,6 +104,12 @@ public abstract class AbstractCamelLanguageServerTest {
 		TextDocumentPositionParams dummyCompletionPositionRequest = new TextDocumentPositionParams(new TextDocumentIdentifier(DUMMY_URI), position);
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = textDocumentService.completion(dummyCompletionPositionRequest);
 		return completions;
+	}
+	
+	protected CompletableFuture<List<? extends SymbolInformation>> getDocumentSymbolFor(CamelLanguageServer camelLanguageServer) {
+		TextDocumentService textDocumentService = camelLanguageServer.getTextDocumentService();
+		DocumentSymbolParams params = new DocumentSymbolParams(new TextDocumentIdentifier(DUMMY_URI));
+		return textDocumentService.documentSymbol(params);
 	}
 
 	public File getTestResource(String name) throws URISyntaxException {

--- a/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.documentsymbol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+public class DocumentSymbolProcessorTest extends AbstractCamelLanguageServerTest {
+	
+	@Test
+	public void testRoutesProvidedAsDocumentSymbol() throws Exception {
+		String textTotest =
+				"<camelContext id=\"camel\" xmlns=\"http://camel.apache.org/schema/spring\">\r\n" + 
+				"\r\n" + 
+				"    <route id=\"a route\">\r\n" + 
+				"      <from uri=\"direct:cafe\"/>\r\n" + 
+				"      <split>\r\n" + 
+				"        <method bean=\"orderSplitter\"/>\r\n" + 
+				"        <to uri=\"direct:drink\"/>\r\n" + 
+				"      </split>\r\n" + 
+				"    </route>\r\n" + 
+				"\r\n" + 
+				"    <route id=\"another Route\">\r\n" + 
+				"      <from uri=\"direct:drink\"/>\r\n" + 
+				"      <recipientList>\r\n" + 
+				"        <method bean=\"drinkRouter\"/>\r\n" + 
+				"      </recipientList>\r\n" + 
+				"    </route>\n"
+				+ "</camelContext>\n";
+		List<? extends SymbolInformation> documentSymbols = testRetrieveDocumentSymbol(textTotest, 2);
+		SymbolInformation firstRoute = documentSymbols.get(0);
+		assertThat(firstRoute.getName()).isEqualTo("a route");
+		Position expectedStart = new Position(2, 24/* expecting 4 but seems a bug in Camel*/);
+		Position expectedEnd = new Position(8, 12);
+		assertThat(firstRoute.getLocation()).isEqualToComparingFieldByFieldRecursively(new Location(DUMMY_URI, new Range(expectedStart, expectedEnd)));
+	}
+
+	@Test
+	public void testEmptyCamelContextReturnNoDocumentSymbol() throws Exception {
+		String textTotest =
+				"<camelContext id=\"camel\" xmlns=\"http://camel.apache.org/schema/spring\">\r\n" + 
+				"</camelContext>\n";
+		testRetrieveDocumentSymbol(textTotest, 0);
+	}
+	
+	@Test
+	public void testRoutesWithoutId() throws Exception {
+		String textTotest =
+				"<camelContext id=\"camel\" xmlns=\"http://camel.apache.org/schema/spring\">\r\n" + 
+				"\r\n" + 
+				"    <route id=\"a route\">\r\n" + 
+				"      <from uri=\"direct:cafe\"/>\r\n" + 
+				"      <split>\r\n" + 
+				"        <method bean=\"orderSplitter\"/>\r\n" + 
+				"        <to uri=\"direct:drink\"/>\r\n" + 
+				"      </split>\r\n" + 
+				"    </route>\r\n" + 
+				"\r\n" + 
+				"    <route id=\"another Route\">\r\n" + 
+				"      <from uri=\"direct:drink\"/>\r\n" + 
+				"      <recipientList>\r\n" + 
+				"        <method bean=\"drinkRouter\"/>\r\n" + 
+				"      </recipientList>\r\n" + 
+				"    </route>\n" +
+				"    <route>\r\n" + 
+				"      <from uri=\"direct:drink\"/>\r\n" + 
+				"      <recipientList>\r\n" + 
+				"        <method bean=\"drinkRouter\"/>\r\n" + 
+				"      </recipientList>\r\n" + 
+				"    </route>\n"
+				+ "</camelContext>\n";
+		testRetrieveDocumentSymbol(textTotest, 3);
+	}
+	
+	@Test
+	@Ignore("ignore until it is fixed more globally, see https://github.com/camel-tooling/camel-language-server/issues/74")
+	public void testRoutesProvidedAsDocumentSymbolWithNamespaceprefix() throws Exception {
+		String textTotest =
+				"<camel:camelContext id=\"camel\" xmlns:camel=\"http://camel.apache.org/schema/spring\">\r\n" + 
+				"\r\n" + 
+				"    <camel:route id=\"a route\">\r\n" + 
+				"      <camel:from uri=\"direct:cafe\"/>\r\n" + 
+				"      <camel:split>\r\n" + 
+				"        <camel:method bean=\"orderSplitter\"/>\r\n" + 
+				"        <camel:to uri=\"direct:drink\"/>\r\n" + 
+				"      </camel:split>\r\n" + 
+				"    </camel:route>\r\n" + 
+				"\r\n" + 
+				"    <camel:route id=\"another Route\">\r\n" + 
+				"      <camel:from uri=\"direct:drink\"/>\r\n" + 
+				"      <camel:recipientList>\r\n" + 
+				"        <camel:method bean=\"drinkRouter\"/>\r\n" + 
+				"      </camel:recipientList>\r\n" + 
+				"    </camel:route>\n"
+				+ "</camel:camelContext>\n";
+		testRetrieveDocumentSymbol(textTotest, 2);
+	}
+
+	private List<? extends SymbolInformation> testRetrieveDocumentSymbol(String textTotest, int expectedSize) throws URISyntaxException, InterruptedException, ExecutionException {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(textTotest);
+		CompletableFuture<List<? extends SymbolInformation>> documentSymbolFor = getDocumentSymbolFor(camelLanguageServer);
+		List<? extends SymbolInformation> symbolsInformation = documentSymbolFor.get();
+		assertThat(symbolsInformation).hasSize(expectedSize);
+		return symbolsInformation;
+	}
+
+}


### PR DESCRIPTION
- allows to find routes more easily
- in VS Code Ctrl+Shift+O
- in Eclipse Desktop with LSP4E provides an outline and with 
- limitation: the SymbolKind used is "Field", there is currently an
hardcoded set of possible symbol kind, none are really matching "Camel
routes"

Signed-off-by: Aurélien Pupier <apupier@redhat.com>