### PR TITLE
FUSETOOLS2-616 - support completion for dashed name of component options

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
@@ -65,15 +65,11 @@ public class CamelComponentParameterPropertyInstance implements ILineRangeDefine
 		return startCharacterInLine + componentParameter.length();
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position,
-			CompletableFuture<CamelCatalog> camelCatalog) {
-		CamelPropertyValueInstance camelPropertyFileValueInstance = camelComponentPropertykey
-				.getCamelPropertyKeyInstance().getCamelPropertyEntryInstance().getCamelPropertyValueInstance();
-		String startComponentProperty = componentParameter.substring(0,
-				position.getCharacter() - getStartPositionInLine());
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		CamelPropertyValueInstance camelPropertyFileValueInstance = camelComponentPropertykey.getCamelPropertyKeyInstance().getCamelPropertyEntryInstance().getCamelPropertyValueInstance();
+		String startComponentProperty = componentParameter.substring(0, position.getCharacter() - getStartPositionInLine());
 		return camelCatalog
-				.thenApply(new CamelComponentOptionNamesCompletionFuture(camelComponentPropertykey.getComponentId(),
-						this, camelPropertyFileValueInstance, startComponentProperty));
+				.thenApply(new CamelComponentOptionNamesCompletionFuture(camelComponentPropertykey.getComponentId(), this, camelPropertyFileValueInstance, startComponentProperty));
 	}
 
 	public String getProperty() {
@@ -99,6 +95,10 @@ public class CamelComponentParameterPropertyInstance implements ILineRangeDefine
 			}
 			return null;
 		});
+	}
+
+	public boolean shouldUseDashedCase() {
+		return camelComponentPropertykey.shouldUseDashedCase();
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
@@ -112,4 +112,8 @@ public class CamelComponentPropertyKey implements ILineRangeDefineable {
 		}
 	}
 
+	public boolean shouldUseDashedCase() {
+		return camelPropertyKeyInstance.shouldUseDashedCase();
+	}
+
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -37,10 +37,12 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 	private CamelPropertyValueInstance camelPropertyValueInstance;
 	private String line;
 	private Position startPosition;
+	private TextDocumentItem textDocumentItem;
 
 	public CamelPropertyEntryInstance(String line, Position startPosition, TextDocumentItem textDocumentItem) {
 		this.line = line;
 		this.startPosition = startPosition;
+		this.textDocumentItem = textDocumentItem;
 		int indexOf = line.indexOf('=');
 		String camelPropertyFileKeyInstanceString;
 		String camelPropertyFileValueInstanceString;
@@ -92,4 +94,9 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 			return CompletableFuture.completedFuture(null);
 		}
 	}
+
+	public boolean shouldUseDashedCase() {
+		return textDocumentItem != null ? new DashedCaseDetector().hasDashedCaseInCamelComponentOption(textDocumentItem.getText()) : false;
+	}
+
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -193,4 +193,8 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 		return CompletableFuture.completedFuture(null);
 	}
 
