### PR TITLE
FUSETOOLS2-67 - provide more precise Diagnostic range for unknown option

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
@@ -54,20 +54,14 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 	public void testValidationError() throws Exception {
 		testDiagnostic("camel-with-endpoint-error", 1, ".xml");
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
-		assertThat(range.getStart().getLine()).isEqualTo(8);
-		assertThat(range.getStart().getCharacter()).isEqualTo(16);
-		assertThat(range.getEnd().getLine()).isEqualTo(8);
-		assertThat(range.getEnd().getCharacter()).isEqualTo(39);
+		checkRange(range, 8, 16, 8, 39);
 	}
 	
 	@Test
 	public void testValidationErrorWithNamespacePrefix() throws Exception {
 		testDiagnostic("camel-with-endpoint-error-withNamespacePrefix", 1, ".xml");
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
-		assertThat(range.getStart().getLine()).isEqualTo(8);
-		assertThat(range.getStart().getCharacter()).isEqualTo(25);
-		assertThat(range.getEnd().getLine()).isEqualTo(8);
-		assertThat(range.getEnd().getCharacter()).isEqualTo(48);
+		checkRange(range, 8, 25, 8, 48);
 	}
 	
 	@Test
@@ -91,10 +85,7 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
 		assertThat(diagnostic.getMessage()).isNotNull();
 		Range range = diagnostic.getRange();
-		assertThat(range.getStart().getLine()).isEqualTo(8);
-		assertThat(range.getStart().getCharacter()).isEqualTo(16);
-		assertThat(range.getEnd().getLine()).isEqualTo(8);
-		assertThat(range.getEnd().getCharacter()).isEqualTo(43);
+		checkRange(range, 8, 16, 8, 43);
 	}
 	
 	@Test
@@ -111,10 +102,7 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 	public void testValidationErrorForJavaFile() throws Exception {
 		testDiagnostic("camel-with-endpoint-error", 1, ".java");
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
-		assertThat(range.getStart().getLine()).isEqualTo(12);
-		assertThat(range.getStart().getCharacter()).isEqualTo(14);
-		assertThat(range.getEnd().getLine()).isEqualTo(12);
-		assertThat(range.getEnd().getCharacter()).isEqualTo(37);
+		checkRange(range, 12, 14, 12, 37);
 	}
 	
 	@Test
@@ -151,6 +139,29 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 	@Test
 	public void testUnknowPropertyOnNonLenientPropertiesComponent() throws Exception {
 		testDiagnostic("camel-with-unknownParameter", 1, ".xml");
+		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
+		checkRange(range, 9, 33, 9, 45);
+	}
+
+	void checkRange(Range range, int startLine, int startCharacter, int endLine, int endCharacter) {
+		assertThat(range.getStart().getLine()).isEqualTo(startLine);
+		assertThat(range.getStart().getCharacter()).isEqualTo(startCharacter);
+		assertThat(range.getEnd().getLine()).isEqualTo(endLine );
+		assertThat(range.getEnd().getCharacter()).isEqualTo(endCharacter);
+	}
+	
+	@Test
+	public void testSeveralUnknowPropertyOnNonLenientPropertiesComponent() throws Exception {
+		testDiagnostic("camel-with-2-unknownParameters", 2, ".xml");
+		Range range1 = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
+		checkRange(range1, 9, 33, 9, 46);
+		Range range2 = lastPublishedDiagnostics.getDiagnostics().get(1).getRange();
+		checkRange(range2, 9, 56, 9, 69);
+	}
+	
+	@Test
+	public void testSeveralUnknowPropertyAndAnotherError() throws Exception {
+		testDiagnostic("camel-with-unknownParameterAndAnotherError", 2, ".xml");
 	}
 	
 	@Test

--- a/src/test/resources/workspace/diagnostic/camel-with-2-unknownParameters.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-2-unknownParameters.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="timer:timerName?unknownParam1=1000&amp;unknownParam2=5000"/>
+      <to uri="direct:drink"/>
+    </route>
+  </camelContext>
+</beans>

--- a/src/test/resources/workspace/diagnostic/camel-with-unknownParameterAndAnotherError.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-unknownParameterAndAnotherError.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="timer:timerName?unknownParam=1000&amp;delay=1000xx"/>
+      <to uri="direct:drink"/>
+    </route>
+  </camelContext>
+</beans>


### PR DESCRIPTION
not covered cases:
- multiline Camel URI
- unknown option which is a substring of another parameter on the same
line

please note that it would be better to have Camel validation result
returning a more precise range directly instead of calculating on
Language Server side

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build