### PR TITLE
266 completion for components id in application.properties

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -90,7 +90,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 		LOGGER.info("completion: {}", uri);
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
 		if(uri.endsWith("application.properties")) {
-			return new CamelApplicationPropertiesCompletionProcessor(textDocumentItem).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+			return new CamelApplicationPropertiesCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		} else {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentIdsCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentIdsCompletionsFuture.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.eclipse.lsp4j.CompletionItem;
+
+import com.github.cameltooling.model.util.ModelHelper;
+
+public class CamelComponentIdsCompletionsFuture implements Function<CamelCatalog, List<CompletionItem>> {
+
+	@Override
+	public List<CompletionItem> apply(CamelCatalog catalog) {
+		return catalog.findComponentNames().stream()
+			.map(componentName -> ModelHelper.generateComponentModel(catalog.componentJSonSchema(componentName), true))
+			.map(componentModel -> {
+				CompletionItem completionItem = new CompletionItem(componentModel.getScheme());
+				completionItem.setDocumentation(componentModel.getDescription());
+				completionItem.setDeprecated(Boolean.valueOf(componentModel.getDeprecated()));
+				return completionItem;
+			})
+			.collect(Collectors.toList());
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelApplicationPropertiesComponentCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelApplicationPropertiesComponentCompletionTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cameltooling.lsp.internal.completion;
+package com.github.cameltooling.lsp.internal.completion.camelapplicationproperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,31 +33,39 @@ import org.junit.jupiter.api.Test;
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
-public class CamelApplicationPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerTest {
-	
+public class CamelApplicationPropertiesComponentCompletionTest extends AbstractCamelLanguageServerTest {
+
 	@Test
 	public void testProvideCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 6));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 16));
 		
-		assertThat(completions.get().getLeft()).hasSize(4);
+		assertThat(completions.get().getLeft()).contains(createExpectedAhcCompletionItem(0, 16, 0, 19));
 	}
 	
 	@Test
-	public void testProvideNoCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 0));
+	public void testProvideCompletionNoCompletionForNonApplicationpropertiesFile() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 16));
 		
 		assertThat(completions.get().getLeft()).isEmpty();
 	}
 	
 	@Test
-	public void testProvideNoCompletionForNonApplicationProperties() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 6));
+	public void testProvideCompletionNoCompletionAtWorngPosition() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 14));
 		
 		assertThat(completions.get().getLeft()).isEmpty();
 	}
 	
 	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(String fileName, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel."));
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel.component."));
 		return getCompletionFor(camelLanguageServer, position, fileName);
 	}
+	
+	protected CompletionItem createExpectedAhcCompletionItem(int lineStart, int characterStart, int lineEnd, int characterEnd) {
+		CompletionItem expectedAhcCompletioncompletionItem = new CompletionItem("ahc");
+		expectedAhcCompletioncompletionItem.setDocumentation(AHC_DOCUMENTATION);
+		expectedAhcCompletioncompletionItem.setDeprecated(false);
+		return expectedAhcCompletioncompletionItem;
+	}
+	
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelApplicationPropertiesTopLevelCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelApplicationPropertiesTopLevelCompletionTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.camelapplicationproperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+public class CamelApplicationPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerTest {
+	
+	@Test
+	public void testProvideCompletion() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 6));
+		
+		assertThat(completions.get().getLeft()).hasSize(4);
+	}
+	
+	@Test
+	public void testProvideNoCompletion() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 0));
+		
+		assertThat(completions.get().getLeft()).isEmpty();
+	}
+	
+	@Test
+	public void testProvideNoCompletionForNonApplicationProperties() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 6));
+		
+		assertThat(completions.get().getLeft()).isEmpty();
+	}
+	
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(String fileName, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel."));
+		return getCompletionFor(camelLanguageServer, position, fileName);
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1105127/62706355-a0f14700-b9ef-11e9-9181-68d86af84882.png)

the completion is only when calling right after the dot.

requires https://github.com/camel-tooling/camel-language-server/pull/265 --> DONE

