### PR TITLE
#93 - fix test to avoid being dependent on JVM list internal order

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstanceTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstanceTest.java
@@ -129,7 +129,7 @@ public class CamelURIInstanceTest {
 			checkTimerPeriodParamForJava(secondOptionParam);
 		} else {
 			checkDelayTimerParam(secondOptionParam);
-			checkTimerPeriodParam(firstOptionParam);
+			checkTimerPeriodParamForJava(firstOptionParam);
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>