### PR TITLE
Suppress warning for Sonar rule on Generic wildcard types

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessor.java
@@ -45,7 +45,8 @@ public class DocumentSymbolProcessor {
 	public DocumentSymbolProcessor(TextDocumentItem textDocumentItem) {
 		this.textDocumentItem = textDocumentItem;
 	}
-
+	
+	@SuppressWarnings("squid:S1452")
 	public CompletableFuture<List<? extends SymbolInformation>> getDocumentSymbols() {
 		return CompletableFuture.supplyAsync(() -> {
 			try {


### PR DESCRIPTION
it it a "false-positive" in our context because we need to have it to be
compatible with the API of a dependency.
see https://groups.google.com/d/msg/sonarqube/BLXAdLEL9QE/UuErZS6oAgAJ

Signed-off-by: Aurélien Pupier <apupier@redhat.com>