### PR TITLE
#92 - Support java and xml writing of Camel uri in internal model

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/DSLModelHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/DSLModelHelper.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.instancemodel;
+
+public interface DSLModelHelper {
+
+	public String getParametersSeparator();
+	
+	public String getTypeDeterminingProducerConsumer();
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/JavaDSLModelHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/JavaDSLModelHelper.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.instancemodel;
+
+public class JavaDSLModelHelper implements DSLModelHelper {
+	
+	private String methodName;
+
+	public JavaDSLModelHelper(String methodName) {
+		this.methodName = methodName;
+	}
+
+	@Override
+	public String getParametersSeparator() {
+		return "&";
+	}
+
+	@Override
+	public String getTypeDeterminingProducerConsumer() {
+		return methodName;
+	}
+	
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/XMLDSLModelHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/XMLDSLModelHelper.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.instancemodel;
+
+import org.w3c.dom.Node;
+
+public class XMLDSLModelHelper implements DSLModelHelper {
+	
+	private Node node;
+
+	public XMLDSLModelHelper(Node node) {
+		this.node = node;
+	}
+
+	@Override
+	public String getParametersSeparator() {
+		return "&amp;";
+	}
+	
+	@Override
+	public String getTypeDeterminingProducerConsumer() {
+		return node.getNodeName();
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstanceTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstanceTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Iterator;
 
 import org.junit.Test;
+import org.w3c.dom.Node;
 
 import com.github.cameltooling.lsp.internal.instancemodel.CamelURIInstance;
 import com.github.cameltooling.lsp.internal.instancemodel.OptionParamURIInstance;
@@ -31,7 +32,7 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testEmptyUri() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("", (Node) null);
 		assertThat(camelURIInstance.getComponent()).isNull();
 		assertThat(camelURIInstance.getOptionParams()).isEmpty();
 		assertThat(camelURIInstance.getOptionParams()).isEmpty();
@@ -39,21 +40,21 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testComponentOnlyInUri() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer", (Node) null);
 		assertThat(camelURIInstance.getComponent().getComponentName()).isEqualTo("timer");
 		assertThat(camelURIInstance.getComponent().getEndPosition()).isEqualTo(5);
 	}
 	
 	@Test
 	public void testComponentWithSomethingElseInUri() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName", (Node) null);
 		assertThat(camelURIInstance.getComponent().getComponentName()).isEqualTo("timer");
 		assertThat(camelURIInstance.getComponent().getEndPosition()).isEqualTo(5);
 	}
 	
 	@Test
 	public void testPathParam() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName", (Node) null);
 		PathParamURIInstance pathParam = camelURIInstance.getPathParams().iterator().next();
 		assertThat(pathParam.getValue()).isEqualTo("timerName");
 		assertThat(pathParam.getStartPosition()).isEqualTo(6);
@@ -62,7 +63,7 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testMultiplePathParam() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("amqp:destinationType:destinationName");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("amqp:destinationType:destinationName", (Node) null);
 		assertThat(camelURIInstance.getPathParams()).containsOnly(
 				new PathParamURIInstance(camelURIInstance, "destinationType", 5, 20),
 				new PathParamURIInstance(camelURIInstance, "destinationName", 21, 36));
@@ -70,7 +71,7 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testMultiplePathParamWithSomethingElseInUri() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("amqp:destinationType:destinationName?anOption");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("amqp:destinationType:destinationName?anOption", (Node) null);
 		assertThat(camelURIInstance.getPathParams()).containsOnly(
 				new PathParamURIInstance(camelURIInstance, "destinationType", 5, 20),
 				new PathParamURIInstance(camelURIInstance, "destinationName", 21, 36));
@@ -78,7 +79,7 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testMultiplePathParamWithSlashDelimiter() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("atmos:name/operation");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("atmos:name/operation", (Node) null);
 		assertThat(camelURIInstance.getPathParams()).containsOnly(
 				new PathParamURIInstance(camelURIInstance, "name", 6, 10),
 				new PathParamURIInstance(camelURIInstance, "operation", 11, 20));
@@ -86,7 +87,7 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testOptionParam() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay=1000");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay=1000", (Node) null);
 		OptionParamURIInstance optionParam = camelURIInstance.getOptionParams().iterator().next();
 		checkDelayTimerParam(optionParam);
 	}
