### PR TITLE
Fusetools2 617 doc on hover for dashed name of component options

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.util.StringHelper;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
@@ -82,7 +83,7 @@ public class CamelComponentParameterPropertyInstance implements ILineRangeDefine
 			if (componentJSonSchema != null) {
 				ComponentModel componentModel = ModelHelper.generateComponentModel(componentJSonSchema, true);
 				if (componentModel != null) {
-					ComponentOptionModel componentOptionModel = componentModel.getComponentOption(getProperty());
+					ComponentOptionModel componentOptionModel = findComponentOptionModel(componentModel);
 					if (componentOptionModel != null) {
 						String description = componentOptionModel.getDescription();
 						if (description != null) {
@@ -95,6 +96,15 @@ public class CamelComponentParameterPropertyInstance implements ILineRangeDefine
 			}
 			return null;
 		});
+	}
+
+	private ComponentOptionModel findComponentOptionModel(ComponentModel componentModel) {
+		String propertyWrittenName = getProperty();
+		ComponentOptionModel componentOptionModel = componentModel.getComponentOption(propertyWrittenName);
+		if(componentOptionModel == null && propertyWrittenName.contains("-")) {
+			componentOptionModel = componentModel.getComponentOption(StringHelper.dashToCamelCase(propertyWrittenName));
+		}
+		return componentOptionModel;
 	}
 
 	public boolean shouldUseDashedCase() {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
@@ -26,6 +26,7 @@ import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.tooling.model.MainModel;
 import org.apache.camel.tooling.model.MainModel.MainOptionModel;
+import org.apache.camel.util.StringHelper;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
@@ -81,8 +82,10 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 				if (catalog instanceof DefaultCamelCatalog) {
 					MainModel mainModel = ((DefaultCamelCatalog) catalog).mainModel();
 					String fullName = CamelPropertyKeyInstance.CAMEL_KEY_PREFIX + groupConfiguration;
-					Optional<MainOptionModel> mainOptionModel = mainModel.getOptions().stream()
-							.filter(option -> option.getName().startsWith(fullName)).findFirst();
+					Optional<MainOptionModel> mainOptionModel = findFirstOption(mainModel, fullName);
+					if (!mainOptionModel.isPresent() && fullName.contains("-")) {
+						mainOptionModel = findFirstOption(mainModel,StringHelper.dashToCamelCase(fullName));
+					}
 					if (mainOptionModel.isPresent()) {
 						Hover hover = new Hover();
 						hover.setContents(Collections.singletonList((Either.forLeft(mainOptionModel.get().getDescription()))));
@@ -93,6 +96,12 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 			});
 		}
 		return CompletableFuture.completedFuture(null);
+	}
+
+	private Optional<MainOptionModel> findFirstOption(MainModel mainModel, String fullName) {
+		return mainModel.getOptions().stream()
+				.filter(option -> option.getName().startsWith(fullName))
+				.findFirst();
 	}
 
 	private boolean isInGroupAttribute(Position position) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverTest.java
@@ -45,8 +45,24 @@ class CamelPropertiesFileHoverTest extends AbstractCamelLanguageServerTest {
 	}
 	
 	@Test
+	void testHoverOnCamelMainOptionsWithDashedNames() throws Exception {
+		String propertyEntry = "camel.main.backlog-tracing=true";
+		CompletableFuture<Hover> hover = getHover(propertyEntry, 13);
+		
+		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("Sets whether backlog tracing is enabled or not. Default is false.");
+	}
+	
+	@Test
 	void testHoverOnCamelComponentOptions() throws Exception {
 		String propertyEntry = "camel.component.acomponent.aComponentProperty=true";
+		CompletableFuture<Hover> hover = getHover(propertyEntry, 29);
+		
+		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("A parameter description");
+	}
+	
+	@Test
+	void testHoverOnCamelComponentOptionsWithDashedNames() throws Exception {
+		String propertyEntry = "camel.component.acomponent.a-component-property=true";
 		CompletableFuture<Hover> hover = getHover(propertyEntry, 29);
 		
 		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("A parameter description");


### PR DESCRIPTION
depends on https://github.com/camel-tooling/camel-language-server/pull/445

![hoverDashedNamesInPropertiesFile](https://user-images.githubusercontent.com/1105127/92116265-e602cb00-edf3-11ea-94e1-dfa0b153b60f.gif)
