### PR TITLE
provide initial top-level completion for application.properties #264

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -61,6 +61,7 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.cameltooling.lsp.internal.completion.CamelApplicationPropertiesCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.definition.DefinitionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticService;
@@ -88,7 +89,11 @@ public class CamelTextDocumentService implements TextDocumentService {
 		String uri = completionParams.getTextDocument().getUri();
 		LOGGER.info("completion: {}", uri);
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
-		return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+		if(uri.endsWith("application.properties")) {
+			return new CamelApplicationPropertiesCompletionProcessor(textDocumentItem).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+		} else {
+			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelApplicationPropertiesCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelApplicationPropertiesCompletionProcessor.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
+
+public class CamelApplicationPropertiesCompletionProcessor {
+
+	private static final String CAMEL_KEY_PREFIX = "camel.";
+	private TextDocumentItem textDocumentItem;
+
+	public CamelApplicationPropertiesCompletionProcessor(TextDocumentItem textDocumentItem) {
+		this.textDocumentItem = textDocumentItem;
+	}
+
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
+		if (textDocumentItem != null && CAMEL_KEY_PREFIX.length() == position.getCharacter()) {
+			String line = new ParserFileHelperUtil().getLine(textDocumentItem, position);
+			if (line.startsWith(CAMEL_KEY_PREFIX)) {
+				return getTopLevelCamelCompletion();
+			}
+		}
+		return CompletableFuture.completedFuture(Collections.emptyList());
+	}
+
+	protected CompletableFuture<List<CompletionItem>> getTopLevelCamelCompletion() {
+		List<CompletionItem> completions = new ArrayList<>();
+		completions.add(new CompletionItem("component"));
+		completions.add(new CompletionItem("main"));
+		completions.add(new CompletionItem("rest"));
+		completions.add(new CompletionItem("hystrix"));
+		return CompletableFuture.completedFuture(completions);
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
@@ -51,7 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
-import com.github.cameltooling.lsp.internal.parser.ParserXMLFileHelper;
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 import com.github.cameltooling.model.diagnostic.BooleanErrorMsg;
 import com.github.cameltooling.model.diagnostic.CamelDiagnosticEndpointMessage;
 import com.github.cameltooling.model.diagnostic.EnumErrorMsg;
@@ -160,7 +160,7 @@ public class DiagnosticService {
 
 	private Range computeRange(String fullCamelText, TextDocumentItem textDocumentItem, CamelEndpointDetails camelEndpointDetails) {
 		int endLine = camelEndpointDetails.getLineNumberEnd() != null ? Integer.valueOf(camelEndpointDetails.getLineNumberEnd()) - 1 : findLine(fullCamelText, camelEndpointDetails);
-		String lineContainingTheCamelURI = new ParserXMLFileHelper().getLine(textDocumentItem, endLine);
+		String lineContainingTheCamelURI = new ParserFileHelperUtil().getLine(textDocumentItem, endLine);
 		String endpointUri = camelEndpointDetails.getEndpointUri();
 		int startOfUri = lineContainingTheCamelURI.indexOf(endpointUri);
 		int startLinePosition;

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaConnectDSLParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaConnectDSLParser.java
@@ -70,18 +70,18 @@ public class CamelKafkaConnectDSLParser extends ParserFileHelper {
 	}
 
 	private int getStartCharacterInDocumentOnLinePosition(TextDocumentItem textDocumentItem, Position position) {
-		String line = getLine(textDocumentItem, position.getLine());
+		String line = parserFileHelperUtil.getLine(textDocumentItem, position.getLine());
 		return line.indexOf('=') + 1;
 	}
 
 	@Override
 	public int getPositionInCamelURI(TextDocumentItem textDocumentItem, Position position) {
-		String line = getLine(textDocumentItem, position.getLine());
+		String line = parserFileHelperUtil.getLine(textDocumentItem, position.getLine());
 		return position.getCharacter() - line.indexOf('=') - 1;
 	}
 
 	public String getCorrespondingMethodName(TextDocumentItem textDocumentItem, int lineNumber) {
-		String line = getLine(textDocumentItem, lineNumber);
+		String line = parserFileHelperUtil.getLine(textDocumentItem, lineNumber);
 		if (line.startsWith(CAMEL_SINK_URL)) {
 			return "to";
 		} else if(line.startsWith(CAMEL_SOURCE_URL)) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelper.java
@@ -23,24 +23,12 @@ import com.github.cameltooling.lsp.internal.instancemodel.CamelURIInstance;
 
 public abstract class ParserFileHelper {
 	
-	public String getLine(TextDocumentItem textDocumentItem, Position position) {
-		int line = position.getLine();
-		return getLine(textDocumentItem, line);
-	}
-	
-	public String getLine(TextDocumentItem textDocumentItem, int line) {
-		String text = textDocumentItem.getText();
-		String[] lines = text.split("\\r?\\n", line + 2);
-		if (lines.length >= line + 1) {
-			return lines[line];
-		}
-		return null;
-	}
+	protected ParserFileHelperUtil parserFileHelperUtil = new ParserFileHelperUtil();
 	
 	public abstract String getCamelComponentUri(String line, int characterPosition);
 	
 	public String getCamelComponentUri(TextDocumentItem textDocumentItem, Position position) {
-		return getCamelComponentUri(getLine(textDocumentItem, position), position.getCharacter());
+		return getCamelComponentUri(parserFileHelperUtil.getLine(textDocumentItem, position), position.getCharacter());
 	}
 	
 	protected boolean isBetween(int position, int start, int end) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperUtil.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperUtil.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.parser;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+public class ParserFileHelperUtil {
+
+	public String getLine(TextDocumentItem textDocumentItem, Position position) {
+		int line = position.getLine();
+		return getLine(textDocumentItem, line);
+	}
+	
+	public String getLine(TextDocumentItem textDocumentItem, int line) {
+		String text = textDocumentItem.getText();
+		String[] lines = text.split("\\r?\\n", line + 2);
+		if (lines.length >= line + 1) {
+			return lines[line];
+		}
+		return null;
+	}
+	
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserJavaFileHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserJavaFileHelper.java
@@ -51,7 +51,7 @@ public class ParserJavaFileHelper extends ParserFileHelper {
 	}
 
 	public String getCorrespondingMethodName(TextDocumentItem textDocumentItem, int line) {
-		String lineString = getLine(textDocumentItem, line);
+		String lineString = parserFileHelperUtil.getLine(textDocumentItem, line);
 		for (String methodName : CAMEL_POSSIBLE_TYPES) {
 			if(lineString.contains(methodName + "(" + getEnclosingStringCharacter())) {
 				return methodName;
@@ -71,13 +71,13 @@ public class ParserJavaFileHelper extends ParserFileHelper {
 	
 	private int getStartCharacterInDocumentOnLinePosition(TextDocumentItem textDocumentItem, Position position) {
 		String beforeCamelURI = getCorrespondingMethodName(textDocumentItem, position.getLine()) + "(" + getEnclosingStringCharacter();
-		return getLine(textDocumentItem, position).indexOf(beforeCamelURI) + beforeCamelURI.length();
+		return parserFileHelperUtil.getLine(textDocumentItem, position).indexOf(beforeCamelURI) + beforeCamelURI.length();
 	}
 
 	@Override
 	public int getPositionInCamelURI(TextDocumentItem textDocumentItem, Position position) {
 		String beforeCamelURI = getCorrespondingMethodName(textDocumentItem, position.getLine()) + "(" + getEnclosingStringCharacter();
-		return position.getCharacter() - getLine(textDocumentItem, position).indexOf(beforeCamelURI) - beforeCamelURI.length();
+		return position.getCharacter() - parserFileHelperUtil.getLine(textDocumentItem, position).indexOf(beforeCamelURI) - beforeCamelURI.length();
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserXMLFileHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserXMLFileHelper.java
@@ -179,12 +179,12 @@ public class ParserXMLFileHelper extends ParserFileHelper {
 	}
 
 	private int getStartCharacterInDocumentOnLinePosition(TextDocumentItem textDocumentItem, Position position) {
-		return getLine(textDocumentItem, position.getLine()).indexOf(URI_PARAM) + 1 + URI_PARAM.length();
+		return parserFileHelperUtil.getLine(textDocumentItem, position.getLine()).indexOf(URI_PARAM) + 1 + URI_PARAM.length();
 	}
 
 	@Override
 	public int getPositionInCamelURI(TextDocumentItem textDocumentItem, Position position) {
-		return position.getCharacter() - getLine(textDocumentItem, position).indexOf(URI_PARAM) - 5;
+		return position.getCharacter() - parserFileHelperUtil.getLine(textDocumentItem, position).indexOf(URI_PARAM) - 5;
 	}
 
 	public List<Node> getAllEndpoints(TextDocumentItem textDocumentItem) throws Exception {

--- a/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
@@ -175,6 +175,17 @@ public class CamelLanguageServerTest extends AbstractCamelLanguageServerTest {
 	}
 	
 	@Test
+	public void testProvideCompletionForApplicationProperties() throws Exception {
+		File f = new File("src/test/resources/workspace/application.properties");
+		assertThat(f).exists();
+		try (FileInputStream fis = new FileInputStream(f)) {
+			CamelLanguageServer cls = initializeLanguageServerWithFileName(fis, "application.properties");
+			CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(cls, new Position(2, 6), "application.properties");
+			assertThat(completions.get().getLeft()).hasSize(4);
+		}
+	}
+	
+	@Test
 	public void testProvideCompletionForJSOnRealFileWithCamelKCloseToModeline() throws Exception {
 		File f = new File("src/test/resources/workspace/sampleWithModelineLike.js");
 		assertThat(f).exists();

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelApplicationPropertiesTopLevelCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelApplicationPropertiesTopLevelCompletionTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+public class CamelApplicationPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerTest {
+	
+	@Test
+	public void testProvideCompletion() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 6));
+		
+		assertThat(completions.get().getLeft()).hasSize(4);
+	}
+	
+	@Test
+	public void testProvideNoCompletion() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 0));
+		
+		assertThat(completions.get().getLeft()).isEmpty();
+	}
+	
+	@Test
+	public void testProvideNoCompletionForNonApplicationProperties() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 6));
+		
+		assertThat(completions.get().getLeft()).isEmpty();
+	}
+	
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(String fileName, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel."));
+		return getCompletionFor(camelLanguageServer, position, fileName);
+	}
+}

--- a/src/test/resources/workspace/application.properties
+++ b/src/test/resources/workspace/application.properties
@@ -1,0 +1,39 @@
+# to configure camel main
+# here you can configure options on camel main (see MainConfigurationProperties class)
+camel.main.name = MyCoolCamel
+camel.main.jmx-enabled = false
+
+# enable tracing
+# camel.main.tracing = true
+# configure tracing what to include from the exchange
+#camel.context.tracer.exchange-formatter.show-exchange-id = false
+#camel.context.tracer.exchange-formatter.show-headers = true
+#camel.context.tracer.exchange-formatter.show-body-type = false
+
+# you can also configure camel context directly
+# camel.context.shutdown-strategy.shutdown-now-on-timeout = false
+
+# load additional property placeholders from this folder
+camel.main.file-configurations=src/main/data/*.properties
+
+# to configure the camel quartz component
+# here we can configure the options on the component level (and we can use dash-naming-style)
+camel.component.quartz.start-delayed-seconds = 3
+
+# to configure Hystrix EIP (global and you need to add camel-hystrix to the classpath)
+### camel.hystrix.group-key=myGroup
+### camel.hystrix.execution-timeout-in-milliseconds=5000
+
+# to configure Rest DSL (global and you need to add camel-undertow to the classpath)
+### camel.rest.component=undertow
+### camel.rest.port=8080
+### camel.rest.component-properties[host-options.buffer-size]=8192
+
+# you can configure whether OS environment should override (=2 which is default) or as fallback (=1)
+### camel.component.properties.environment-variable-mode=1
+
+# properties used in the route
+myCron = 0/2 * * * * ?
+
+# application properties
+hi = Hello


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1105127/62701351-5e763d00-b9e4-11e9-82f0-c6809ea31e87.png)

![image](https://user-images.githubusercontent.com/1105127/62701752-5c60ae00-b9e5-11e9-8d04-f80f243d06b6.png)


- it allows to setup the mechanism for application.properties
- it has hardcoded 3 values only for now
- includes a small refactor to extract some useful methods of
ParserHelper


