### PR TITLE
FUSETOOLS2-627 - upgrade one test stage on Travis from Java 14 to Java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
       script:
         - mvn verify -V
     - stage: test
-      jdk: openjdk14
+      jdk: openjdk15
       script:
         - mvn verify -V
     - stage: deploy


### PR DESCRIPTION
15

replacing Java 14 as it is not a LTS (Long Term Support)


