### PR TITLE
Provide websocket support #260

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ These clients are available:
 
 Manual configuration is possible with:
 * [Sublime Text](https://github.com/camel-tooling/camel-lsp-client-sublime)
+* [CodeMirror](https://github.com/camel-tooling/camel-lsp-client-codemirror)
 
 Help is welcome to provide more client implementations, especially for:
 * [Emacs](https://github.com/camel-tooling/camel-lsp-client-emacs)
@@ -42,6 +43,11 @@ On hover, the documentation of the Camel component is available.
 
 On save, diagnostics on Camel URIs are updated:
 ![Diagnostic on Camel URI](./images/diagnostic.png "Diagnostic on Camel URI")
+
+### Websocket support
+
+Connection through websocket is supported. The server needs to be launched with `--websocket` option. Then, the connection can be made through
+`ws://<yourHostName>:8025/camel-language-server`
 
 ## Features planned
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 		<camel.tooling.common.version>0.0.3-SNAPSHOT</camel.tooling.common.version>
 		<roaster.version>2.20.1.Final</roaster.version>
 		<awaitility.version>4.0.1</awaitility.version>
+		<tyrus.version>1.12</tyrus.version>
 	</properties>
 
 	<distributionManagement>
@@ -249,6 +250,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lsp4j</groupId>
+			<artifactId>org.eclipse.lsp4j.websocket</artifactId>
+			<version>${lsp4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j</artifactId>
 			<version>${lsp4j.version}</version>
 		</dependency>
@@ -309,6 +315,16 @@
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<version>1.25</version>            
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.tyrus</groupId>
+			<artifactId>tyrus-server</artifactId>
+			<version>${tyrus.version}</version>
+		</dependency>
+		<dependency>
+  			<groupId>org.glassfish.tyrus</groupId>
+			<artifactId>tyrus-container-grizzly-server</artifactId>
+			<version>${tyrus.version}</version>
 		</dependency>
 	</dependencies>
 	

--- a/src/main/java/com/github/cameltooling/lsp/internal/Runner.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/Runner.java
@@ -16,8 +16,13 @@
  */
 package com.github.cameltooling.lsp.internal;
 
+import java.util.Arrays;
+
 import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.launch.LSPLauncher;
 import org.eclipse.lsp4j.services.LanguageClient;
+
+import com.github.cameltooling.lsp.internal.websocket.WebSocketRunner;
 
 /**
  * @author lhein
@@ -25,9 +30,12 @@ import org.eclipse.lsp4j.services.LanguageClient;
 public class Runner {
 
 	public static void main(String[] args) {
-		CamelLanguageServer server = new CamelLanguageServer();
-		Launcher<LanguageClient> launcher = Launcher.createLauncher(server, LanguageClient.class, System.in, System.out);
-		server.connect(launcher.getRemoteProxy());
-		launcher.startListening();
+		if (Arrays.asList(args).contains("--websocket")) {
+			new WebSocketRunner().runWebSocketServer();
+		} else {
+			CamelLanguageServer server = new CamelLanguageServer();
+			Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, System.in, System.out);
+			launcher.startListening();
+		}
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/websocket/CamelLSPWebSocketEndpoint.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/websocket/CamelLSPWebSocketEndpoint.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.websocket;
+
+import java.util.Collection;
+
+import org.eclipse.lsp4j.jsonrpc.Launcher.Builder;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageClientAware;
+import org.eclipse.lsp4j.websocket.WebSocketEndpoint;
+
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+public class CamelLSPWebSocketEndpoint extends WebSocketEndpoint<LanguageClient> {
+
+	@Override
+	protected void configure(Builder<LanguageClient> builder) {
+		builder.setLocalService(new CamelLanguageServer());
+		builder.setRemoteInterface(LanguageClient.class);
+	}
+
+	@Override
+	protected void connect(Collection<Object> localServices, LanguageClient remoteProxy) {
+		localServices.stream()
+			.filter(LanguageClientAware.class::isInstance)
+			.forEach(languageClientAware -> ((LanguageClientAware) languageClientAware).connect(remoteProxy));
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/websocket/CamelLSPWebSocketServerConfigProvider.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/websocket/CamelLSPWebSocketServerConfigProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.websocket;
+
+import java.util.Collections;
+import java.util.Set;
+
+import javax.websocket.Endpoint;
+import javax.websocket.server.ServerApplicationConfig;
+import javax.websocket.server.ServerEndpointConfig;
+
+public class CamelLSPWebSocketServerConfigProvider implements ServerApplicationConfig {
+
+	private static final String WEBSOCKET_CAMEL_SERVER_PATH = "/camel-language-server";
+
+	@Override
+	public Set<ServerEndpointConfig> getEndpointConfigs(Set<Class<? extends Endpoint>> endpointClasses) {
+		ServerEndpointConfig conf = ServerEndpointConfig.Builder.create(CamelLSPWebSocketEndpoint.class, WEBSOCKET_CAMEL_SERVER_PATH).build();
+		return Collections.singleton(conf);
+	}
+
+	@Override
+	public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
+		return scanned;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/websocket/WebSocketRunner.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/websocket/WebSocketRunner.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.websocket;
+
+import javax.websocket.DeploymentException;
+
+import org.glassfish.tyrus.server.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebSocketRunner {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketRunner.class);
+
+	public void runWebSocketServer() {
+		Server server = new Server("localhost", 8025, "/", null, CamelLSPWebSocketServerConfigProvider.class);
+		Runtime.getRuntime().addShutdownHook(new Thread(server::stop, "camel-lsp-websocket-server-shutdown-hook"));
+
+		try {
+			server.start();
+			Thread.currentThread().join();
+		} catch (InterruptedException e) {
+			LOGGER.error("Camel LSP Websocket server has been interrupted.", e);
+			Thread.currentThread().interrupt();
+		} catch (DeploymentException e) {
+			LOGGER.error("Cannot start Camel LSP Websocket server.", e);
+		} finally {
+			server.stop();
+		}
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/RunnerWebSocketTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/RunnerWebSocketTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.websocket.ClientEndpointConfig;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.Session;
+
+import org.glassfish.tyrus.client.ClientManager;
+import org.junit.jupiter.api.Test;
+
+public class RunnerWebSocketTest {
+	
+	private CountDownLatch messageLatch = new CountDownLatch(1);
+	
+	@Test
+	public void testWebsocketServerStarted() throws Exception {
+		startRunnerWithWebsocketOption();
+		
+		messageLatch.await(1, TimeUnit.SECONDS);
+		
+		final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
+        ClientManager client = ClientManager.createClient();
+        client.connectToServer(new Endpoint() {
+
+            @Override
+            public void onOpen(Session session, EndpointConfig config) {
+            	messageLatch.countDown();
+            }
+            
+        }, cec, new URI("ws://localhost:8025/camel-language-server"));
+	}
+
+	private void startRunnerWithWebsocketOption() {
+		new Thread(new Runnable() {
+			
+			@Override
+			public void run() {
+				Runner.main(new String[] {"--websocket"});
+			}
+		}).start();
+	}
+
+}


### PR DESCRIPTION
- use Tyrus, the reference implementation
- connection through non-configurable port 8025
- camel server jar needs to launched with --websocket

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

no test, I don't know yet how to write test for it :-(