@@ -104,13 +105,28 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testSeveralOptionParam() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay=1000&amp;period=2000");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay=1000&amp;period=2000", (Node) null);
 		Iterator<OptionParamURIInstance> iterator = camelURIInstance.getOptionParams().iterator();
 		OptionParamURIInstance firstOptionParam = iterator.next();
 		OptionParamURIInstance secondOptionParam = iterator.next();
 		if("delay".equals(firstOptionParam.getKey().getKeyName())) {
 			checkDelayTimerParam(firstOptionParam);
 			checkTimerPeriodParam(secondOptionParam);
+		} else {
+			checkDelayTimerParam(secondOptionParam);
+			checkTimerPeriodParam(firstOptionParam);
+		}
+	}
+	
+	@Test
+	public void testSeveralOptionParamForJava() throws Exception {
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay=1000&period=2000", (String) null);
+		Iterator<OptionParamURIInstance> iterator = camelURIInstance.getOptionParams().iterator();
+		OptionParamURIInstance firstOptionParam = iterator.next();
+		OptionParamURIInstance secondOptionParam = iterator.next();
+		if("delay".equals(firstOptionParam.getKey().getKeyName())) {
+			checkDelayTimerParam(firstOptionParam);
+			checkTimerPeriodParamForJava(secondOptionParam);
 		} else {
 			checkDelayTimerParam(secondOptionParam);
 			checkTimerPeriodParam(firstOptionParam);
@@ -128,9 +144,20 @@ public class CamelURIInstanceTest {
 		assertThat(secondOptionParam.getValue().getEndPosition()).isEqualTo(42);
 	}
 	
+	private void checkTimerPeriodParamForJava(OptionParamURIInstance secondOptionParam) {
+		assertThat(secondOptionParam.getStartPosition()).isEqualTo(27);
+		assertThat(secondOptionParam.getEndPosition()).isEqualTo(38);
+		assertThat(secondOptionParam.getKey().getKeyName()).isEqualTo("period");
+		assertThat(secondOptionParam.getKey().getStartPosition()).isEqualTo(27);
+		assertThat(secondOptionParam.getKey().getEndPosition()).isEqualTo(33);
+		assertThat(secondOptionParam.getValue().getValueName()).isEqualTo("2000");
+		assertThat(secondOptionParam.getValue().getStartPosition()).isEqualTo(34);
+		assertThat(secondOptionParam.getValue().getEndPosition()).isEqualTo(38);
+	}
+	
 	@Test
 	public void testEmptyOptionParam() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?", (Node) null);
 		OptionParamURIInstance optionParam = camelURIInstance.getOptionParams().iterator().next();
 		assertThat(optionParam.getStartPosition()).isEqualTo(16);
 		assertThat(optionParam.getEndPosition()).isEqualTo(16);
@@ -142,7 +169,7 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testEmptyOptionValueParam() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay", (Node) null);
 		OptionParamURIInstance optionParam = camelURIInstance.getOptionParams().iterator().next();
 		assertThat(optionParam.getStartPosition()).isEqualTo(16);
 		assertThat(optionParam.getEndPosition()).isEqualTo(21);
@@ -154,7 +181,20 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testEmptyOptionValueParamWithAnd() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay&amp;");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay&amp;", (Node) null);
+		Iterator<OptionParamURIInstance> iterator = camelURIInstance.getOptionParams().iterator();
+		OptionParamURIInstance firstOptionParam = iterator.next();
+		OptionParamURIInstance secondOptionParam = iterator.next();
+		if("delay".equals(firstOptionParam.getKey().getKeyName())) {
+			checkDelayParameter(firstOptionParam);
+		} else {
+			checkDelayParameter(secondOptionParam);
+		}
+	}
+	
+	@Test
+	public void testEmptyOptionValueParamWithAndForJava() throws Exception {
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay&", (String) null);
 		Iterator<OptionParamURIInstance> iterator = camelURIInstance.getOptionParams().iterator();
 		OptionParamURIInstance firstOptionParam = iterator.next();
 		OptionParamURIInstance secondOptionParam = iterator.next();
@@ -176,7 +216,7 @@ public class CamelURIInstanceTest {
 	
 	@Test
 	public void testEmptyOptionValueParamWithEqual() throws Exception {
-		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay=");
+		CamelURIInstance camelURIInstance = new CamelURIInstance("timer:timerName?delay=", (Node) null);
 		OptionParamURIInstance optionParam = camelURIInstance.getOptionParams().iterator().next();
 		assertThat(optionParam.getStartPosition()).isEqualTo(16);
 		assertThat(optionParam.getEndPosition()).isEqualTo(22);


### PR DESCRIPTION
the only spotted difference for now is the &amp;
there is also the preparation for the producer computation, some
information will be needed when parsing the enclosing elements of the
Camel uri string

Please note that nothing is visible yet from the interface, this is only internal work to support Java later