### PR TITLE
FUSETOOLS2-513 - provide completion for top level modeline options

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -71,11 +71,14 @@ import org.slf4j.LoggerFactory;
 import com.github.cameltooling.lsp.internal.codeactions.InvalidEnumQuickfix;
 import com.github.cameltooling.lsp.internal.codeactions.UnknownPropertyQuickfix;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
+import com.github.cameltooling.lsp.internal.completion.CamelKModelineCompletionprocessor;
 import com.github.cameltooling.lsp.internal.completion.CamelPropertiesCompletionProcessor;
 import com.github.cameltooling.lsp.internal.definition.DefinitionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticRunner;
 import com.github.cameltooling.lsp.internal.documentsymbol.DocumentSymbolProcessor;
 import com.github.cameltooling.lsp.internal.hover.HoverProcessor;
+import com.github.cameltooling.lsp.internal.parser.CamelKModelineParser;
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 import com.github.cameltooling.lsp.internal.references.ReferencesProcessor;
 import com.github.cameltooling.lsp.internal.settings.JSONUtility;
 import com.google.gson.Gson;
@@ -125,9 +128,15 @@ public class CamelTextDocumentService implements TextDocumentService {
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
 		if (uri.endsWith(".properties")){
 			return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+		} else if(isOnCamelKModeline(completionParams, textDocumentItem)){
+			return new CamelKModelineCompletionprocessor(textDocumentItem).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		} else {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		}
+	}
+
+	private boolean isOnCamelKModeline(CompletionParams completionParams, TextDocumentItem textDocumentItem) {
+		return completionParams.getPosition().getLine() == 0 && new CamelKModelineParser().retrieveModelineCamelKStart(new ParserFileHelperUtil().getLine(textDocumentItem, 0)) != null;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKModelineCompletionprocessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKModelineCompletionprocessor.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModeline;
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
+
+public class CamelKModelineCompletionprocessor {
+
+	private TextDocumentItem textDocumentItem;
+
+	public CamelKModelineCompletionprocessor(TextDocumentItem textDocumentItem) {
+		this.textDocumentItem = textDocumentItem;
+	}
+
+	public CompletableFuture<List<CompletionItem>>  getCompletions(Position position) {
+		String modelineString = new ParserFileHelperUtil().getLine(textDocumentItem, 0);
+		return new CamelKModeline(modelineString).getCompletions(position.getCharacter());
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKModelineOptionNames.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKModelineOptionNames.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.lsp4j.CompletionItem;
+
+public class CamelKModelineOptionNames {
+	
+	private CamelKModelineOptionNames() {}
+
+	private static final List<CompletionItem> COMPLETION_ITEMS;
+	
+	static {
+		COMPLETION_ITEMS = new ArrayList<>();
+		COMPLETION_ITEMS.add(createCompletionItem("dependency", "An external library that should be included. E.g. for Maven dependencies \"dependency=mvn:org.my/app:1.0\""));
+		COMPLETION_ITEMS.add(createCompletionItem("env", "Set an environment variable in the integration container. E.g \"env=MY_VAR=my-value\""));
+		COMPLETION_ITEMS.add(createCompletionItem("label", "Add a label to the integration. E.g. \"label=my.company=hello\""));
+		COMPLETION_ITEMS.add(createCompletionItem("name", "The integration name"));
+		COMPLETION_ITEMS.add(createCompletionItem("open-api", "Add an OpenAPI v2 spec (file path)"));
+		COMPLETION_ITEMS.add(createCompletionItem("profile", "Trait profile used for deployment"));
+		COMPLETION_ITEMS.add(createCompletionItem("property", "Add a camel property"));
+		COMPLETION_ITEMS.add(createCompletionItem("property-file", "Bind a property file to the integration. E.g. \"property-file=integration.properties\""));
+		COMPLETION_ITEMS.add(createCompletionItem("resource", "Add a resource"));
+		COMPLETION_ITEMS.add(createCompletionItem("trait", "Configure a trait. E.g. \"trait=service.enabled=false\""));
+	}
+
+	private static CompletionItem createCompletionItem(String label, String documentation) {
+		CompletionItem completionItem = new CompletionItem(label);
+		completionItem.setDocumentation(documentation);
+		return completionItem;
+	}
+	
+	public static List<CompletionItem> getCompletionItems() {
+		return COMPLETION_ITEMS;
+	}
+	
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
@@ -54,4 +54,8 @@ public class CamelKModelineOption implements ILineRangeDefineable {
 		return optionValue;
 	}
 
+	public boolean isInRange(int positionInLine) {
+		return getStartPositionInLine() <= positionInLine && getEndPositionInLine() >= positionInLine;
+	}
+
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.parser;
+
+public class CamelKModelineParser {
+
+	public static final String MODELINE_LIKE_CAMEL_K = "// camel-k:";
+	public static final String MODELINE_LIKE_CAMEL_K_YAML = "# camel-k:";
+	public static final String MODELINE_LIKE_CAMEL_K_XML = "<!-- camel-k:";
+	
+	public String retrieveModelineCamelKStart(String fullModeline) {
+		if(fullModeline.startsWith(MODELINE_LIKE_CAMEL_K)) {
+			return MODELINE_LIKE_CAMEL_K;
+		} else if(fullModeline.startsWith(MODELINE_LIKE_CAMEL_K_YAML)) {
+			return MODELINE_LIKE_CAMEL_K_YAML;
+		} else if(fullModeline.startsWith(MODELINE_LIKE_CAMEL_K_XML)) {
+			return MODELINE_LIKE_CAMEL_K_XML;
+		}
+		return null;
+	}
+	
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
@@ -18,8 +18,6 @@ package com.github.cameltooling.lsp.internal.parser;
 
 import org.eclipse.lsp4j.TextDocumentItem;
 
-import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModeline;
-
 public class ParserFileHelperFactory {
 	
 	private static final String CAMELK_GROOVY_FILENAME_SUFFIX = ".camelk.groovy";
@@ -74,7 +72,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isJSFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".js") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K);
+		return uri.endsWith(".js") && textDocumentItem.getText().startsWith(CamelKModelineParser.MODELINE_LIKE_CAMEL_K);
 	}
 
 	private boolean isCamelKafkaConnectDSL(TextDocumentItem textDocumentItem, String uri) {
@@ -95,7 +93,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isKotlinFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".kts") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K);
+		return uri.endsWith(".kts") && textDocumentItem.getText().startsWith(CamelKModelineParser.MODELINE_LIKE_CAMEL_K);
 	}
 
 	private boolean isCamelKGroovyDSL(TextDocumentItem textDocumentItem, String uri) {
@@ -106,7 +104,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isGroovyFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".groovy") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K);
+		return uri.endsWith(".groovy") && textDocumentItem.getText().startsWith(CamelKModelineParser.MODELINE_LIKE_CAMEL_K);
 	}
 
 	protected boolean isGroovyFileWithCamelKShebang(TextDocumentItem textDocumentItem, String uri) {
@@ -121,7 +119,7 @@ public class ParserFileHelperFactory {
 	}
 
 	private boolean isYamlFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".yaml") && textDocumentItem.getText().startsWith(CamelKModeline.MODELINE_LIKE_CAMEL_K_YAML);
