### PR TITLE
FUSETOOLS2-512 - first iteration to parse modeline

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModeline.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModeline.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.modelinemodel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
+
+public class CamelKModeline implements ILineRangeDefineable{
+	
+	public static final String MODELINE_LIKE_CAMEL_K = "// camel-k:";
+	public static final String MODELINE_LIKE_CAMEL_K_YAML = "# camel-k:";
+	public static final String MODELINE_LIKE_CAMEL_K_XML = "<!-- camel-k:";
+	
+	private String fullModeline;
+	private List<CamelKModelineOption> options = new ArrayList<>();
+
+	public CamelKModeline(String fullModeline) {
+		this.fullModeline = fullModeline;
+		String modelineCamelkStart = retrieveModelineCamelKStart(fullModeline);
+		if(modelineCamelkStart != null) {
+			parseOptions(fullModeline, modelineCamelkStart);
+		}
+	}
+
+	private void parseOptions(String fullModeline, String modelineCamelkStart) {
+		int currentPosition = modelineCamelkStart.length();
+		String remainingModeline = fullModeline.substring(currentPosition);
+		while(!remainingModeline.isEmpty()) {
+			int nextSpaceLikeCharacter = getNextSpaceLikeCharacter(remainingModeline);
+			if(nextSpaceLikeCharacter != -1) {
+				options.add(new CamelKModelineOption(remainingModeline.substring(1, nextSpaceLikeCharacter), currentPosition + 1));
+				remainingModeline = remainingModeline.substring(nextSpaceLikeCharacter);
+				currentPosition += nextSpaceLikeCharacter; 
+			} else {
+				if(!isEnfOfXmlModeline(remainingModeline)) {
+					options.add(new CamelKModelineOption(remainingModeline.substring(1), currentPosition + 1));
+				}
+				remainingModeline = "";
+			}
+		}
+	}
+
+	private boolean isEnfOfXmlModeline(String remainingModeline) {
+		return "-->".equals(remainingModeline.substring(1));
+	}
+
+	private String retrieveModelineCamelKStart(String fullModeline) {
+		if(fullModeline.startsWith(MODELINE_LIKE_CAMEL_K)) {
+			return MODELINE_LIKE_CAMEL_K;
+		} else if(fullModeline.startsWith(MODELINE_LIKE_CAMEL_K_YAML)) {
+			return MODELINE_LIKE_CAMEL_K_YAML;
+		} else if(fullModeline.startsWith(MODELINE_LIKE_CAMEL_K_XML)) {
+			return MODELINE_LIKE_CAMEL_K_XML;
+		}
+		return null;
+	}
+
+	private int getNextSpaceLikeCharacter(String remainingModeline) {
+		int nextSpace = remainingModeline.indexOf(' ', 1);
+		int nextTab = remainingModeline.indexOf('\t', 1);
+		if(nextSpace == -1) {
+			return nextTab;
+		} else if(nextTab == -1){
+			return nextSpace;
+		} else {
+			return Math.min(nextSpace, nextTab);
+		}
+	}
+
+	@Override
+	public int getLine() {
+		return 0;
+	}
+
+	@Override
+	public int getStartPositionInLine() {
+		return 0;
+	}
+
+	@Override
+	public int getEndPositionInLine() {
+		return fullModeline.length();
+	}
+
+	public List<CamelKModelineOption> getOptions() {
+		return options;
+	}
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.modelinemodel;
+
+import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
+
+public class CamelKModelineOption implements ILineRangeDefineable {
+	
+	private String optionName;
+	private String optionValue;
+	private int startCharacter;
+
+	public CamelKModelineOption(String option, int startCharacter) {
+		int nameValueIndexSeparator = option.indexOf('=');
+		this.optionName = option.substring(0, nameValueIndexSeparator != -1 ? nameValueIndexSeparator : option.length());
+		this.optionValue = nameValueIndexSeparator != -1 ? option.substring(nameValueIndexSeparator+1) : null;
+		this.startCharacter = startCharacter;
+	}
+	
+	@Override
+	public int getLine() {
+		return 0;
+	}
+
+	@Override
+	public int getStartPositionInLine() {
+		return startCharacter;
+	}
+
+	@Override
+	public int getEndPositionInLine() {
+		return startCharacter + optionName.length() + (optionValue != null ? optionValue.length() + 1 : 0);
+	}
+
+	public String getOptionName() {
+		return optionName;
+	}
+
+	public String getOptionValue() {
+		return optionValue;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
@@ -18,6 +18,8 @@ package com.github.cameltooling.lsp.internal.parser;
 
 import org.eclipse.lsp4j.TextDocumentItem;
 
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModeline;
+
 public class ParserFileHelperFactory {
 	
 	private static final String CAMELK_GROOVY_FILENAME_SUFFIX = ".camelk.groovy";
@@ -25,8 +27,6 @@ public class ParserFileHelperFactory {
 	private static final String CAMELK_YAML_FILENAME_SUFFIX = ".camelk.yaml";
 	private static final String CAMELK_JS_FILENAME_SUFFIX = ".camelk.js";
 	private static final String SHEBANG_CAMEL_K = "#!/usr/bin/env camel-k";
-	private static final String MODELINE_LIKE_CAMEL_K = "// camel-k:";
-	private static final String MODELINE_LIKE_CAMEL_K_YAML = "# camel-k: language=yaml";
 
 	public ParserFileHelper getCorrespondingParserFileHelper(TextDocumentItem textDocumentItem, int line) {
 		ParserXMLFileHelper xmlParser = new ParserXMLFileHelper();
@@ -74,7 +74,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isJSFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".js") && textDocumentItem.getText().startsWith(MODELINE_LIKE_CAMEL_K);
+		return uri.endsWith(".js") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K);
 	}
 
 	private boolean isCamelKafkaConnectDSL(TextDocumentItem textDocumentItem, String uri) {
@@ -95,7 +95,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isKotlinFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".kts") && textDocumentItem.getText().startsWith(MODELINE_LIKE_CAMEL_K);
+		return uri.endsWith(".kts") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K);
 	}
 
 	private boolean isCamelKGroovyDSL(TextDocumentItem textDocumentItem, String uri) {
@@ -106,7 +106,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isGroovyFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".groovy") && textDocumentItem.getText().startsWith(MODELINE_LIKE_CAMEL_K);
+		return uri.endsWith(".groovy") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K);
 	}
 
 	protected boolean isGroovyFileWithCamelKShebang(TextDocumentItem textDocumentItem, String uri) {
@@ -121,7 +121,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isYamlFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".yaml") && textDocumentItem.getText().startsWith(MODELINE_LIKE_CAMEL_K_YAML);
+		return uri.endsWith(".yaml") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K_YAML);
 	}
 
 	protected boolean isYamlFileWithCamelKShebang(TextDocumentItem textDocumentItem, String uri) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOptionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOptionTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.modelinemodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CamelKModelineOptionTest {
+	
+	String modelineString = "// camel-k: language=groovy";
+	CamelKModeline basicModeline = new CamelKModeline(modelineString);
+
+	@Test
+	void testOptionParsingBasic() throws Exception {
+		List<CamelKModelineOption> options = basicModeline.getOptions();
+		assertThat(options).hasSize(1);
+		CamelKModelineOption languageOption = options.get(0);
+		assertThat(languageOption.getOptionName()).isEqualTo("language");
+		assertThat(languageOption.getOptionValue()).isEqualTo("groovy");
+	}
+	
+	@Test
+	void test2Options() throws Exception {
+		String modelineWith2Options = "// camel-k: language=groovy trait=quarkus.enabled=true";
+		checkFor2Options(modelineWith2Options);
+	}
+	
+	@Test
+	void test2OptionsWithTabSeparator() throws Exception {
+		String modelineWith2Options = "// camel-k:\tlanguage=groovy\ttrait=quarkus.enabled=true";
+		checkFor2Options(modelineWith2Options);
+	}
+	
+	@Test
+	void testOptionsWithMixedSeparator() throws Exception {
+		String modelineWithMixedSeparator = "// camel-k:\tlanguage=groovy trait=quarkus.enabled=true\tdependency=mvn:org.my/application:1.0";
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator).getOptions();
+		assertThat(options).hasSize(3);
+	}
+	
+	@Test
+	void testOptionsWithIncompleteOptions() throws Exception {
+		String modelineWithMixedSeparator = "// camel-k: language=groovy trait";
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator).getOptions();
+		assertThat(options).hasSize(2);
+		CamelKModelineOption incompleteOption = options.get(1);
+		assertThat(incompleteOption.getOptionName()).isEqualTo("trait");
+		assertThat(incompleteOption.getOptionValue()).isNull();
+		assertThat(incompleteOption.getStartPositionInLine()).isEqualTo(28);
+		assertThat(incompleteOption.getEndPositionInLine()).isEqualTo(33);
+	}
+
+	private void checkFor2Options(String modelineWith2Options) {
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWith2Options).getOptions();
+		assertThat(options).hasSize(2);
+		CamelKModelineOption languageGroovyOption = options.get(0);
+		assertThat(languageGroovyOption.getOptionName()).isEqualTo("language");
+		assertThat(languageGroovyOption.getOptionValue()).isEqualTo("groovy");
+		assertThat(languageGroovyOption.getStartPositionInLine()).isEqualTo(12);
+		assertThat(languageGroovyOption.getEndPositionInLine()).isEqualTo(27);
+		CamelKModelineOption traitOption = options.get(1);
+		assertThat(traitOption.getOptionName()).isEqualTo("trait");
+		assertThat(traitOption.getOptionValue()).isEqualTo("quarkus.enabled=true");
+		assertThat(traitOption.getStartPositionInLine()).isEqualTo(28);
+		assertThat(traitOption.getEndPositionInLine()).isEqualTo(modelineWith2Options.length());
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.modelinemodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CamelKModelineTest {
+	
+	String modelineString = "// camel-k: language=groovy";
+	CamelKModeline basicModeline = new CamelKModeline(modelineString);
+	
+	public static Stream<Arguments> data() {
+		return Stream.of(
+				Arguments.of("// camel-k: language=groovy"),
+				Arguments.of("# camel-k: language=yaml"),
+				Arguments.of("<!-- camel-k: language=xml -->"));
+	}
+	
+	@ParameterizedTest
+	@MethodSource("data")
+	void testGetLine(String modelineString) throws Exception {
+		CamelKModeline modeline = new CamelKModeline(modelineString);
+		assertThat(modeline.getLine()).isEqualTo(0);
+	}
+
+	@ParameterizedTest
+	@MethodSource("data")
+	void testGetStartPositionInLine(String modelineString) throws Exception {
+		CamelKModeline modeline = new CamelKModeline(modelineString);
+		assertThat(modeline.getStartPositionInLine()).isEqualTo(0);
+	}
+
+	@ParameterizedTest
+	@MethodSource("data")
+	void testGetEndPositionInLine(String modelineString) throws Exception {
+		CamelKModeline modeline = new CamelKModeline(modelineString);
+		assertThat(modeline.getEndPositionInLine()).isEqualTo(modelineString.length());
+	}
+	
+	@ParameterizedTest
+	@MethodSource("data")
+	void testGetNumberOfOptions(String modelineString) throws Exception {
+		CamelKModeline modeline = new CamelKModeline(modelineString);
+		assertThat(modeline.getOptions()).hasSize(1);
+	}
+
+}


### PR DESCRIPTION
No impact on external behavior. It is the first piece to be able to
provide support for modeline. Now that there is a model for it we will
eb able to provide it. The model will surely evolve to handle completion
in Option Values but it can be done later to keep small chunks of code.

- parse into a model taking care of position with options
- handling modeline for all supported languages (yaml and xml are
special cases compared to others)
- keep same level of constraints than before in terms of space around
"// camel-k: " and "# camel-k: ". the Runtime allows to write
""//camel-k:" for instance. this can be improved in another task. it
wasn't the goal of this one.
- support space and tab character between options. The runtime is using
a regexp which seems to allow \r \n and \f but it will create invalid
files so we don't need that.


Signed-off-by: Aurélien Pupier <apupier@redhat.com>

# Pull Request informations

## Rebase & Merge default requirements

1. Green build for master branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **master** branch build