### PR TITLE
FUSETOOLS2-69 - limit quickfix for unknown properties to "similar" ones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 		<roaster.version>2.20.1.Final</roaster.version>
 		<awaitility.version>4.0.1</awaitility.version>
 		<tyrus.version>1.15</tyrus.version>
+		<commons-text.version>1.8</commons-text.version>
 	</properties>
 
 	<distributionManagement>
@@ -288,6 +289,11 @@
   			<groupId>org.glassfish.tyrus</groupId>
 			<artifactId>tyrus-container-grizzly-server</artifactId>
 			<version>${tyrus.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>${commons-text.version}</version>
 		</dependency>
 	</dependencies>
 	

--- a/src/test/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfixTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfixTest.java
@@ -91,7 +91,7 @@ public class UnknownPropertyQuickfixTest extends AbstractCamelLanguageServerTest
 	
 	private void checkRetrievedCodeAction(TextDocumentIdentifier textDocumentIdentifier, Diagnostic diagnostic, CompletableFuture<List<Either<Command, CodeAction>>> codeActions)
 			throws InterruptedException, ExecutionException {
-		assertThat(codeActions.get()).isNotEmpty();
+		assertThat(codeActions.get()).hasSize(1);
 		CodeAction codeAction = codeActions.get().get(0).getRight();
 		assertThat(codeAction.getDiagnostics()).containsOnly(diagnostic);
 		assertThat(codeAction.getKind()).isEqualTo(CodeActionKind.QuickFix);
@@ -99,8 +99,8 @@ public class UnknownPropertyQuickfixTest extends AbstractCamelLanguageServerTest
 		assertThat(createdChanges).isNotEmpty();
 		TextEdit textEdit = createdChanges.get(0);
 		Range range = textEdit.getRange();
-		new RangeChecker().check(range, 9, 33, 9, 45);
-		assertThat(textEdit.getNewText()).isEqualTo("bridgeErrorHandler");
+		new RangeChecker().check(range, 9, 33, 9, 37);
+		assertThat(textEdit.getNewText()).isEqualTo("delay");
 	}
 
 	private TextDocumentIdentifier initAnLaunchDiagnostic() throws FileNotFoundException {

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
@@ -166,7 +166,7 @@ public class CamelDiagnosticTest extends AbstractCamelLanguageServerTest {
 	public void testUnknowPropertyOnNonLenientPropertiesComponent() throws Exception {
 		testDiagnostic("camel-with-unknownParameter", 1, ".xml");
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
-		checkRange(range, 9, 33, 9, 45);
+		checkRange(range, 9, 33, 9, 37);
 	}
 
 	private void checkRange(Range range, int startLine, int startCharacter, int endLine, int endCharacter) {

--- a/src/test/resources/workspace/diagnostic/camel-with-unknownParameter.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-unknownParameter.xml
@@ -7,7 +7,7 @@
 
   <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
     <route id="a route">
-      <from uri="timer:timerName?unknownParam=1000"/>
+      <from uri="timer:timerName?decy=1000"/>
       <to uri="direct:drink"/>
     </route>
   </camelContext>


### PR DESCRIPTION
based on LevenshteinDistance: This is the number of changes needed to
change one sequence into another, where each change is a single
character modification (deletion, insertion or substitution).

![filteredListOfQuickfix](https://user-images.githubusercontent.com/1105127/70069883-d4855c00-15f2-11ea-9ee9-883a3ce10eba.gif)

in case there is no "similar" properties. I implemented to provide no quickfix.
Would it be better to provide all possible properties even if the list can be very very long (several hundreds)?

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build