### PR TITLE
FUSETOOLS2-73 - Provide precise range for wrong enum values

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
@@ -81,6 +81,24 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 	}
 	
 	@Test
+	public void testInvalidEnum() throws Exception {
+		testDiagnostic("camel-with-invalid-enum", 1, ".xml");
+		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
+		assertThat(diagnostic.getMessage()).isNotNull();
+		Range range = diagnostic.getRange();
+		checkRange(range, 9, 49, 9, 65);
+	}
+	
+	@Test
+	public void testInvalidEnumWithSameStringOnSameLine() throws Exception {
+		testDiagnostic("camel-with-invalid-enum-with-same-string-in-camel-uri", 1, ".xml");
+		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
+		assertThat(diagnostic.getMessage()).isNotNull();
+		Range range = diagnostic.getRange();
+		checkRange(range, 9, 56, 9, 72);
+	}
+	
+	@Test
 	public void testValidationErrorWithSyntaxError() throws Exception {
 		testDiagnostic("camel-with-endpoint-error-withampersand", 1, ".xml");
 		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
@@ -157,6 +175,17 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 		checkRange(range2, 9, 56, 9, 69);
 	}
 	
+	@Test
+	public void testSeveralErrorsWithPreciseSpecificrange() throws Exception {
+		testDiagnostic("camel-with-several-errors-with-precise-specific-range", 3, ".xml");
+		Range range1 = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
+		checkRange(range1, 9, 33, 9, 46);
+		Range range2 = lastPublishedDiagnostics.getDiagnostics().get(1).getRange();
+		checkRange(range2, 9, 56, 9, 69);
+		Range range3 = lastPublishedDiagnostics.getDiagnostics().get(2).getRange();
+		checkRange(range3, 9, 95, 9, 111);
+	}
+
 	@Test
 	public void testSeveralUnknowPropertyAndAnotherError() throws Exception {
 		testDiagnostic("camel-with-unknownParameterAndAnotherError", 2, ".xml");

--- a/src/test/resources/workspace/diagnostic/camel-with-invalid-enum-with-same-string-in-camel-uri.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-invalid-enum-with-same-string-in-camel-uri.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="timer:InvalidEnumValue?exchangePattern=InvalidEnumValue"/>
+      <to uri="timer:timerName2?delay=1000"></to>
+    </route>
+  </camelContext>
+</beans>

--- a/src/test/resources/workspace/diagnostic/camel-with-invalid-enum.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-invalid-enum.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="timer:timerName?exchangePattern=InvalidEnumValue"/>
+      <to uri="timer:timerName?delay=10"></to>
+    </route>
+  </camelContext>
+</beans>

--- a/src/test/resources/workspace/diagnostic/camel-with-several-errors-with-precise-specific-range.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-several-errors-with-precise-specific-range.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="a route">
+      <from uri="timer:timerName?unknownParam1=1000&amp;unknownParam2=5000&amp;exchangePattern=InvalidEnumValue"/>
+      <to uri="direct:drink"/>
+    </route>
+  </camelContext>
+</beans>


### PR DESCRIPTION
- doesn't handle multi-line
- doesn't handle cases of property name AND property enum value are
repeated in the same Camel URI (which seems highly improbable). it
handles the case of repeated property enum values

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

![Screenshot from 2019-11-29 14-15-31](https://user-images.githubusercontent.com/1105127/69871311-c06bf280-12b2-11ea-9723-4b86fe903dc2.png)


# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build