### PR TITLE
FUSETOOLS2-528 - Provide Camel Component property completion in modeline

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentIdsCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentIdsCompletionsFuture.java
@@ -23,15 +23,15 @@ import java.util.stream.Collectors;
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 
-import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelComponentNamePropertyFileInstance;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelComponentNamePropertyInstance;
 import com.github.cameltooling.model.util.ModelHelper;
 
 public class CamelComponentIdsCompletionsFuture implements Function<CamelCatalog, List<CompletionItem>> {
 
 	private String startFilter;
-	private CamelComponentNamePropertyFileInstance camelComponentNamePropertyFileInstance;
+	private CamelComponentNamePropertyInstance camelComponentNamePropertyFileInstance;
 
-	public CamelComponentIdsCompletionsFuture(CamelComponentNamePropertyFileInstance camelComponentNamePropertyFileInstance, String startFilter) {
+	public CamelComponentIdsCompletionsFuture(CamelComponentNamePropertyInstance camelComponentNamePropertyFileInstance, String startFilter) {
 		this.camelComponentNamePropertyFileInstance = camelComponentNamePropertyFileInstance;
 		this.startFilter = startFilter;
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionNamesCompletionFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionNamesCompletionFuture.java
@@ -24,19 +24,19 @@ import java.util.stream.Stream;
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 
-import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelComponentParameterPropertyFileInstance;
-import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyFileValueInstance;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelComponentParameterPropertyInstance;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyValueInstance;
 import com.github.cameltooling.model.ComponentOptionModel;
 import com.github.cameltooling.model.util.ModelHelper;
 
 public class CamelComponentOptionNamesCompletionFuture implements Function<CamelCatalog, List<CompletionItem>> {
 
 	private String componentId;
-	private CamelPropertyFileValueInstance camelPropertyFileValueInstance;
+	private CamelPropertyValueInstance camelPropertyFileValueInstance;
 	private String startFilter;
-	private CamelComponentParameterPropertyFileInstance camelComponentParameterPropertyFileInstance;
+	private CamelComponentParameterPropertyInstance camelComponentParameterPropertyFileInstance;
 
-	public CamelComponentOptionNamesCompletionFuture(String componentId, CamelComponentParameterPropertyFileInstance camelComponentParameterPropertyFileInstance, CamelPropertyFileValueInstance camelPropertyFileValueInstance, String startFilter) {
+	public CamelComponentOptionNamesCompletionFuture(String componentId, CamelComponentParameterPropertyInstance camelComponentParameterPropertyFileInstance, CamelPropertyValueInstance camelPropertyFileValueInstance, String startFilter) {
 		this.componentId = componentId;
 		this.camelComponentParameterPropertyFileInstance = camelComponentParameterPropertyFileInstance;
 		this.camelPropertyFileValueInstance = camelPropertyFileValueInstance;

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionValuesCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionValuesCompletionsFuture.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 
-import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelComponentPropertyFilekey;
-import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyFileValueInstance;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelComponentPropertyKey;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyValueInstance;
 import com.github.cameltooling.model.ComponentOptionModel;
 import com.github.cameltooling.model.util.ModelHelper;
 
@@ -36,11 +36,11 @@ public class CamelComponentOptionValuesCompletionsFuture implements Function<Cam
 	
 	private static final String BOOLEAN_TYPE = "boolean";
 	
-	private CamelPropertyFileValueInstance camelPropertyFileValueInstance;
+	private CamelPropertyValueInstance camelPropertyFileValueInstance;
 
 	private String startFilter;
 
-	public CamelComponentOptionValuesCompletionsFuture(CamelPropertyFileValueInstance camelPropertyFileValueInstance, String startFilter) {
+	public CamelComponentOptionValuesCompletionsFuture(CamelPropertyValueInstance camelPropertyFileValueInstance, String startFilter) {
 		this.camelPropertyFileValueInstance = camelPropertyFileValueInstance;
 		this.startFilter = startFilter;
 	}
@@ -76,7 +76,7 @@ public class CamelComponentOptionValuesCompletionsFuture implements Function<Cam
 	}
 
 	private Optional<ComponentOptionModel> retrieveEndpointOptionModel(CamelCatalog camelCatalog) {
-		CamelComponentPropertyFilekey camelComponentPropertyFilekey = camelPropertyFileValueInstance.getKey().getCamelComponentPropertyFilekey();
+		CamelComponentPropertyKey camelComponentPropertyFilekey = camelPropertyFileValueInstance.getKey().getCamelComponentPropertyKey();
 		if(camelComponentPropertyFilekey != null) {
 			String componentId = camelComponentPropertyFilekey.getComponentId();
 			String keyName = camelComponentPropertyFilekey.getComponentProperty();

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
@@ -25,7 +25,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
-import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyFileEntryInstance;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyEntryInstance;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 
 public class CamelPropertiesCompletionProcessor {
@@ -41,7 +41,7 @@ public class CamelPropertiesCompletionProcessor {
 	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
 		if (textDocumentItem != null) {
 			String line = new ParserFileHelperUtil().getLine(textDocumentItem, position);
-			return new CamelPropertyFileEntryInstance(camelCatalog, line, position.getLine(), textDocumentItem).getCompletions(position);
+			return new CamelPropertyEntryInstance(line, new Position(position.getLine(), 0), textDocumentItem).getCompletions(position, camelCatalog);
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineOptionNames.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineOptionNames.java
@@ -31,6 +31,7 @@ public class CamelKModelineOptionNames {
 	private static final List<CompletionItem> COMPLETION_ITEMS;
 	public static final String OPTION_NAME_TRAIT = "trait";
 	public static final String OPTION_NAME_DEPENDENCY = "dependency";
+	public static final String OPTION_NAME_PROPERTY = "property";
 	
 	static {
 		OPTION_NAMES_WITH_DESCRIPTION = new HashMap<>();
@@ -40,7 +41,7 @@ public class CamelKModelineOptionNames {
 		OPTION_NAMES_WITH_DESCRIPTION.put("name", "The integration name");
 		OPTION_NAMES_WITH_DESCRIPTION.put("open-api", "Add an OpenAPI v2 spec (file path)");
 		OPTION_NAMES_WITH_DESCRIPTION.put("profile", "Trait profile used for deployment");
-		OPTION_NAMES_WITH_DESCRIPTION.put("property", "Add a camel property");
+		OPTION_NAMES_WITH_DESCRIPTION.put(OPTION_NAME_PROPERTY, "Add a camel property");
 		OPTION_NAMES_WITH_DESCRIPTION.put("property-file", "Bind a property file to the integration. E.g. \"property-file=integration.properties\"");
 		OPTION_NAMES_WITH_DESCRIPTION.put("resource", "Add a resource");
 		OPTION_NAMES_WITH_DESCRIPTION.put(OPTION_NAME_TRAIT, "Configure a trait. E.g. \"trait=service.enabled=false\"");

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentNamePropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentNamePropertyInstance.java
@@ -32,38 +32,36 @@ import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
  * it is used to represents "timer"
  * 
  */
-public class CamelComponentNamePropertyFileInstance implements ILineRangeDefineable {
+public class CamelComponentNamePropertyInstance implements ILineRangeDefineable {
 
 	private String componentName;
-	private CamelComponentPropertyFilekey camelComponentPropertyFilekey;
-	private CompletableFuture<CamelCatalog> camelCatalog;
+	private CamelComponentPropertyKey camelComponentPropertyKey;
 
-	public CamelComponentNamePropertyFileInstance(CompletableFuture<CamelCatalog> camelCatalog, String componentName, CamelComponentPropertyFilekey camelComponentPropertyFilekey) {
-		this.camelCatalog = camelCatalog;
+	public CamelComponentNamePropertyInstance(String componentName, CamelComponentPropertyKey camelComponentPropertyKey) {
 		this.componentName = componentName;
-		this.camelComponentPropertyFilekey = camelComponentPropertyFilekey;
+		this.camelComponentPropertyKey = camelComponentPropertyKey;
 	}
 
 	@Override
 	public int getLine() {
-		return camelComponentPropertyFilekey.getLine();
+		return camelComponentPropertyKey.getLine();
 	}
 
 	@Override
 	public int getStartPositionInLine() {
-		return CamelPropertyFileKeyInstance.CAMEL_COMPONENT_KEY_PREFIX.length();
+		return camelComponentPropertyKey.getStartPositionInLine();
 	}
 
 	@Override
 	public int getEndPositionInLine() {
-		return CamelPropertyFileKeyInstance.CAMEL_COMPONENT_KEY_PREFIX.length() + componentName.length();
+		return getStartPositionInLine() + componentName.length();
 	}
 
 	public String getName() {
 		return componentName;
 	}
 	
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
 		int characterPosition = position.getCharacter();
 		String componentIdBeforePosition = componentName.substring(0, characterPosition - getStartPositionInLine());
 		return camelCatalog.thenApply(new CamelComponentIdsCompletionsFuture(this, componentIdBeforePosition));

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
@@ -32,23 +32,21 @@ import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
  * it is used to represents "delay"
  * 
  */
-public class CamelComponentParameterPropertyFileInstance implements ILineRangeDefineable {
+public class CamelComponentParameterPropertyInstance implements ILineRangeDefineable {
 
-	private CompletableFuture<CamelCatalog> camelCatalog;
 	private String componentParameter;
-	private CamelComponentPropertyFilekey camelComponentPropertyFilekey;
+	private CamelComponentPropertyKey camelComponentPropertykey;
 	private int startCharacterInLine;
 
-	public CamelComponentParameterPropertyFileInstance(CompletableFuture<CamelCatalog> camelCatalog, String componentParameter, int startCharacterInLine, CamelComponentPropertyFilekey camelComponentPropertyFilekey) {
-		this.camelCatalog = camelCatalog;
+	public CamelComponentParameterPropertyInstance(String componentParameter, int startCharacterInLine, CamelComponentPropertyKey camelComponentPropertyKey) {
 		this.componentParameter = componentParameter;
 		this.startCharacterInLine = startCharacterInLine;
-		this.camelComponentPropertyFilekey = camelComponentPropertyFilekey;
+		this.camelComponentPropertykey = camelComponentPropertyKey;
 	}
 
 	@Override
 	public int getLine() {
-		return camelComponentPropertyFilekey.getLine();
+		return camelComponentPropertykey.getLine();
 	}
 
 	@Override
@@ -61,10 +59,10 @@ public class CamelComponentParameterPropertyFileInstance implements ILineRangeDe
 		return startCharacterInLine + componentParameter.length();
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
-		CamelPropertyFileValueInstance camelPropertyFileValueInstance = camelComponentPropertyFilekey.getCamelPropertyFileKeyInstance().getCamelPropertyFileEntryInstance().getCamelPropertyFileValueInstance();
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		CamelPropertyValueInstance camelPropertyFileValueInstance = camelComponentPropertykey.getCamelPropertyKeyInstance().getCamelPropertyEntryInstance().getCamelPropertyValueInstance();
 		String startComponentProperty = componentParameter.substring(0, position.getCharacter() - getStartPositionInLine());
-		return camelCatalog.thenApply(new CamelComponentOptionNamesCompletionFuture(camelComponentPropertyFilekey.getComponentId(), this, camelPropertyFileValueInstance, startComponentProperty));
+		return camelCatalog.thenApply(new CamelComponentOptionNamesCompletionFuture(camelComponentPropertykey.getComponentId(), this, camelPropertyFileValueInstance, startComponentProperty));
 	}
 
 	public String getProperty() {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
@@ -32,48 +32,50 @@ import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
  * it is used to represents "timer.delay"
  * 
  */
-public class CamelComponentPropertyFilekey implements ILineRangeDefineable {
+public class CamelComponentPropertyKey implements ILineRangeDefineable {
 
-	private String fullCamelComponentPropertyFileKey;
-	private CamelComponentNamePropertyFileInstance componentName;
-	private CamelComponentParameterPropertyFileInstance componentProperty;
-	private CamelPropertyFileKeyInstance camelPropertyFileKeyInstance;
+	private String fullCamelComponentPropertyKey;
+	private CamelComponentNamePropertyInstance componentName;
+	private CamelComponentParameterPropertyInstance componentProperty;
+	private CamelPropertyKeyInstance camelPropertyKeyInstance;
 
-	public CamelComponentPropertyFilekey(CompletableFuture<CamelCatalog> camelCatalog, String camelComponentPropertyFileKey, CamelPropertyFileKeyInstance camelPropertyFileKeyInstance) {
-		this.fullCamelComponentPropertyFileKey = camelComponentPropertyFileKey;
-		this.camelPropertyFileKeyInstance = camelPropertyFileKeyInstance;
-		int firstDotIndex = camelComponentPropertyFileKey.indexOf('.');
+	public CamelComponentPropertyKey(String camelComponentPropertyKey, CamelPropertyKeyInstance camelPropertyKeyInstance) {
+		this.fullCamelComponentPropertyKey = camelComponentPropertyKey;
+		this.camelPropertyKeyInstance = camelPropertyKeyInstance;
+		int firstDotIndex = camelComponentPropertyKey.indexOf('.');
 		if(firstDotIndex != -1) {
-			componentName = new CamelComponentNamePropertyFileInstance(camelCatalog, camelComponentPropertyFileKey.substring(0, firstDotIndex), this);
-			componentProperty = new CamelComponentParameterPropertyFileInstance(camelCatalog, camelComponentPropertyFileKey.substring(firstDotIndex+1), componentName.getEndPositionInLine() + 1, this);
+			componentName = new CamelComponentNamePropertyInstance(camelComponentPropertyKey.substring(0, firstDotIndex), this);
+			componentProperty = new CamelComponentParameterPropertyInstance(camelComponentPropertyKey.substring(firstDotIndex+1), componentName.getEndPositionInLine() + 1, this);
 		} else {
-			componentName = new CamelComponentNamePropertyFileInstance(camelCatalog, camelComponentPropertyFileKey, this);
+			componentName = new CamelComponentNamePropertyInstance(camelComponentPropertyKey, this);
 		}
 	}
 
 	public boolean isInRange(int positionChar) {
 		return getStartPositionInLine() <= positionChar
-				&& positionChar <= fullCamelComponentPropertyFileKey.length() + getStartPositionInLine();
+				&& positionChar <= fullCamelComponentPropertyKey.length() + getStartPositionInLine();
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
 		int characterPosition = position.getCharacter();
 		if(isInside(componentName, characterPosition)) {
-			return componentName.getCompletions(position);
+			return componentName.getCompletions(position, camelCatalog);
 		} else if(isInside(componentProperty, characterPosition)){
-			return componentProperty.getCompletions(position);
+			return componentProperty.getCompletions(position, camelCatalog);
 		} else {
 			return CompletableFuture.completedFuture(Collections.emptyList());
 		}
 	}
 
 	private boolean isInside(ILineRangeDefineable lineRangeDefineable, int characterPosition) {
-		return lineRangeDefineable.getStartPositionInLine() <= characterPosition && lineRangeDefineable.getEndPositionInLine() >= characterPosition;
+		return lineRangeDefineable != null
+				&& lineRangeDefineable.getStartPositionInLine() <= characterPosition
+				&& lineRangeDefineable.getEndPositionInLine() >= characterPosition;
 	}
 
 	@Override
 	public int getStartPositionInLine() {
-		return CamelPropertyFileKeyInstance.CAMEL_COMPONENT_KEY_PREFIX.length();
+		return camelPropertyKeyInstance.getStartPositionInLine() + CamelPropertyKeyInstance.CAMEL_COMPONENT_KEY_PREFIX.length();
 	}
 
 	public String getComponentId() {
@@ -86,16 +88,16 @@ public class CamelComponentPropertyFilekey implements ILineRangeDefineable {
 
 	@Override
 	public int getLine() {
-		return getCamelPropertyFileKeyInstance().getLine();
+		return getCamelPropertyKeyInstance().getLine();
 	}
 
 	@Override
 	public int getEndPositionInLine() {
-		return getStartPositionInLine() + fullCamelComponentPropertyFileKey.length();
+		return getStartPositionInLine() + fullCamelComponentPropertyKey.length();
 	}
 
-	public CamelPropertyFileKeyInstance getCamelPropertyFileKeyInstance() {
-		return camelPropertyFileKeyInstance;
+	public CamelPropertyKeyInstance getCamelPropertyKeyInstance() {
+		return camelPropertyKeyInstance;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -27,19 +27,19 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 
 /**
- * Represents one entry in properties file. For instance, the whole entry "camel.component.timer.delay=1000"
+ * Represents one entry in properties file or in Camel K modeline. For instance, the whole entry "camel.component.timer.delay=1000"
  *
  */
-public class CamelPropertyFileEntryInstance implements ILineRangeDefineable {
+public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 	
-	private CamelPropertyFileKeyInstance camelPropertyFileKeyInstance;
-	private CamelPropertyFileValueInstance camelPropertyFileValueInstance;
+	private CamelPropertyKeyInstance camelPropertyKeyInstance;
+	private CamelPropertyValueInstance camelPropertyValueInstance;
 	private String line;
-	private int lineNumber;
+	private Position startPosition;
 
-	public CamelPropertyFileEntryInstance(CompletableFuture<CamelCatalog> camelCatalog, String line, int lineNumber, TextDocumentItem textDocumentItem) {
+	public CamelPropertyEntryInstance(String line, Position startPosition, TextDocumentItem textDocumentItem) {
 		this.line = line;
-		this.lineNumber = lineNumber;
+		this.startPosition = startPosition;
 		int indexOf = line.indexOf('=');
 		String camelPropertyFileKeyInstanceString;
 		String camelPropertyFileValueInstanceString;
@@ -50,37 +50,37 @@ public class CamelPropertyFileEntryInstance implements ILineRangeDefineable {
 			camelPropertyFileKeyInstanceString = line;
 			camelPropertyFileValueInstanceString = null;
 		}
-		camelPropertyFileKeyInstance = new CamelPropertyFileKeyInstance(camelCatalog, camelPropertyFileKeyInstanceString, this);
-		camelPropertyFileValueInstance = new CamelPropertyFileValueInstance(camelCatalog, camelPropertyFileValueInstanceString, camelPropertyFileKeyInstance, textDocumentItem);
+		camelPropertyKeyInstance = new CamelPropertyKeyInstance(camelPropertyFileKeyInstanceString, this);
+		camelPropertyValueInstance = new CamelPropertyValueInstance(camelPropertyFileValueInstanceString, camelPropertyKeyInstance, textDocumentItem);
 	}
 	
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
-		if (position.getCharacter() <= camelPropertyFileKeyInstance.getEndposition()) {
-			return camelPropertyFileKeyInstance.getCompletions(position);
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		if (position.getCharacter() <= camelPropertyKeyInstance.getEndposition()) {
+			return camelPropertyKeyInstance.getCompletions(position, camelCatalog);
 		} else {
-			return camelPropertyFileValueInstance.getCompletions(position);
+			return camelPropertyValueInstance.getCompletions(position, camelCatalog);
 		}
 	}
 	
-	CamelPropertyFileKeyInstance getCamelPropertyFileKeyInstance() {
-		return camelPropertyFileKeyInstance;
+	CamelPropertyKeyInstance getCamelPropertyKeyInstance() {
+		return camelPropertyKeyInstance;
 	}
 
-	CamelPropertyFileValueInstance getCamelPropertyFileValueInstance() {
-		return camelPropertyFileValueInstance;
+	CamelPropertyValueInstance getCamelPropertyValueInstance() {
+		return camelPropertyValueInstance;
 	}
 
 	public int getLine() {
-		return lineNumber;
+		return startPosition.getLine();
 	}
 
 	@Override
 	public int getStartPositionInLine() {
-		return 0;
+		return startPosition.getCharacter();
 	}
 
 	@Override
 	public int getEndPositionInLine() {
-		return line.length();
+		return getStartPositionInLine() + line.length();
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -33,32 +33,34 @@ import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
  * it is used to represents "camel.component.timer.delay"
  * 
  */
-public class CamelPropertyFileKeyInstance implements ILineRangeDefineable {
+public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 	
 	private static final String CAMEL_KEY_PREFIX = "camel.";
 	static final String CAMEL_COMPONENT_KEY_PREFIX = "camel.component.";
 	
-	private String camelPropertyFileKey;
-	private CamelComponentPropertyFilekey camelComponentPropertyFilekey;
-	private CamelPropertyFileEntryInstance camelPropertyFileEntryInstance;
+	private String camelPropertyKey;
+	private CamelComponentPropertyKey camelComponentPropertyKey;
+	private CamelPropertyEntryInstance camelPropertyEntryInstance;
 
-	public CamelPropertyFileKeyInstance(CompletableFuture<CamelCatalog> camelCatalog, String camelPropertyFileKey, CamelPropertyFileEntryInstance camelPropertyFileEntryInstance) {
-		this.camelPropertyFileKey = camelPropertyFileKey;
-		this.camelPropertyFileEntryInstance = camelPropertyFileEntryInstance;
+	public CamelPropertyKeyInstance(String camelPropertyFileKey, CamelPropertyEntryInstance camelPropertyEntryInstance) {
+		this.camelPropertyKey = camelPropertyFileKey;
+		this.camelPropertyEntryInstance = camelPropertyEntryInstance;
 		if (camelPropertyFileKey.startsWith(CAMEL_COMPONENT_KEY_PREFIX)) {
-			camelComponentPropertyFilekey = new CamelComponentPropertyFilekey(camelCatalog, camelPropertyFileKey.substring(CAMEL_COMPONENT_KEY_PREFIX.length()), this);
+			camelComponentPropertyKey = new CamelComponentPropertyKey(camelPropertyFileKey.substring(CAMEL_COMPONENT_KEY_PREFIX.length()), this);
 		}
 	}
 
 	public int getEndposition() {
-		return camelPropertyFileKey.length();
+		return camelPropertyEntryInstance.getStartPositionInLine() + camelPropertyKey.length();
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
-		if (CAMEL_KEY_PREFIX.length() == position.getCharacter() && camelPropertyFileKey.startsWith(CAMEL_KEY_PREFIX)) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		if(position.getCharacter() == getStartPositionInLine()) {
+			return CompletableFuture.completedFuture(Collections.singletonList(new CompletionItem(CAMEL_KEY_PREFIX)));
+		} else if (getStartPositionInLine() + CAMEL_KEY_PREFIX.length() == position.getCharacter() && camelPropertyKey.startsWith(CAMEL_KEY_PREFIX)) {
 			return getTopLevelCamelCompletion();
-		} else if(camelComponentPropertyFilekey != null && camelComponentPropertyFilekey.isInRange(position.getCharacter())) {
-			return camelComponentPropertyFilekey.getCompletions(position);
+		} else if(camelComponentPropertyKey != null && camelComponentPropertyKey.isInRange(position.getCharacter())) {
+			return camelComponentPropertyKey.getCompletions(position, camelCatalog);
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
@@ -73,30 +75,30 @@ public class CamelPropertyFileKeyInstance implements ILineRangeDefineable {
 		return CompletableFuture.completedFuture(completions);
 	}
 
-	public String getCamelPropertyFileKey() {
-		return camelPropertyFileKey;
+	public String getCamelPropertyKey() {
+		return camelPropertyKey;
 	}
 
-	public CamelComponentPropertyFilekey getCamelComponentPropertyFilekey() {
-		return camelComponentPropertyFilekey;
+	public CamelComponentPropertyKey getCamelComponentPropertyKey() {
+		return camelComponentPropertyKey;
 	}
 
-	public CamelPropertyFileEntryInstance getCamelPropertyFileEntryInstance() {
-		return camelPropertyFileEntryInstance;
+	public CamelPropertyEntryInstance getCamelPropertyEntryInstance() {
+		return camelPropertyEntryInstance;
 	}
 
 	public int getLine() {
-		return camelPropertyFileEntryInstance.getLine();
+		return camelPropertyEntryInstance.getLine();
 	}
 
 	@Override
 	public int getStartPositionInLine() {
-		return 0;
+		return camelPropertyEntryInstance.getStartPositionInLine();
 	}
 
 	@Override
 	public int getEndPositionInLine() {
-		return camelPropertyFileKey.length();
+		return camelPropertyKey.length();
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -34,35 +34,33 @@ import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
  * For instance, with "camel.component.timer.delay=1000",
  * it is used to represents "1000"
  */
-public class CamelPropertyFileValueInstance implements ILineRangeDefineable {
+public class CamelPropertyValueInstance implements ILineRangeDefineable {
 
-	private CompletableFuture<CamelCatalog> camelCatalog;
-	private String camelPropertyFileValue;
-	private CamelPropertyFileKeyInstance key;
+	private String camelPropertyValue;
+	private CamelPropertyKeyInstance key;
 
 	private TextDocumentItem textDocumentItem;
 
-	public CamelPropertyFileValueInstance(CompletableFuture<CamelCatalog> camelCatalog, String camelPropertyFileValue, CamelPropertyFileKeyInstance key, TextDocumentItem textDocumentItem) {
-		this.camelCatalog = camelCatalog;
-		this.camelPropertyFileValue = camelPropertyFileValue;
+	public CamelPropertyValueInstance(String camelPropertyFileValue, CamelPropertyKeyInstance key, TextDocumentItem textDocumentItem) {
+		this.camelPropertyValue = camelPropertyFileValue;
 		this.key = key;
 		this.textDocumentItem = textDocumentItem;
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
-		if (new CamelKafkaUtil().isCamelURIForKafka(key.getCamelPropertyFileKey())) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		if (new CamelKafkaUtil().isCamelURIForKafka(key.getCamelPropertyKey())) {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position);
 		} else {
-			String startFilter = camelPropertyFileValue.substring(0, position.getCharacter() - key.getEndposition() -1);
+			String startFilter = camelPropertyValue.substring(0, position.getCharacter() - key.getEndposition() -1);
 			return camelCatalog.thenApply(new CamelComponentOptionValuesCompletionsFuture(this, startFilter));
 		}
 	}
 
 	public String getCamelPropertyFileValue() {
-		return camelPropertyFileValue;
+		return camelPropertyValue;
 	}
 	
-	public CamelPropertyFileKeyInstance getKey() {
+	public CamelPropertyKeyInstance getKey() {
 		return key;
 	}
 
@@ -78,7 +76,7 @@ public class CamelPropertyFileValueInstance implements ILineRangeDefineable {
 
 	@Override
 	public int getEndPositionInLine() {
-		return getStartPositionInLine() + (camelPropertyFileValue != null ? camelPropertyFileValue.length() : 0);
+		return getStartPositionInLine() + (camelPropertyValue != null ? camelPropertyValue.length() : 0);
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
@@ -50,11 +50,6 @@ public class CamelKModelineDependencyOption implements ICamelKModelineOptionValu
 	public String getValueAsString() {
 		return value;
 	}
-
-	@Override
-	public boolean isInRange(int position) {
-		return startPosition <= position && position <= getEndPositionInLine();
-	}
 	
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(int position, CompletableFuture<CamelCatalog> camelCatalog) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
@@ -49,6 +49,8 @@ public class CamelKModelineOption implements ILineRangeDefineable {
 				return new CamelKModelineTraitOption(value, startPosition);
 			} else if(CamelKModelineOptionNames.OPTION_NAME_DEPENDENCY.equals(optionName)) {
 				return new CamelKModelineDependencyOption(value, startPosition);
+			} else if(CamelKModelineOptionNames.OPTION_NAME_PROPERTY.equals(optionName)) {
+				return new CamelKModelinePropertyOption(value, startPosition);
 			} else {
 				return new GenericCamelKModelineOptionValue(value, startPosition);
 			}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
@@ -16,34 +16,45 @@
  */
 package com.github.cameltooling.lsp.internal.modelinemodel;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.Position;
 
-import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyEntryInstance;
 
-public interface ICamelKModelineOptionValue extends ILineRangeDefineable {
+public class CamelKModelinePropertyOption implements ICamelKModelineOptionValue {
 
-	public default int getLine() {
-		return 0;
+	private CamelPropertyEntryInstance value;
+	private int startPosition;
+	private String fullStringValue;
+
+	public CamelKModelinePropertyOption(String value, int startPosition) {
+		this.value = new CamelPropertyEntryInstance(value, new Position(0, startPosition), null);
+		this.fullStringValue = value;
+		this.startPosition = startPosition;
 	}
 
-	public String getValueAsString();
-
-	public default CompletableFuture<List<CompletionItem>> getCompletions(int position, CompletableFuture<CamelCatalog> camelCatalog) {
-		return CompletableFuture.completedFuture(Collections.emptyList());
+	@Override
+	public int getStartPositionInLine() {
+		return startPosition;
 	}
 
-	public default boolean isInRange(int position) {
-		return getStartPositionInLine() <= position && position <= getEndPositionInLine();
+	@Override
+	public int getEndPositionInLine() {
+		return value.getEndPositionInLine();
 	}
 
-	public default CompletableFuture<Hover> getHover(int characterPosition) {
-		return CompletableFuture.completedFuture(null);
+	@Override
+	public String getValueAsString() {
+		return fullStringValue;
+	}
+	
+	@Override
+	public CompletableFuture<List<CompletionItem>> getCompletions(int positionInLine, CompletableFuture<CamelCatalog> camelCatalog) {
+		return value.getCompletions(new Position(0, positionInLine), camelCatalog);
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOption.java
@@ -64,11 +64,6 @@ public class CamelKModelineTraitOption implements ICamelKModelineOptionValue {
 	public String getValueAsString() {
 		return optionValue;
 	}
-
-	@Override
-	public boolean isInRange(int position) {
-		return startPosition <= position && position <= endPosition;
-	}
 	
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(int position, CompletableFuture<CamelCatalog> camelCatalog) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/GenericCamelKModelineOptionValue.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/GenericCamelKModelineOptionValue.java
@@ -39,10 +39,5 @@ public class GenericCamelKModelineOptionValue implements ICamelKModelineOptionVa
 	public String getValueAsString() {
 		return value;
 	}
-	
-	@Override
-	public boolean isInRange(int position) {
-		return startPosition <= position && position <= getEndPositionInLine();
-	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
@@ -43,15 +43,25 @@ class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerT
 	}
 	
 	@Test
-	void testProvideNoCompletion() throws Exception {
+	void testProvideCompletionOnSecondLine() throws Exception {
+		String fileName = "a.properties";
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(fileName, new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "whateverfirstline\ncamel."));
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(1, 6), fileName);
+		
+		assertThat(completions.get().getLeft()).hasSize(4);
+	}
+	
+	@Test
+	void testProvideCompletionForCamel() throws Exception {
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 0));
 		
-		assertThat(completions.get().getLeft()).isEmpty();
+		assertThat(completions.get().getLeft().get(0).getLabel()).isEqualTo("camel.");
 	}
 	
 	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position) throws URISyntaxException, InterruptedException, ExecutionException {
 		String fileName = "a.properties";
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer(fileName, new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel."));
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(fileName, new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel.\ncamel."));
 		return getCompletionFor(camelLanguageServer, position, fileName);
 	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelComponentPropertyTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelComponentPropertyTest.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.modeline;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class CamelKModelineCamelComponentPropertyTest extends AbstractCamelLanguageServerTest {
+
+	@Test
+	void testProvideCompletionForComponentNames() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: property=camel.component.");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 37));
+		
+		List<CompletionItem> completionItems = completions.get().getLeft();
+		assertThat(completionItems).hasSizeGreaterThan(50);
+		CompletionItem timerCompletionItem = completionItems.stream().filter(completionItem -> "timer".equals(completionItem.getLabel())).findFirst().get();
+		assertThat(timerCompletionItem.getDocumentation().getLeft()).isEqualTo("Generate messages in specified intervals using java.util.Timer.");
+	}
+	
+	@Test
+	void testProvideCompletionForComponentAttribute() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: property=camel.component.timer.");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 43));
+		
+		List<CompletionItem> completionItems = completions.get().getLeft();
+		assertThat(completionItems).hasSize(2);
+		CompletionItem timerCompletionItem = completionItems.stream().filter(completionItem -> "bridgeErrorHandler".equals(completionItem.getLabel())).findFirst().get();
+		assertThat(timerCompletionItem.getDocumentation().getLeft()).isEqualTo("Allows for bridging the consumer to the Camel routing Error Handler, which mean any exceptions occurred while the consumer is trying to pickup incoming messages, or the likes, will now be processed as a message and handled by the routing Error Handler. By default the consumer will use the org.apache.camel.spi.ExceptionHandler to deal with exceptions, that will be logged at WARN or ERROR level and ignored.");
+	}
+		
+	@Test
+	void testProvideCompletionForComponentSuffix() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: property=");
+		
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 21));
+		
+		List<CompletionItem> completionItems = completions.get().getLeft();
+		Optional<CompletionItem> timerCompletionItem = completionItems.stream().filter(completionItem -> "camel.".equals(completionItem.getLabel())).findFirst();
+		assertThat(timerCompletionItem).isNotEmpty();
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstanceTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstanceTest.java
@@ -18,44 +18,42 @@ package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.CompletableFuture;
-
-import org.apache.camel.catalog.CamelCatalog;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.junit.jupiter.api.Test;
 
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
-class CamelPropertyFileEntryInstanceTest {
+class CamelPropertyEntryInstanceTest {
 
 	@Test
 	void testEmpty() throws Exception {
-		CamelPropertyFileEntryInstance cpfei = createModel("");
-		assertThat(cpfei.getCamelPropertyFileKeyInstance().getCamelPropertyFileKey()).isEmpty();
+		CamelPropertyEntryInstance cpfei = createModel("");
+		assertThat(cpfei.getCamelPropertyKeyInstance().getCamelPropertyKey()).isEmpty();
 	}
 	
 	@Test
 	void testKey() throws Exception {
-		CamelPropertyFileEntryInstance cpfei = createModel("camel.akey=avalue");
-		assertThat(cpfei.getCamelPropertyFileKeyInstance().getCamelPropertyFileKey()).isEqualTo("camel.akey");
+		CamelPropertyEntryInstance cpfei = createModel("camel.akey=avalue");
+		assertThat(cpfei.getCamelPropertyKeyInstance().getCamelPropertyKey()).isEqualTo("camel.akey");
 	}
 	
 	@Test
 	void testComponent() throws Exception {
-		CamelPropertyFileEntryInstance cpfei = createModel("camel.component.acomponentid.akey=avalue");
-		assertThat(cpfei.getCamelPropertyFileKeyInstance().getCamelPropertyFileKey()).isEqualTo("camel.component.acomponentid.akey");
-		assertThat(cpfei.getCamelPropertyFileKeyInstance().getCamelComponentPropertyFilekey().getComponentId()).isEqualTo("acomponentid");
-		assertThat(cpfei.getCamelPropertyFileKeyInstance().getCamelComponentPropertyFilekey().getComponentProperty()).isEqualTo("akey");
+		CamelPropertyEntryInstance cpfei = createModel("camel.component.acomponentid.akey=avalue");
+		assertThat(cpfei.getCamelPropertyKeyInstance().getCamelPropertyKey()).isEqualTo("camel.component.acomponentid.akey");
+		assertThat(cpfei.getCamelPropertyKeyInstance().getCamelComponentPropertyKey().getComponentId()).isEqualTo("acomponentid");
+		assertThat(cpfei.getCamelPropertyKeyInstance().getCamelComponentPropertyKey().getComponentProperty()).isEqualTo("akey");
 	}
 	
 	@Test
 	void testValue() throws Exception {
-		CamelPropertyFileEntryInstance cpfei = createModel("camel.akey=avalue");
-		assertThat(cpfei.getCamelPropertyFileValueInstance().getCamelPropertyFileValue()).isEqualTo("avalue");
+		CamelPropertyEntryInstance cpfei = createModel("camel.akey=avalue");
+		assertThat(cpfei.getCamelPropertyValueInstance().getCamelPropertyFileValue()).isEqualTo("avalue");
 	}
 
-	private CamelPropertyFileEntryInstance createModel(String lineToTest) {
-		return new CamelPropertyFileEntryInstance(CompletableFuture.completedFuture((CamelCatalog)null), lineToTest, 0, createTextDocumentItem(lineToTest));
+	private CamelPropertyEntryInstance createModel(String lineToTest) {
+		return new CamelPropertyEntryInstance(lineToTest, new Position(0,0), createTextDocumentItem(lineToTest));
 	}
 
 	private TextDocumentItem createTextDocumentItem(String value) {


### PR DESCRIPTION
it is reusing the work initially done for application.properties and
Camel Kafka properties files

![completionCamelComponentProertyInModeline](https://user-images.githubusercontent.com/1105127/86110839-56c0fa80-bac6-11ea-8e9e-ebff2de98883.gif)