+		return uri.endsWith(".yaml") && textDocumentItem.getText().startsWith(CamelKModelineParser.MODELINE_LIKE_CAMEL_K_YAML);
 	}
 
 	protected boolean isYamlFileWithCamelKShebang(TextDocumentItem textDocumentItem, String uri) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.modeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class CamelKModelineCompletionTest extends AbstractCamelLanguageServerTest {
+
+	@Test
+	void testProvideCompletionWithOnlyPrefix() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: ");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 12));
+		
+		List<CompletionItem> completionItems = completions.get().getLeft();
+		assertThat(completionItems).hasSize(10);
+		checkTraitCompletionAvailable(completionItems);
+	}
+	
+	private void checkTraitCompletionAvailable(List<CompletionItem> completionItems) {
+		CompletionItem traitCompletionItem = new CompletionItem("trait");
+		traitCompletionItem.setDocumentation("Configure a trait. E.g. \"trait=service.enabled=false\"");
+		assertThat(completionItems).contains(traitCompletionItem);
+	}
+	
+	@Test
+	void testProvideCompletionAtTheEndOfLine() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: language=groovy trait=service.enabled=false ");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 56));
+		
+		List<CompletionItem> completionItems = completions.get().getLeft();
+		assertThat(completionItems).hasSize(10);
+		checkTraitCompletionAvailable(completionItems);
+	}
+	
+	@Test
+	void testProvideNoCompletionInPrefix() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: ");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 5));
+		
+		assertThat(completions.get().getLeft()).hasSize(0);
+	}
+	
+	@Test
+	void testProvideNoCompletionInsideOption() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: trait=quarkus.enabled=true");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 14));
+		
+		assertThat(completions.get().getLeft()).hasSize(0);
+	}
+	
+}


### PR DESCRIPTION
based on https://github.com/camel-tooling/camel-language-server/pull/393

- hardcoded list for now. The "useful" ones, as mentioned in Camel K
documentation, are not available dynamically for now anyway.
- it is providing completion only at the end of a modeline, not in the
middle

![completionModelineIteration1](https://user-images.githubusercontent.com/1105127/85704408-8cd63700-b6e0-11ea-9f30-b38cde436252.gif)
