### PR TITLE
FUSETOOLS2-547 - add new top-level, named as group, for Camel component

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -16,10 +16,11 @@
  */
 package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
@@ -37,6 +38,8 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 	
 	private static final String CAMEL_KEY_PREFIX = "camel.";
 	static final String CAMEL_COMPONENT_KEY_PREFIX = "camel.component.";
+	private static final String[] ALL_GROUPS = new String[] {"main", "faulttolerance", "hystrix", "resilience4j", "rest", "health", "lra", "threadpool"};
+	private static final List<CompletionItem> ALL_GROUP_COMPLETIONS = Arrays.stream(ALL_GROUPS).map(CompletionItem::new).collect(Collectors.toList());
 	
 	private String camelPropertyKey;
 	private CamelComponentPropertyKey camelComponentPropertyKey;
@@ -67,12 +70,7 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 	
 
 	protected CompletableFuture<List<CompletionItem>> getTopLevelCamelCompletion() {
-		List<CompletionItem> completions = new ArrayList<>();
-		completions.add(new CompletionItem("component"));
-		completions.add(new CompletionItem("main"));
-		completions.add(new CompletionItem("rest"));
-		completions.add(new CompletionItem("hystrix"));
-		return CompletableFuture.completedFuture(completions);
+		return CompletableFuture.completedFuture(ALL_GROUP_COMPLETIONS);
 	}
 
 	public String getCamelPropertyKey() {

--- a/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
@@ -389,7 +389,7 @@ class CamelLanguageServerTest extends AbstractCamelLanguageServerTest {
 		try (FileInputStream fis = new FileInputStream(f)) {
 			CamelLanguageServer cls = initializeLanguageServerWithFileName(fis, "application.properties");
 			CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(cls, new Position(2, 6), "application.properties");
-			assertThat(completions.get().getLeft()).hasSize(4);
+			assertThat(completions.get().getLeft()).hasSize(8);
 		}
 	}
 	

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
@@ -39,7 +39,7 @@ class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerT
 	void testProvideCompletion() throws Exception {
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 6));
 		
-		assertThat(completions.get().getLeft()).hasSize(4);
+		assertThat(completions.get().getLeft()).hasSize(8);
 	}
 	
 	@Test
@@ -49,7 +49,7 @@ class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerT
 		
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(1, 6), fileName);
 		
-		assertThat(completions.get().getLeft()).hasSize(4);
+		assertThat(completions.get().getLeft()).hasSize(8);
 	}
 	
 	@Test


### PR DESCRIPTION
properties

![AddNewTopLevelApplicationproperties](https://user-images.githubusercontent.com/1105127/86360001-0b4b4f80-bc72-11ea-8cfb-88a79ec3f227.gif)


