### PR TITLE
register client proxy to the server

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/RunnerStandardIOTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/RunnerStandardIOTest.java
@@ -16,32 +16,27 @@
  */
 package com.github.cameltooling.lsp.internal;
 
-import java.util.Arrays;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-import org.eclipse.lsp4j.jsonrpc.Launcher;
-import org.eclipse.lsp4j.launch.LSPLauncher;
-import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.websocket.WebSocketRunner;
+public class RunnerStandardIOTest {
 
-/**
- * @author lhein
- */
-public class Runner {
+	@Test
+	void testClientProxyAvailable() throws Exception {
+		startRunnerWithoutOption();
+		await("Await that Server has started and have a remote proxy client").untilAsserted(() -> assertThat(Runner.server).isNotNull());
+		await("Await that Server has started and have a remote proxy client").untilAsserted(() -> assertThat(Runner.server.getClient()).isNotNull());
+	}
 
-	/**
-	 * For test only
-	 */
-	static CamelLanguageServer server;
-
-	public static void main(String[] args) {
-		if (Arrays.asList(args).contains("--websocket")) {
-			new WebSocketRunner().runWebSocketServer();
-		} else {
-			server = new CamelLanguageServer();
-			Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, System.in, System.out);
-			server.connect(launcher.getRemoteProxy());
-			launcher.startListening();
-		}
+	private void startRunnerWithoutOption() {
+		new Thread(new Runnable() {
+			
+			@Override
+			public void run() {
+				Runner.main(new String[]{});
+			}
+		}).start();
 	}
 }


### PR DESCRIPTION
camel-tooling/camel-lsp-client-vscode#142

it was removed during refactor for Websocket but it was not intended.
Added a test to avoid regression in the future for this very specific
point. Issue was caught by UI tests in client side.

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build