+	public boolean shouldUseDashedCase() {
+		return camelPropertyEntryInstance.shouldUseDashedCase();
+	}
+
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetector.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetector.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
+
+public class DashedCaseDetector {
+
+	public boolean hasDashedCaseInCamelComponentOption(String text) {
+		String[] lines = text.split("\\r?\\n");
+		for (String line : lines) {
+			if (line.matches("camel.component.\\w+.\\w+-.*")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/AbstractCamelPropertiesComponentOptionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/AbstractCamelPropertiesComponentOptionTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.camelapplicationproperties;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+public abstract class AbstractCamelPropertiesComponentOptionTest extends AbstractCamelLanguageServerTest{
+
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position, String propertyEntry) throws URISyntaxException, InterruptedException, ExecutionException {
+		String fileName = "a.properties";
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(fileName, new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, propertyEntry));
+		return getCompletionFor(camelLanguageServer, position, fileName);
+	}
+	
+	@Override
+	protected Map<Object, Object> getInitializationOptions() {
+		String component = "{\n" + 
+				" \"component\": {\n" + 
+				"    \"kind\": \"component\",\n" + 
+				"    \"scheme\": \"acomponent\",\n" + 
+				"    \"syntax\": \"acomponent:withsyntax\",\n" + 
+				"    \"title\": \"A Component\",\n" + 
+				"    \"description\": \"Description of my component.\",\n" + 
+				"    \"label\": \"\",\n" + 
+				"    \"deprecated\": true,\n" + 
+				"    \"deprecationNote\": \"\",\n" + 
+				"    \"async\": false,\n" + 
+				"    \"consumerOnly\": true,\n" + 
+				"    \"producerOnly\": false,\n" + 
+				"    \"lenientProperties\": false,\n" + 
+				"    \"javaType\": \"org.test.AComponent\",\n" + 
+				"    \"firstVersion\": \"1.0.0\",\n" + 
+				"    \"groupId\": \"org.test\",\n" + 
+				"    \"artifactId\": \"camel-acomponent\",\n" + 
+				"    \"version\": \"3.0.0\"\n" + 
+				"  },\n" + 
+				"  \"componentProperties\": {\n" + 
+				"\"aComponentProperty\": { \"kind\": \"parameter\", \"displayName\": \"A Component property \", \"group\": \"common\", \"required\": false, \"type\": \"string\", \"javaType\": \"java.lang.String\", \"deprecated\": false, \"secret\": false, \"defaultValue\": \"aDefaultValue\", \"configurationClass\": \"org.apache.camel.component.knative.KnativeConfiguration\", \"configurationField\": \"configuration\", \"description\": \"A parameter description\" },\n" +
+				"\"aSecondComponentProperty\": { \"kind\": \"parameter\", \"displayName\": \"A Second Component property \", \"group\": \"common\", \"required\": false, \"type\": \"string\", \"javaType\": \"java.lang.String\", \"deprecated\": false, \"secret\": false, \"defaultValue\": \"aDefaultValue\", \"configurationClass\": \"org.apache.camel.component.knative.KnativeConfiguration\", \"configurationField\": \"configuration\", \"description\": \"A second parameter description\" }\n" +
+				"  },\n" + 
+				"  \"properties\": {\n" +
+				"  }\n" + 
+				"}";
+		return createMapSettingsWithComponent(component);
+	}
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesComponentOptionDashedNameCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesComponentOptionDashedNameCompletionTest.java
@@ -29,58 +29,60 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 
-class CamelPropertiesComponentOptionNameCompletionTest extends AbstractCamelPropertiesComponentOptionTest {
+class CamelPropertiesComponentOptionDashedNameCompletionTest extends AbstractCamelPropertiesComponentOptionTest {
+	
+	private static String LINE_WITH_DASHED_COMPONENT = "\ncamel.component.acomponent.with-dash=demo";
 	
 	@Test
 	void testProvideCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent.");
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent." + LINE_WITH_DASHED_COMPONENT);
 		
 		assertThat(completions.get().getLeft()).hasSize(2);
 	}
 	
 	@Test
 	void testProvideCompletionHasDefaultValue() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent.");
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent." + LINE_WITH_DASHED_COMPONENT);
 		
-		assertThat(completions.get().getLeft().get(0).getInsertText()).isEqualTo("aComponentProperty=aDefaultValue");
+		assertThat(completions.get().getLeft().get(0).getInsertText()).isEqualTo("a-component-property=aDefaultValue");
 	}
 	
 	@Test
 	void testProvideCompletionWithoutDefaultValueIfAValueAlreadyProvided() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent.aComponentProperty=aValue");
-		CompletionItem expectedCompletionItem = new CompletionItem("aComponentProperty");
-		expectedCompletionItem.setInsertText("aComponentProperty");
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent.a-component-property=aValue");
+		CompletionItem expectedCompletionItem = new CompletionItem("a-component-property");
+		expectedCompletionItem.setInsertText("a-component-property");
 		expectedCompletionItem.setDocumentation("A parameter description");
 		expectedCompletionItem.setDeprecated(false);
 		expectedCompletionItem.setDetail(String.class.getName());
-		expectedCompletionItem.setTextEdit(new TextEdit(new Range(new Position(0, 27), new Position(0, 45)), "aComponentProperty"));
+		expectedCompletionItem.setTextEdit(new TextEdit(new Range(new Position(0, 27), new Position(0, 47)), "a-component-property"));
 		assertThat(completions.get().getLeft()).contains(expectedCompletionItem);
 	}
 	
 	@Test
 	void testInsertAndReplace() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent.awrongtoreplace=aValue");
-		CompletionItem expectedCompletionItem = new CompletionItem("aComponentProperty");
-		expectedCompletionItem.setInsertText("aComponentProperty");
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 27), "camel.component.acomponent.a-wrong-to-replace=aValue");
+		CompletionItem expectedCompletionItem = new CompletionItem("a-component-property");
+		expectedCompletionItem.setInsertText("a-component-property");
 		expectedCompletionItem.setDocumentation("A parameter description");
 		expectedCompletionItem.setDeprecated(false);
 		expectedCompletionItem.setDetail(String.class.getName());
