### PR TITLE
FUSETOOLS2-619 - completion with dashed name for main options in

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
@@ -26,6 +26,7 @@ import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.tooling.model.MainModel;
 import org.apache.camel.tooling.model.MainModel.MainOptionModel;
+import org.apache.camel.util.StringHelper;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
@@ -101,6 +102,7 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 
 	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
 		if (isInGroupAttribute(position)) {
+			boolean shouldUseDashed = shouldUseDashedCase();
 			return camelCatalog.thenApply(catalog -> {
 				if (catalog instanceof DefaultCamelCatalog) {
 					MainModel mainModel = ((DefaultCamelCatalog) catalog).mainModel();
@@ -108,6 +110,9 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 					return mainModel.getOptions().stream().filter(option -> option.getName().startsWith(groupPrefix))
 							.map(option -> {
 								String realOptionName = option.getName().substring(groupPrefix.length());
+								if(shouldUseDashed) {
+									realOptionName = StringHelper.camelCaseToDash(realOptionName);
+								}
 								CompletionItem completionItem = new CompletionItem(realOptionName);
 								completionItem.setDocumentation(option.getDescription());
 								completionItem.setDeprecated(option.isDeprecated());
@@ -120,6 +125,10 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 			});
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());
+	}
+
+	private boolean shouldUseDashedCase() {
+		return camelPropertyKeyInstance.shouldUseDashedCase();
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetector.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetector.java
@@ -21,7 +21,7 @@ public class DashedCaseDetector {
 	public boolean hasDashedCaseInCamelComponentOption(String text) {
 		String[] lines = text.split("\\r?\\n");
 		for (String line : lines) {
-			if (line.matches("camel.component.\\w+.\\w+-.*")) {
+			if (line.matches("camel.\\w+.\\w+.\\w+-.*")) {
 				return true;
 			}
 		}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesGroupPropertyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelPropertiesGroupPropertyCompletionTest.java
@@ -37,22 +37,29 @@ class CamelPropertiesGroupPropertyCompletionTest extends AbstractCamelLanguageSe
 
 	@Test
 	void testProvideCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 11));
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 11), "camel.main.");
 		
-		assertThat(completions.get().getLeft()).contains(createExpectedCompletionItem());
+		assertThat(completions.get().getLeft()).contains(createExpectedCompletionItem("allowUseOriginalMessage"));
 	}
 	
-	private CompletionItem createExpectedCompletionItem() {
-		CompletionItem completionItem = new CompletionItem("allowUseOriginalMessage");
+	@Test
+	void testProvideCompletionWithDashedName() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 11), "camel.main.\ncamel.main.auto-startup=true");
+		
+		assertThat(completions.get().getLeft()).contains(createExpectedCompletionItem("allow-use-original-message"));
+	}
+	
+	private CompletionItem createExpectedCompletionItem(String expectedOption) {
+		CompletionItem completionItem = new CompletionItem(expectedOption);
 		completionItem.setDocumentation("Sets whether to allow access to the original message from Camel's error handler, or from org.apache.camel.spi.UnitOfWork.getOriginalInMessage(). Turning this off can optimize performance, as defensive copy of the original message is not needed. Default is false.");
 		completionItem.setDeprecated(false);
-		completionItem.setInsertText("allowUseOriginalMessage=");
-		return completionItem ;
+		completionItem.setInsertText(expectedOption + "=");
+		return completionItem;
 	}
 
-	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position) throws URISyntaxException, InterruptedException, ExecutionException {
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position, String text) throws URISyntaxException, InterruptedException, ExecutionException {
 		String fileName = "a.properties";
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, "camel.main."));
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, text));
 		return getCompletionFor(camelLanguageServer, position, fileName);
 	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetectorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetectorTest.java
@@ -47,6 +47,11 @@ class DashedCaseDetectorTest {
 	}
 	
 	@Test
+	void testHasDashedCaseInCamelMainOption() throws Exception {
+		assertThat(hasDashed("camel.main.auto-startup=123")).isTrue();
+	}
+	
+	@Test
 	void testHasDashedCaseInCamelComponentOptionWithSeveralLines() throws Exception {
 		assertThat(hasDashed(
 				"camel.component.id.myNameNotDashed=123\n" +


### PR DESCRIPTION
properties file

when there is already a dashed name in the same file

![completionOfDashedNameForGrouppropertiesInPropertiesFile](https://user-images.githubusercontent.com/1105127/92120258-1b5de780-edf9-11ea-8324-c7456a3e9a27.gif)
