### PR TITLE
FUSETOOLS2-527 - add insert and replace for mvn dependency completion

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
@@ -98,6 +98,7 @@ public class CamelKModelineDependencyOption implements ICamelKModelineOptionValu
 		completionItem.setSortText("1"); // allows to be before Camel Components in completion list
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		completionItem.setInsertText("mvn:${1:groupId}/${2:artifactId}:${3:version}");
+		CompletionResolverUtils.applyTextEditToCompletionItem(this, completionItem);
 		return completionItem;
 	}
 	

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineDependencyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineDependencyCompletionTest.java
@@ -86,7 +86,7 @@ class CamelKModelineDependencyCompletionTest extends AbstractCamelLanguageServer
 	
 	@Test
 	void testProvideCompletionForMavenComponentDependency() throws Exception {
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: dependency=");
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: dependency=test");
 		
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 23));
 		
@@ -95,5 +95,7 @@ class CamelKModelineDependencyCompletionTest extends AbstractCamelLanguageServer
 		CompletionItem timerCompletionItem = completionItems.stream().filter(completionItem -> completionItem.getLabel().startsWith("mvn")).findFirst().get();
 		assertThat(timerCompletionItem.getInsertTextFormat()).isEqualTo(InsertTextFormat.Snippet);
 		assertThat(timerCompletionItem.getInsertText()).isEqualTo("mvn:${1:groupId}/${2:artifactId}:${3:version}");
+		assertThat(timerCompletionItem.getTextEdit().getRange().getStart().getCharacter()).isEqualTo(23);
+		assertThat(timerCompletionItem.getTextEdit().getRange().getEnd().getCharacter()).isEqualTo(23 + "test".length());
 	}
 }


### PR DESCRIPTION
it adds the insert-and-replace and also it workarounds the bad behavior
of VS Code which is filtering out completion items without range/text
Edit when some others completion have it.

![fixCompletionMvn](https://user-images.githubusercontent.com/1105127/90610676-12202880-e206-11ea-8cc0-8731532e0e6e.gif)
