### PR TITLE
Specify xtend.lib version (#140)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,11 @@
 			<version>${lsp4j.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.xtend</groupId>
+			<artifactId>org.eclipse.xtend.lib</artifactId>
+			<version>2.14.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>


### PR DESCRIPTION
to workaround the fact that lsp4j is declaring aversion range dependency
and that on CI it is trying to take a SNAPSHOT version and failing

Signed-off-by: Aurélien Pupier <apupier@redhat.com>