### PR TITLE
Exclude dependabot branches from non-PR jobs #286

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache:
 env:
   global:
   - GPG_DIR="`pwd`/cd"
+branches:
+  except:
+    - /^dependabot.*$/
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build