-		expectedCompletionItem.setTextEdit(new TextEdit(new Range(new Position(0, 27), new Position(0, 42)), "aComponentProperty"));
+		expectedCompletionItem.setTextEdit(new TextEdit(new Range(new Position(0, 27), new Position(0, 45)), "a-component-property"));
 		assertThat(completions.get().getLeft()).contains(expectedCompletionItem);
 	}
 	
 	@Test
 	void testProvideNoCompletionAfterComponentproperty() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 46), "camel.component.acomponent.aComponentProperty.");
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 48), "camel.component.acomponent.a-component-property.");
 		
 		assertThat(completions.get().getLeft()).isEmpty();
 	}
 	
 	@Test
 	void testProvideFilteredCompletionWhenInsideValue() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 29), "camel.component.acomponent.aComponentProperty.");
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 30), "camel.component.acomponent.a-component-property.");
 		
 		assertThat(completions.get().getLeft()).hasSize(1);
-		assertThat(completions.get().getLeft().get(0).getInsertText()).isEqualTo("aComponentProperty=aDefaultValue");
+		assertThat(completions.get().getLeft().get(0).getInsertText()).isEqualTo("a-component-property=aDefaultValue");
 	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetectorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetectorTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DashedCaseDetectorTest {
+
+	@Test
+	void testHasNoDashedCaseInCamelComponentOption() throws Exception {
+		assertThat(hasDashed("camel.component.id.myNameNotDashed=123")).isFalse();
+	}
+	
+	@Test
+	void testHasNoDashedCaseInCamelComponentOptionWithSeveralLines() throws Exception {
+		assertThat(hasDashed(
+				"camel.component.id.myNameNotDashed=123\n" +
+				"camel.component.id.myOtherNameNotDashed=123")).isFalse();
+	}
+	
+	@Test
+	void testIgnoreOtherLinesDashed() throws Exception {
+		assertThat(hasDashed(
+				"camel.component.id.myNameNotDashed=123\n" +
+				"with-dashed")).isFalse();
+	}
+
+	@Test
+	void testHasDashedCaseInCamelComponentOption() throws Exception {
+		assertThat(hasDashed("camel.component.id.my-name-dashed=123")).isTrue();
+	}
+	
+	@Test
+	void testHasDashedCaseInCamelComponentOptionWithSeveralLines() throws Exception {
+		assertThat(hasDashed(
+				"camel.component.id.myNameNotDashed=123\n" +
+				"camel.component.id.my-name-dashed=123")).isTrue();
+	}
+	
+	private boolean hasDashed(String text) {
+		return new DashedCaseDetector().hasDashedCaseInCamelComponentOption(text);
+	}
+	
+}


### PR DESCRIPTION
the choice to provide dashed or camelCase name is based on the other
parts of the file. if there is already dashed name, it is proposing
dashed ones, otherwise, it is proposing Camel cased ones

![dashedCompletionForComponentOptionNameInPropertiesFiles](https://user-images.githubusercontent.com/1105127/91979915-c94c9180-ed26-11ea-89f3-c8f0ede5d1ef.gif)

see [subtasks of story](https://issues.redhat.com/browse/FUSETOOLS2-550) for several follow-up cases
