### PR TITLE
FUSETOOLS2-558 - use insert and replace for Camel K modeline traits

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKTraitManager.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKTraitManager.java
@@ -29,6 +29,8 @@ import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CompletionItem;
 
 import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModelineTraitDefinition;
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModelineTraitDefinitionProperty;
 import com.google.gson.Gson;
 
 public class CamelKTraitManager {
@@ -48,18 +50,18 @@ public class CamelKTraitManager {
 		return traits;
 	}
 	
-	public static List<CompletionItem> getTraitDefinitionNameCompletionItems(String filter){
+	public static List<CompletionItem> getTraitDefinitionNameCompletionItems(String filter, CamelKModelineTraitDefinition camelKModelineTraitDefinition){
 		return getTraits().stream()
-				.map(TraitDefinition::createCompletionItem)
+				.map(traitDefinition -> traitDefinition.createCompletionItem(camelKModelineTraitDefinition))
 				.filter(FilterPredicateUtils.matchesCompletionFilter(filter))
 				.collect(Collectors.toList());
 	}
 
-	public static List<CompletionItem> getTraitPropertyNameCompletionItems(String traitDefinitionName, String filter) {
-		Optional<TraitDefinition> traitDefinition = getTrait(traitDefinitionName);
+	public static List<CompletionItem> getTraitPropertyNameCompletionItems(String filter, CamelKModelineTraitDefinitionProperty traitDefinitionProperty) {
+		Optional<TraitDefinition> traitDefinition = getTrait(traitDefinitionProperty.getTraitOption().getTraitDefinition().getValueAsString());
 		if(traitDefinition.isPresent()) {
 			return traitDefinition.get().getProperties().stream()
-					.map(TraitProperty::createCompletionItem)
+					.map(traitProperty -> traitProperty.createCompletionItem(traitDefinitionProperty))
 					.filter(FilterPredicateUtils.matchesCompletionFilter(filter))
 					.collect(Collectors.toList());
 		}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/TraitDefinition.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/TraitDefinition.java
@@ -20,6 +20,10 @@ import java.util.List;
 
 import org.eclipse.lsp4j.CompletionItem;
 
+import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModelineTraitDefinition;
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModelineTraitOption;
+
 public class TraitDefinition {
 	
 	private String name;
@@ -28,9 +32,15 @@ public class TraitDefinition {
 	private List<String> profiles;
 	private List<TraitProperty> properties;
 	
-	public CompletionItem createCompletionItem() {
+	public CompletionItem createCompletionItem(CamelKModelineTraitDefinition traitDefinition) {
 		CompletionItem completionItem = new CompletionItem(name);
 		completionItem.setDocumentation(description);
+		if(hasAPropertySpecified(traitDefinition.getTraitOption())) {
+			completionItem.setInsertText(name);
+		} else {
+			completionItem.setInsertText(name + ".");
+		}
+		CompletionResolverUtils.applyTextEditToCompletionItem(traitDefinition, completionItem);
 		return completionItem;
 	}
 
@@ -52,6 +62,10 @@ public class TraitDefinition {
 
 	public List<String> getProfiles() {
 		return profiles;
+	}
+	
+	private boolean hasAPropertySpecified(CamelKModelineTraitOption traitOption) {
+		return traitOption.getTraitProperty() != null;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/TraitProperty.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/TraitProperty.java
@@ -18,6 +18,10 @@ package com.github.cameltooling.lsp.internal.completion.modeline;
 
 import org.eclipse.lsp4j.CompletionItem;
 
+import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModelineTraitDefinitionProperty;
+import com.github.cameltooling.lsp.internal.modelinemodel.CamelKModelineTraitOption;
+
 public class TraitProperty {
 
 	private String name;
@@ -25,17 +29,30 @@ public class TraitProperty {
 	private String type;
 	private Object defaultValue;
 	
-	public CompletionItem createCompletionItem() {
+	public CompletionItem createCompletionItem(CamelKModelineTraitDefinitionProperty camelKModelineTraitDefinitionProperty) {
 		CompletionItem completionItem = new CompletionItem(name);
 		completionItem.setDocumentation(description);
-		if (defaultValue != null) {
-			if("int".equals(type) && defaultValue instanceof Double) {
-				completionItem.setInsertText(name+"="+((Double)defaultValue).intValue());
+		CamelKModelineTraitOption traitOption = camelKModelineTraitDefinitionProperty.getTraitOption();
+		if (hasAValueSpecified(traitOption)) {
+			completionItem.setInsertText(name);
+		} else {
+			String prefix = name + "=";
+			if (defaultValue != null) {
+				if ("int".equals(type) && defaultValue instanceof Double) {
+					completionItem.setInsertText(prefix + ((Double) defaultValue).intValue());
+				} else {
+					completionItem.setInsertText(prefix + defaultValue);
+				}
 			} else {
-				completionItem.setInsertText(name+"="+defaultValue);
+				completionItem.setInsertText(prefix);
 			}
 		}
+		CompletionResolverUtils.applyTextEditToCompletionItem(camelKModelineTraitDefinitionProperty, completionItem);
 		return completionItem;
+	}
+
+	private boolean hasAValueSpecified(CamelKModelineTraitOption traitOption) {
+		return traitOption.getValueAsString().contains("=");
 	}
 
 	public String getDescription() {

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKModelineDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKModelineDiagnosticService.java
@@ -44,12 +44,12 @@ public class CamelKModelineDiagnosticService {
 		for (CamelKModelineTraitOption traitOption : traitOptions) {
 			for (CamelKModelineTraitOption traitOption2 : traitOptions) {
 				if(!traitOption.equals(traitOption2)) {
-				String definitionName = traitOption.getTraitDefinitionName();
-				String propertyName = traitOption.getTraitPropertyName();
+				String definitionName = traitOption.getTraitDefinition().getValueAsString();
+				String propertyName = traitOption.getTraitProperty().getValueAsString();
 				if(definitionName != null
 					&& propertyName != null
-					&& definitionName.equals(traitOption2.getTraitDefinitionName())
-					&& propertyName.equals(traitOption2.getTraitPropertyName())) {
+					&& definitionName.equals(traitOption2.getTraitDefinition().getValueAsString())
+					&& propertyName.equals(traitOption2.getTraitProperty().getValueAsString())) {
 						Range range = new Range(new Position(0,traitOption2.getStartPositionInLine()), new Position(0,traitOption2.getEndPositionInLine()));
 						diagnostics.add(new Diagnostic(range, "More than one trait defines the same property: " + definitionName + "." + propertyName));
 					}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinition.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinition.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.modelinemodel;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.github.cameltooling.lsp.internal.completion.modeline.CamelKTraitManager;
+
+public class CamelKModelineTraitDefinition implements ICamelKModelineOptionValue {
+
+	private String traitDefinitionName;
+	private int startPosition;
+	private CamelKModelineTraitOption traitOption;
+
+	public CamelKModelineTraitDefinition(CamelKModelineTraitOption traitOption, String traitDefinitionName, int startPosition) {
+		this.traitOption = traitOption;
+		this.traitDefinitionName = traitDefinitionName;
+		this.startPosition = startPosition;
+	}
+
+	@Override
+	public int getStartPositionInLine() {
+		return startPosition;
+	}
+
+	@Override
+	public int getEndPositionInLine() {
+		return getStartPositionInLine() + traitDefinitionName.length();
+	}
+
+	@Override
+	public String getValueAsString() {
+		return traitDefinitionName;
+	}
+	
+	@Override
+	public CompletableFuture<List<CompletionItem>> getCompletions(int position, CompletableFuture<CamelCatalog> camelCatalog) {
+		String filter = retrieveTraitDefinitionPartBefore(position);
+		return CompletableFuture.completedFuture(CamelKTraitManager.getTraitDefinitionNameCompletionItems(filter, this));
+	}
+	
+	private String retrieveTraitDefinitionPartBefore(int position) {
+		return traitDefinitionName.substring(0, position - getStartPositionInLine());
+	}
+	
+	@Override
+	public CompletableFuture<Hover> getHover(int characterPosition, CompletableFuture<CamelCatalog> camelCatalog) {
+		String description = CamelKTraitManager.getDescription(traitDefinitionName);
+		if (description != null) {
+			Hover hover = new Hover();
+			hover.setContents(Collections.singletonList((Either.forLeft(description))));
+			return CompletableFuture.completedFuture(hover);
+		}
+		return ICamelKModelineOptionValue.super.getHover(characterPosition, camelCatalog);
+	}
+
+	public CamelKModelineTraitOption getTraitOption() {
+		return traitOption;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinitionProperty.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinitionProperty.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.modelinemodel;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.camel.catalog.CamelCatalog;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.github.cameltooling.lsp.internal.completion.modeline.CamelKTraitManager;
+
+public class CamelKModelineTraitDefinitionProperty implements ICamelKModelineOptionValue {
+
+	private String traitDefinitionProperty;
+	private int startPosition;
+	private CamelKModelineTraitOption traitOption;
+
+	public CamelKModelineTraitDefinitionProperty(CamelKModelineTraitOption camelKModelineTraitOption, String traitDefinitionProperty, int startPosition) {
+		this.traitOption = camelKModelineTraitOption;
+		this.traitDefinitionProperty = traitDefinitionProperty;
+		this.startPosition = startPosition;
+	}
+
+	@Override
+	public int getStartPositionInLine() {
+		return startPosition;
+	}
+
+	@Override
+	public int getEndPositionInLine() {
+		return getStartPositionInLine() + traitDefinitionProperty.length();
+	}
+
+	@Override
+	public String getValueAsString() {
+		return traitDefinitionProperty;
+	}
+	
+	@Override
+	public CompletableFuture<List<CompletionItem>> getCompletions(int position, CompletableFuture<CamelCatalog> camelCatalog) {
+		String filter = retrieveTraitPropertyPartBefore(position);
+		return CompletableFuture.completedFuture(CamelKTraitManager.getTraitPropertyNameCompletionItems(filter, this));
+	}
+	
+	private String retrieveTraitPropertyPartBefore(int position) {
+		return traitDefinitionProperty.substring(0, position - getStartPositionInLine());
+	}
+	
+	@Override
+	public CompletableFuture<Hover> getHover(int characterPosition, CompletableFuture<CamelCatalog> camelCatalog) {
+		String description = CamelKTraitManager.getPropertyDescription(getTraitOption().getTraitDefinition().getValueAsString(), traitDefinitionProperty);
+		if (description != null) {
+			Hover hover = new Hover();
+			hover.setContents(Collections.singletonList((Either.forLeft(description))));
+			return CompletableFuture.completedFuture(hover);
+		}
+		return ICamelKModelineOptionValue.super.getHover(characterPosition, camelCatalog);
+	}
+
+	public CamelKModelineTraitOption getTraitOption() {
+		return traitOption;
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOptionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOptionTest.java
@@ -27,25 +27,25 @@ class CamelKModelineTraitOptionTest {
 	@Test
 	void checkDefinitionName() throws Exception {
 		CamelKModelineTraitOption traitOption = retrieveFirstTrait("// camel-k: trait=quarkus.enabled=true");
-		assertThat(traitOption.getTraitDefinitionName()).isEqualTo("quarkus");
+		assertThat(traitOption.getTraitDefinition().getValueAsString()).isEqualTo("quarkus");
 	}
 	
 	@Test
 	void checkDefinitionNameWithIncompleteValues() throws Exception {
 		CamelKModelineTraitOption traitOption = retrieveFirstTrait("// camel-k: trait=quarkus.");
-		assertThat(traitOption.getTraitDefinitionName()).isEqualTo("quarkus");
+		assertThat(traitOption.getTraitDefinition().getValueAsString()).isEqualTo("quarkus");
 	}
 	
 	@Test
 	void checkPropertyName() throws Exception {
 		CamelKModelineTraitOption traitOption = retrieveFirstTrait("// camel-k: trait=quarkus.enabled=true");
-		assertThat(traitOption.getTraitPropertyName()).isEqualTo("enabled");
+		assertThat(traitOption.getTraitProperty().getValueAsString()).isEqualTo("enabled");
 	}
 	
 	@Test
 	void checkPropertyNameWithoutValue() throws Exception {
 		CamelKModelineTraitOption traitOption = retrieveFirstTrait("// camel-k: trait=quarkus.enabled=");
-		assertThat(traitOption.getTraitPropertyName()).isEqualTo("enabled");
+		assertThat(traitOption.getTraitProperty().getValueAsString()).isEqualTo("enabled");
 	}
 
 	private CamelKModelineTraitOption retrieveFirstTrait(String modelineWithMixedSeparator) {


### PR DESCRIPTION
- side-effect to workaround limitations of VS Code which was causing
completion for traits not working in yaml
- also inserts "." after definition name if not present

![insertAndReplaceTraitsCamelKModeline](https://user-images.githubusercontent.com/1105127/87042524-1105df80-c1f4-11ea-9c82-b3a69a88d328.gif)
