### PR TITLE
Upgrade AssertJ from 3.9.1 to 3.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<lsp4j.version>0.3.1</lsp4j.version>
 		<slf4j.version>1.7.6</slf4j.version>
 		<junit.version>4.12</junit.version>
-		<assertj.version>3.9.1</assertj.version>
+		<assertj.version>3.10.0</assertj.version>
 		<camel.version>2.21.1</camel.version>
 		<camel.tooling.common.version>0.0.1-SNAPSHOT</camel.tooling.common.version>
 	</properties>


### PR DESCRIPTION
see release note:
http://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.10.0

Signed-off-by: Aurélien Pupier <apupier@redhat.com>