### PR TITLE
FUSETOOLS2-82 - all properties files are supported

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -65,8 +65,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.codeactions.UnknownPropertyQuickfix;
-import com.github.cameltooling.lsp.internal.completion.CamelApplicationPropertiesCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
+import com.github.cameltooling.lsp.internal.completion.CamelPropertiesCompletionProcessor;
 import com.github.cameltooling.lsp.internal.definition.DefinitionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticService;
 import com.github.cameltooling.lsp.internal.documentsymbol.DocumentSymbolProcessor;
@@ -118,8 +118,8 @@ public class CamelTextDocumentService implements TextDocumentService {
 		String uri = completionParams.getTextDocument().getUri();
 		LOGGER.info("completion: {}", uri);
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
-		if(uri.endsWith("application.properties")) {
-			return new CamelApplicationPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+		if (uri.endsWith(".properties")){
+			return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		} else {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
@@ -26,16 +26,17 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
+import com.github.cameltooling.lsp.internal.parser.CamelKafkaConnectDSLParser;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 
-public class CamelApplicationPropertiesCompletionProcessor {
+public class CamelPropertiesCompletionProcessor {
 
 	private static final String CAMEL_KEY_PREFIX = "camel.";
 	private static final String CAMEL_COMPONENT_KEY_PREFIX = "camel.component.";
 	private TextDocumentItem textDocumentItem;
 	private CompletableFuture<CamelCatalog> camelCatalog;
 
-	public CamelApplicationPropertiesCompletionProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog) {
+	public CamelPropertiesCompletionProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog) {
 		this.textDocumentItem = textDocumentItem;
 		this.camelCatalog = camelCatalog;
 	}
@@ -48,6 +49,8 @@ public class CamelApplicationPropertiesCompletionProcessor {
 				return getTopLevelCamelCompletion();
 			} else if(CAMEL_COMPONENT_KEY_PREFIX.equals(prefix)) {
 				return camelCatalog.thenApply(new CamelComponentIdsCompletionsFuture());
+			} else if (new CamelKafkaConnectDSLParser().getCamelComponentUri(line, position.getCharacter()) != null) {
+				return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position);
 			}
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesComponentCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesComponentCompletionTest.java
@@ -33,30 +33,24 @@ import org.junit.jupiter.api.Test;
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
-public class CamelApplicationPropertiesComponentCompletionTest extends AbstractCamelLanguageServerTest {
+public class CamelPropertiesComponentCompletionTest extends AbstractCamelLanguageServerTest {
 
 	@Test
 	public void testProvideCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 16));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 16));
 		
 		assertThat(completions.get().getLeft()).contains(createExpectedAhcCompletionItem(0, 16, 0, 19));
 	}
 	
 	@Test
-	public void testProvideCompletionNoCompletionForNonApplicationpropertiesFile() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 16));
+	public void testProvideCompletionNoCompletionAtWrongPosition() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 14));
 		
 		assertThat(completions.get().getLeft()).isEmpty();
 	}
 	
-	@Test
-	public void testProvideCompletionNoCompletionAtWorngPosition() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 14));
-		
-		assertThat(completions.get().getLeft()).isEmpty();
-	}
-	
-	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(String fileName, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+		String fileName = "a.properties";
 		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel.component."));
 		return getCompletionFor(camelLanguageServer, position, fileName);
 	}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
@@ -33,31 +33,25 @@ import org.junit.jupiter.api.Test;
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
-public class CamelApplicationPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerTest {
+public class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerTest {
 	
 	@Test
 	public void testProvideCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 6));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 6));
 		
 		assertThat(completions.get().getLeft()).hasSize(4);
 	}
 	
 	@Test
 	public void testProvideNoCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("application.properties", new Position(0, 0));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 0));
 		
 		assertThat(completions.get().getLeft()).isEmpty();
 	}
 	
-	@Test
-	public void testProvideNoCompletionForNonApplicationProperties() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion("applicationWithDifferentName.properties", new Position(0, 6));
-		
-		assertThat(completions.get().getLeft()).isEmpty();
-	}
-	
-	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(String fileName, Position position) throws URISyntaxException, InterruptedException, ExecutionException {
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel."));
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+		String fileName = "a.properties";
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(fileName, new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel."));
 		return getCompletionFor(camelLanguageServer, position, fileName);
 	}
 }


### PR DESCRIPTION
previously only application.properties were supported for camel.xxx and
all names for Kafka full Camel URI completion.

now all properties files are supported with camel.xxx, keeping the
support of full Camel URI support for specific source and sink Camel
Kafka Connect

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

![completionAllPropertiesFiles](https://user-images.githubusercontent.com/1105127/70532804-0b5df380-1b58-11ea-88e4-f75899e4f6cd.gif)


# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build