### PR TITLE
Return no hover instead of empty hover

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/HoverProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/HoverProcessor.java
@@ -16,7 +16,6 @@
  */
 package com.github.cameltooling.lsp.internal.hover;
 
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
@@ -54,7 +53,7 @@ public class HoverProcessor {
 		} catch (Exception e) {
 			LOGGER.error("Error searching hover", e);
 		}
-		return CompletableFuture.completedFuture(new Hover(Collections.emptyList()));
+		return CompletableFuture.completedFuture(null);
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelLanguageServerHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelLanguageServerHoverTest.java
@@ -61,8 +61,7 @@ public class CamelLanguageServerHoverTest extends AbstractCamelLanguageServerTes
 		TextDocumentPositionParams position = new TextDocumentPositionParams(new TextDocumentIdentifier(DUMMY_URI+".xml"), new Position(0, 4));
 		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(position);
 		
-		assertThat(hover.get().getContents().getLeft()).isEmpty();
-		assertThat(hover.get().getContents().getRight()).isNull();
+		assertThat(hover.get()).isNull();
 	}
 	
 	@Test
@@ -72,8 +71,7 @@ public class CamelLanguageServerHoverTest extends AbstractCamelLanguageServerTes
 		TextDocumentPositionParams position = new TextDocumentPositionParams(new TextDocumentIdentifier(DUMMY_URI+".xml"), new Position(0, 15));
 		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(position);
 		
-		assertThat(hover.get().getContents().getLeft()).isEmpty();
-		assertThat(hover.get().getContents().getRight()).isNull();
+		assertThat(hover.get()).isNull();
 	}
 
 }


### PR DESCRIPTION
which was previously done to workaround
https://github.com/eclipse/lsp4j/issues/172

Signed-off-by: Aurélien Pupier <apupier@redhat.com>