### PR TITLE
Avoid false positive for "lenient" properties #220

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
@@ -111,7 +111,7 @@ public class DiagnosticService {
 		try {
 			CamelCatalog camelCatalogResolved = camelCatalog.get();
 			for (CamelEndpointDetails camelEndpointDetails : endpoints) {
-				EndpointValidationResult validateEndpointProperties = camelCatalogResolved.validateEndpointProperties(camelEndpointDetails.getEndpointUri(), true);
+				EndpointValidationResult validateEndpointProperties = camelCatalogResolved.validateEndpointProperties(camelEndpointDetails.getEndpointUri(), false);
 				if (validateEndpointProperties.hasErrors()) {
 					endpointErrors.put(new CamelEndpointDetailsWrapper(camelEndpointDetails), validateEndpointProperties);
 				}

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
@@ -33,6 +33,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
@@ -121,6 +122,22 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 		camelLanguageServer.getTextDocumentService().didChange(params);
 		
 		await().timeout(AWAIT_TIMEOUT).untilAsserted(() -> assertThat(lastPublishedDiagnostics.getDiagnostics()).isEmpty());
+	}
+	
+	@Test
+	@Ignore("Not yet supported by Camel, see CAMEL-13382")
+	public void testNoErrorWithProperty() throws Exception {
+		testDiagnostic("camel-with-properties", 0, ".xml");
+	}
+	
+	@Test
+	public void testUnknowPropertyOnNonLenientPropertiesComponent() throws Exception {
+		testDiagnostic("camel-with-unknownParameter", 1, ".xml");
+	}
+	
+	@Test
+	public void testUnknowPropertyOnLenientPropertiesComponent() throws Exception {
+		testDiagnostic("camel-with-unknownParameter-forlenientcomponent", 0, ".xml");
 	}
 	
 	private void testDiagnostic(String fileUnderTest, int expectedNumberOfError, String extension) throws FileNotFoundException {

--- a/src/test/resources/workspace/diagnostic/camel-with-properties.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-properties.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="timer:timerName?delay=1000"/>
+      <to uri="timer:timerName?${aProperty}=10"></to>
+    </route>
+  </camelContext>
+</beans>

--- a/src/test/resources/workspace/diagnostic/camel-with-unknownParameter-forlenientcomponent.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-unknownParameter-forlenientcomponent.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="http://an.url?unknownParam=1000"/>
+      <to uri="direct:drink"/>
+    </route>
+  </camelContext>
+</beans>

--- a/src/test/resources/workspace/diagnostic/camel-with-unknownParameter.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-unknownParameter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="timer:timerName?unknownParam=1000"/>
+      <to uri="direct:drink"/>
+    </route>
+  </camelContext>
+</beans>


### PR DESCRIPTION
Some Camel components have "lenient" properties. It means that they can
have custom parameters. These parameters were reported as "unknown
parameter" although they are valid.

provided a test for using toD and Camel global properties and set it as
@Ignore waiting for a fix at Camel level. see CAMEL-13382

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [x] Are there **Unit tests**?
- [x] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [x] Tagged with relevant **PR labels**
2. [x] Green **job for PR**
3. [x] PR was created more than **24 hours ago** or **All committers approved** it
4. [x] Green **master** branch build