### PR TITLE
Fusetools2 548 use catalog file for application properties

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractCamelLanguageServerTest {
 	protected static final String DUMMY_URI = "dummyUri";
 	private String extensionUsed;
 	protected PublishDiagnosticsParams lastPublishedDiagnostics;
-	private CamelLanguageServer camelLanguageServer;
+	protected CamelLanguageServer camelLanguageServer;
 
 	public AbstractCamelLanguageServerTest() {
 		super();

--- a/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.camel.tooling.model.MainModel;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
 import org.eclipse.lsp4j.CompletionItem;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
+import com.google.gson.Gson;
 
 
 class CamelLanguageServerTest extends AbstractCamelLanguageServerTest {
@@ -389,7 +391,9 @@ class CamelLanguageServerTest extends AbstractCamelLanguageServerTest {
 		try (FileInputStream fis = new FileInputStream(f)) {
 			CamelLanguageServer cls = initializeLanguageServerWithFileName(fis, "application.properties");
 			CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(cls, new Position(2, 6), "application.properties");
-			assertThat(completions.get().getLeft()).hasSize(9);
+			String mainJsonSchema = cls.getTextDocumentService().getCamelCatalog().get().mainJsonSchema();
+			MainModel mainModel = new Gson().fromJson(mainJsonSchema, MainModel.class);
+			assertThat(completions.get().getLeft()).hasSize(mainModel.getGroups().size() + 1);
 		}
 	}
 	

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.camel.tooling.model.MainModel;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Position;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+import com.google.gson.Gson;
 
 class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerTest {
 	
@@ -39,7 +41,9 @@ class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerT
 	void testProvideCompletion() throws Exception {
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 6));
 		
-		assertThat(completions.get().getLeft()).hasSize(9);
+		MainModel mainModel = loadMainModel(camelLanguageServer);
+		
+		assertThat(completions.get().getLeft()).hasSize(mainModel.getGroups().size() + 1);
 	}
 	
 	@Test
@@ -49,7 +53,14 @@ class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerT
 		
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(1, 6), fileName);
 		
-		assertThat(completions.get().getLeft()).hasSize(9);
+		MainModel mainModel = loadMainModel(camelLanguageServer);
+		
+		assertThat(completions.get().getLeft()).hasSize(mainModel.getGroups().size() + 1);
+	}
+
+	private MainModel loadMainModel(CamelLanguageServer camelLanguageServer) throws InterruptedException, ExecutionException {
+		String mainJsonSchema = camelLanguageServer.getTextDocumentService().getCamelCatalog().get().mainJsonSchema();
+		return new Gson().fromJson(mainJsonSchema, MainModel.class);
 	}
 	
 	@Test


### PR DESCRIPTION
based on https://github.com/camel-tooling/camel-language-server/pull/415

nota: given that 3.4.0 had regressions, the default Camel Catalog is still 3.3.0 and thus less items are provided in completion than on current master, but it is more accurate as respecting the Camel version.