### PR TITLE
FUSETOOLS2-530 - Provide hover for Camel Component Property in Modeline

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -77,7 +77,7 @@ import com.github.cameltooling.lsp.internal.definition.DefinitionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticRunner;
 import com.github.cameltooling.lsp.internal.documentsymbol.DocumentSymbolProcessor;
 import com.github.cameltooling.lsp.internal.hover.CamelKModelineHoverProcessor;
-import com.github.cameltooling.lsp.internal.hover.HoverProcessor;
+import com.github.cameltooling.lsp.internal.hover.CamelURIHoverProcessor;
 import com.github.cameltooling.lsp.internal.parser.CamelKModelineParser;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 import com.github.cameltooling.lsp.internal.references.ReferencesProcessor;
@@ -153,7 +153,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 		if(isOnCamelKModeline(hoverParams.getPosition().getLine(), textDocumentItem)) {
 			return new CamelKModelineHoverProcessor(textDocumentItem).getHover(hoverParams.getPosition().getCharacter(), getCamelCatalog());
 		} else {
-			return new HoverProcessor(textDocumentItem, getCamelCatalog()).getHover(hoverParams.getPosition());
+			return new CamelURIHoverProcessor(textDocumentItem, getCamelCatalog()).getHover(hoverParams.getPosition());
 		}
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverFuture.java
@@ -27,11 +27,11 @@ import com.github.cameltooling.lsp.internal.instancemodel.CamelUriElementInstanc
 import com.github.cameltooling.model.ComponentModel;
 import com.github.cameltooling.model.util.ModelHelper;
 
-public class HoverFuture implements Function<CamelCatalog, Hover> {
+public class CamelURIHoverFuture implements Function<CamelCatalog, Hover> {
 	
 	private CamelUriElementInstance uriElement;
 	
-	public HoverFuture(CamelUriElementInstance uriElement) {
+	public CamelURIHoverFuture(CamelUriElementInstance uriElement) {
 		this.uriElement = uriElement;
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverProcessor.java
@@ -31,13 +31,13 @@ import com.github.cameltooling.lsp.internal.parser.ParserFileHelper;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperFactory;
 import com.github.cameltooling.model.util.StringUtils;
 
-public class HoverProcessor {
+public class CamelURIHoverProcessor {
 	
-	private static final Logger LOGGER = LoggerFactory.getLogger(HoverProcessor.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(CamelURIHoverProcessor.class);
 	private TextDocumentItem textDocumentItem;
 	private CompletableFuture<CamelCatalog> camelCatalog;
 
-	public HoverProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog) {
+	public CamelURIHoverProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog) {
 		this.textDocumentItem = textDocumentItem;
 		this.camelCatalog = camelCatalog;
 	}
@@ -52,7 +52,7 @@ public class HoverProcessor {
 					CamelURIInstance camelURIInstance = parserFileHelper.createCamelURIInstance(textDocumentItem, position, camelComponentUri);
 					int positionInCamelUri = parserFileHelper.getPositionInCamelURI(textDocumentItem, position);
 					CamelUriElementInstance elem = camelURIInstance.getSpecificElement(positionInCamelUri);
-					return camelCatalog.thenApply(new HoverFuture(elem));
+					return camelCatalog.thenApply(new CamelURIHoverFuture(elem));
 				}
 			}
 		} catch (Exception e) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
@@ -98,6 +99,17 @@ public class CamelComponentPropertyKey implements ILineRangeDefineable {
 
 	public CamelPropertyKeyInstance getCamelPropertyKeyInstance() {
 		return camelPropertyKeyInstance;
+	}
+
+	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		int characterPosition = position.getCharacter();
+		if(isInside(componentName, characterPosition)) {
+			return componentName.getHover(camelCatalog);
+		} else if(isInside(componentProperty, characterPosition)){
+			return componentProperty.getHover(camelCatalog);
+		} else {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
@@ -82,5 +83,13 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 	@Override
 	public int getEndPositionInLine() {
 		return getStartPositionInLine() + line.length();
+	}
+
+	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		if (position.getCharacter() <= camelPropertyKeyInstance.getEndposition()) {
+			return camelPropertyKeyInstance.getHover(position, camelCatalog);
+		} else {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
@@ -99,6 +100,13 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 	@Override
 	public int getEndPositionInLine() {
 		return camelPropertyKey.length();
+	}
+
+	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		if(camelComponentPropertyKey != null && camelComponentPropertyKey.isInRange(position.getCharacter())) {
+			return camelComponentPropertyKey.getHover(position, camelCatalog);
+		}
+		return CompletableFuture.completedFuture(null);
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 
 import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyEntryInstance;
@@ -55,6 +56,11 @@ public class CamelKModelinePropertyOption implements ICamelKModelineOptionValue 
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(int positionInLine, CompletableFuture<CamelCatalog> camelCatalog) {
 		return value.getCompletions(new Position(0, positionInLine), camelCatalog);
+	}
+	
+	@Override
+	public CompletableFuture<Hover> getHover(int characterPosition, CompletableFuture<CamelCatalog> camelCatalog) {
+		return value.getHover(new Position(0, characterPosition), camelCatalog);
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineComponentPropertyHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineComponentPropertyHoverTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.hover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class CamelKModelineComponentPropertyHoverTest extends AbstractCamelLanguageServerTest {
+
+	@Test
+	void testProvideDocumentationOnHoverOfComponentName() throws Exception {
+		testProvideDocumentationOnHover("// camel-k: property=camel.component.timer.basicPropertyBinding=true", 38, "Generate messages in specified intervals using java.util.Timer.");
+	}
+	
+	@Test
+	void testProvideDocumentationOnHoverOfComponentAttribute() throws Exception {
+		testProvideDocumentationOnHover("// camel-k: property=camel.component.timer.basicPropertyBinding=true", 50, "Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities");
+	}
+	
+	@Test
+	void testNoErrorWithPartialNoComponentNameSpecified() throws Exception {
+		testProvideDocumentationOnHover("// camel-k: property=camel.component.timer", 38, "Generate messages in specified intervals using java.util.Timer.");
+	}
+	
+	@Test
+	void testNoErrorWithUnknownComponent() throws Exception {
+		testProvideDocumentationOnHover("// camel-k: property=camel.component.unknown", 38, null);
+	}
+	
+	@Test
+	void testNoErrorWithUnknownParameter() throws Exception {
+		testProvideDocumentationOnHover("// camel-k: property=camel.component.timer.unknown", 50, null);
+	}
+	
+	private void testProvideDocumentationOnHover(String modeline, int position, String expectedDescription) throws URISyntaxException, InterruptedException, ExecutionException {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(modeline, ".java");
+		
+		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".java"), new Position(0, position));
+		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
+		
+		if (expectedDescription != null) {
+			assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo(expectedDescription);
+		} else {
+			assertThat(hover.get()).isNull();
+		}
+	}
+}


### PR DESCRIPTION
![descriptionOnHoverForCamelComponentProperty](https://user-images.githubusercontent.com/1105127/86342846-725c0a80-bc58-11ea-8f34-166dc759250c.gif)
