### PR TITLE
FUSETOOLS2-558 - use insert and replace for Camel properties

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesComponentCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesComponentCompletionTest.java
@@ -53,10 +53,10 @@ class CamelPropertiesComponentCompletionTest extends AbstractCamelLanguageServer
 	}
 	
 	@Test
-	void testProvideCompletionNoCompletionAtWrongPosition() throws Exception {
+	void testProvideFilteredCompletion() throws Exception {
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 14));
 		
-		assertThat(completions.get().getLeft()).isEmpty();
+		assertThat(completions.get().getLeft()).hasSize(1);
 	}
 	
 	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position) throws URISyntaxException, InterruptedException, ExecutionException {

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesTopLevelCompletionTest.java
@@ -67,7 +67,7 @@ class CamelPropertiesTopLevelCompletionTest extends AbstractCamelLanguageServerT
 	void testProvideCompletionForCamel() throws Exception {
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 0));
 		
-		assertThat(completions.get().getLeft().get(0).getLabel()).isEqualTo("camel.");
+		assertThat(completions.get().getLeft().get(0).getLabel()).isEqualTo("camel");
 	}
 	
 	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position) throws URISyntaxException, InterruptedException, ExecutionException {


### PR DESCRIPTION
- side-effect to workaroud limitations of VS Code which was causing
completion for "camel" and groups not working in yaml
- also inserts "." after inserted text when needed

![insertAndReplaceCamelProperties](https://user-images.githubusercontent.com/1105127/87140880-7b755900-c2a2-11ea-9c12-9da859bd742c.gif)
