### PR TITLE
Improve range position of diagnostic #113

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
@@ -153,9 +153,20 @@ public class DiagnosticService {
 
 	private Range computeRange(String fullCamelText, TextDocumentItem textDocumentItem, CamelEndpointDetails camelEndpointDetails) {
 		int endLine = camelEndpointDetails.getLineNumberEnd() != null ? Integer.valueOf(camelEndpointDetails.getLineNumberEnd()) - 1 : findLine(fullCamelText, camelEndpointDetails);
-		int endLineSize = new ParserXMLFileHelper().getLine(textDocumentItem, endLine).length();
+		String lineContainingTheCamelURI = new ParserXMLFileHelper().getLine(textDocumentItem, endLine);
+		String endpointUri = camelEndpointDetails.getEndpointUri();
+		int startOfUri = lineContainingTheCamelURI.indexOf(endpointUri);
+		int startLinePosition;
+		int endLinePosition;
+		if (startOfUri != -1) {
+			startLinePosition = startOfUri;
+			endLinePosition = startOfUri + endpointUri.length();
+		} else {
+			startLinePosition = 0;
+			endLinePosition = lineContainingTheCamelURI.length();
+		}
 		int startLine = camelEndpointDetails.getLineNumber() != null ? Integer.valueOf(camelEndpointDetails.getLineNumber()) - 1 : findLine(fullCamelText, camelEndpointDetails);
-		return new Range(new Position(startLine, 0), new Position(endLine, endLineSize));
+		return new Range(new Position(startLine, startLinePosition), new Position(endLine, endLinePosition));
 	}
 
 	/**

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
@@ -44,9 +44,9 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 		testDiagnostic("camel-with-endpoint-error", 1, ".xml");
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
 		assertThat(range.getStart().getLine()).isEqualTo(8);
-		assertThat(range.getStart().getCharacter()).isEqualTo(0);
+		assertThat(range.getStart().getCharacter()).isEqualTo(16);
 		assertThat(range.getEnd().getLine()).isEqualTo(8);
-		assertThat(range.getEnd().getCharacter()).isEqualTo(52);
+		assertThat(range.getEnd().getCharacter()).isEqualTo(39);
 	}
 	
 	@Test
@@ -54,9 +54,9 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 		testDiagnostic("camel-with-endpoint-error-withNamespacePrefix", 1, ".xml");
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
 		assertThat(range.getStart().getLine()).isEqualTo(8);
-		assertThat(range.getStart().getCharacter()).isEqualTo(0);
+		assertThat(range.getStart().getCharacter()).isEqualTo(25);
 		assertThat(range.getEnd().getLine()).isEqualTo(8);
-		assertThat(range.getEnd().getCharacter()).isEqualTo(51);
+		assertThat(range.getEnd().getCharacter()).isEqualTo(48);
 	}
 	
 	@Test
@@ -84,9 +84,9 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 		testDiagnostic("camel-with-endpoint-error", 1, ".java");
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
 		assertThat(range.getStart().getLine()).isEqualTo(12);
-		assertThat(range.getStart().getCharacter()).isEqualTo(0);
+		assertThat(range.getStart().getCharacter()).isEqualTo(14);
 		assertThat(range.getEnd().getLine()).isEqualTo(12);
-		assertThat(range.getEnd().getCharacter()).isEqualTo(39);
+		assertThat(range.getEnd().getCharacter()).isEqualTo(37);
 	}
 	
 	private void testDiagnostic(String fileUnderTest, int expectedNumberOfError, String extension) throws FileNotFoundException {
@@ -96,8 +96,8 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(new TextDocumentIdentifier(DUMMY_URI+extension));
 		camelLanguageServer.getTextDocumentService().didSave(params);
 		
-		await().timeout(Duration.ONE_SECOND).untilAsserted(() -> assertThat(lastPublishedDiagnostics).isNotNull());
-		await().timeout(Duration.ONE_SECOND).untilAsserted(() -> assertThat(lastPublishedDiagnostics.getDiagnostics()).hasSize(expectedNumberOfError));
+		await().timeout(Duration.TEN_MINUTES).untilAsserted(() -> assertThat(lastPublishedDiagnostics).isNotNull());
+		await().timeout(Duration.TEN_MINUTES).untilAsserted(() -> assertThat(lastPublishedDiagnostics.getDiagnostics()).hasSize(expectedNumberOfError));
 	}
 	
 }


### PR DESCRIPTION
re-reparsing the uri as Camel still not providing the start and end
character

now on the Camel URI instead of the full line:
![image](https://user-images.githubusercontent.com/1105127/50517508-e7251600-0ab0-11e9-8685-9ac11e6f14f6.png)
