### PR TITLE
Fusetools2 520 provide completion for trait property name with default value

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/TraitProperty.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/TraitProperty.java
@@ -28,6 +28,13 @@ public class TraitProperty {
 	public CompletionItem createCompletionItem() {
 		CompletionItem completionItem = new CompletionItem(name);
 		completionItem.setDocumentation(description);
+		if (defaultValue != null) {
+			if("int".equals(type) && defaultValue instanceof Double) {
+				completionItem.setInsertText(name+"="+((Double)defaultValue).intValue());
+			} else {
+				completionItem.setInsertText(name+"="+defaultValue);
+			}
+		}
 		return completionItem;
 	}
 	


### PR DESCRIPTION
based on https://github.com/camel-tooling/camel-language-server/pull/397

![defaultValueAddedAfterCompletion](https://user-images.githubusercontent.com/1105127/85867032-9c30af80-b7c8-11ea-9200-bb66eab69b55.gif)
