### PR TITLE
Align xtend library with the one used by lsp4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>2.18.0</version>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
- version from xtend
https://github.com/eclipse/lsp4j/blob/328ce8a4c89b0cd84fb62118f459b6cf79b09e90/gradle/versions.gradle#L16
- it allows to get rid of
https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236


