### PR TITLE
FUSETOOLS2-504 - add support for new duration error type

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/InvalidDurationErrorMsg.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/InvalidDurationErrorMsg.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.catalog.diagnostic;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.github.cameltooling.lsp.internal.catalog.util.StringUtils;
+
+public class InvalidDurationErrorMsg implements CamelDiagnosticMessage<Map.Entry<String, String>> {
+
+	@Override
+	public String getErrorMessage(Entry<String, String> entry) {
+		boolean empty = StringUtils.isEmpty(entry.getValue());
+		if (empty) {
+			return "Empty duration value";
+		} else {
+			return "Invalid duration value: " + entry.getValue();
+		}
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/EndpointDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/EndpointDiagnosticService.java
@@ -46,6 +46,7 @@ import org.jboss.forge.roaster.model.source.JavaClassSource;
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.BooleanErrorMsg;
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.EnumErrorMsg;
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.IntegerErrorMsg;
+import com.github.cameltooling.lsp.internal.catalog.diagnostic.InvalidDurationErrorMsg;
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.NumberErrorMsg;
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.ReferenceErrorMsg;
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.UnknownErrorMsg;
@@ -235,6 +236,7 @@ public class EndpointDiagnosticService extends DiagnosticService {
 		computeErrorMessage(sb, validationResult.getInvalidNumber(), new NumberErrorMsg());
 		computeErrorMessage(sb, validationResult.getInvalidBoolean(), new BooleanErrorMsg());
 		computeErrorMessage(sb, validationResult.getInvalidReference(), new ReferenceErrorMsg());
+		computeErrorMessage(sb, validationResult.getInvalidDuration(), new InvalidDurationErrorMsg());
 		computeErrorMessage(sb, validationResult.getSyntaxError());
 		return sb.toString();
 	}

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/AbstractDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/AbstractDiagnosticTest.java
@@ -23,7 +23,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.time.Duration;
+import java.util.List;
 
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -50,6 +52,15 @@ public abstract class AbstractDiagnosticTest extends AbstractCamelLanguageServer
 		
 		await().timeout(AWAIT_TIMEOUT).untilAsserted(() -> assertThat(lastPublishedDiagnostics).isNotNull());
 		await().timeout(AWAIT_TIMEOUT).untilAsserted(() -> assertThat(lastPublishedDiagnostics.getDiagnostics()).hasSize(expectedNumberOfError));
+		
+		checkHasNonEmptyMessage(lastPublishedDiagnostics.getDiagnostics());
+	}
+
+	private void checkHasNonEmptyMessage(List<Diagnostic> diagnostics) {
+		for (Diagnostic diagnostic : diagnostics) {
+			assertThat(diagnostic.getMessage()).isNotEmpty();
+		}
+		
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
@@ -45,7 +45,7 @@ class CamelDiagnosticTest extends AbstractDiagnosticTest {
 		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
 		checkRange(range, 8, 16, 8, 39);
 	}
-	
+
 	@Test
 	void testValidationErrorWithNamespacePrefix() throws Exception {
 		testDiagnostic("camel-with-endpoint-error-withNamespacePrefix", 1, ".xml");


### PR DESCRIPTION
also improved test to check that there is no diagnostic with empty
message. The diagnostic in this case is not very useful and they are
ignored in VS Code UI.

![Screenshot from 2020-07-20 12-38-14](https://user-images.githubusercontent.com/1105127/87928914-e59db300-ca85-11ea-9b52-0259f0869d6a.png)
