### PR TITLE
FUSETOOLS2-707 - filter out files in IDE config folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ On hover, the documentation of the Camel component is available.
 On save, diagnostics on Camel URIs are updated:
 ![Diagnostic on Camel URI](./images/diagnostic.png "Diagnostic on Camel URI")
 
+### Camel K modeline support
+
+* Completion for:
+  * option names
+  * trait definition names
+  * trait property names
+  * Camel artifact id for dependency
+  * mvn dependency
+  * Camel component properties
+  * resource-like properties (`resource`, `open-api`, `property-file`). It is providing relevant sibling files filtering out some IDEs configuration folders (`.vscode`, `.settings`, `.theia`).
+
 ### WebSocket support
 
 Connection through WebSocket is supported. The server needs to be launched with `--websocket` option.

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineLocalResourceRelatedOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineLocalResourceRelatedOption.java
@@ -37,6 +37,10 @@ import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
 
 public abstract class CamelKModelineLocalResourceRelatedOption implements ICamelKModelineOptionValue {
 
+	private static final String IDE_CONFIG_FOLDER_THEIA = ".theia";
+	private static final String IDE_CONFIG_FOLDER_ECLIPSE_DESKTOP = ".settings";
+	private static final String IDE_CONFIG_FOLDER_VSCODE = ".vscode";
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(CamelKModelineLocalResourceRelatedOption.class);
 	
 	private String value;
@@ -65,7 +69,7 @@ public abstract class CamelKModelineLocalResourceRelatedOption implements ICamel
 	}
 	
 	protected abstract String getPropertyName();
-	protected abstract Predicate<? super Path> getFilter();
+	protected abstract Predicate<Path> getFilter();
 	
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(int position, CompletableFuture<CamelCatalog> camelCatalog) {
@@ -88,6 +92,7 @@ public abstract class CamelKModelineLocalResourceRelatedOption implements ICamel
 			return pathStream
 					.filter(Files::isRegularFile)
 					.filter(path -> !path.equals(documentUriPath))
+					.filter(this::isOutsideOfIDEConfigFolder)
 					.filter(getFilter())
 					.map(documentUriParentPath::relativize)
 					.map(Path::toString)
@@ -98,5 +103,12 @@ public abstract class CamelKModelineLocalResourceRelatedOption implements ICamel
 					})
 					.collect(Collectors.toList());
 		}
+	}
+
+	private boolean isOutsideOfIDEConfigFolder(Path path) {
+		String absolutePath = path.toAbsolutePath().toString();
+		return !absolutePath.contains(IDE_CONFIG_FOLDER_VSCODE)
+				&& !absolutePath.contains(IDE_CONFIG_FOLDER_ECLIPSE_DESKTOP)
+				&& !absolutePath.contains(IDE_CONFIG_FOLDER_THEIA);
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOpenAPIOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOpenAPIOption.java
@@ -33,7 +33,7 @@ public class CamelKModelineOpenAPIOption extends CamelKModelineLocalResourceRela
 	}
 
 	@Override
-	protected Predicate<? super Path> getFilter() {
+	protected Predicate<Path> getFilter() {
 		return path ->  {
 			String filename = path.getFileName().toString();
 			return filename.endsWith(".json")

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyFileOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyFileOption.java
@@ -27,7 +27,7 @@ public class CamelKModelinePropertyFileOption extends CamelKModelineLocalResourc
 		super(value, startPosition, documentItemUri);
 	}
 	
-	protected Predicate<? super Path> getFilter() {
+	protected Predicate<Path> getFilter() {
 		return path -> path.getFileName().toString().endsWith(".properties");
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineResourceOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineResourceOption.java
@@ -33,7 +33,7 @@ public class CamelKModelineResourceOption extends CamelKModelineLocalResourceRel
 	}
 
 	@Override
-	protected Predicate<? super Path> getFilter() {
+	protected Predicate<Path> getFilter() {
 		return path -> true;
 	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -257,4 +257,11 @@ public abstract class AbstractCamelLanguageServerTest {
 		return initializationOptions;
 	}
 	
+	protected void createFolderWithFile(String folderName, String fileName, File parent) throws IOException {
+		File aSiblingFolder = new File(parent, folderName);
+		aSiblingFolder.mkdir();
+		File aPropertiesFileInSiblingFolder = new File(aSiblingFolder, fileName);
+		aPropertiesFileInSiblingFolder.createNewFile();
+	}
+	
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelOpenAPITest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelOpenAPITest.java
@@ -68,6 +68,12 @@ class CamelKModelineCamelOpenAPITest extends AbstractCamelLanguageServerTest {
 	 *   | a.json
 	 *   | myFolder
 	 *   --| aSecond.yaml
+	 *   | .vscode
+	 *   --| shouldbefiltered.yaml
+	 *   | .settings
+	 *   --| shouldbefiltered2.yaml
+	 *   | .theia
+	 *   --| shouldbefiltered3.yaml
 	 * 
 	 * @return The Camel K yaml file created at the root of the temporary directory
 	 * @throws IOException
@@ -77,10 +83,12 @@ class CamelKModelineCamelOpenAPITest extends AbstractCamelLanguageServerTest {
 		Files.write("# camel-k: open-api=".getBytes(), camelKfile);
 		File aSiblingPropertyFile = new File(temporaryDir, "a.json");
 		aSiblingPropertyFile.createNewFile();
-		File aSiblingFolder = new File(temporaryDir, "myFolder");
-		aSiblingFolder.mkdir();
-		File aPropertiesFileInSiblingFolder = new File(aSiblingFolder, "aSecond.yaml");
-		aPropertiesFileInSiblingFolder.createNewFile();
+		
+		createFolderWithFile("myFolder", "aSecond.yaml", temporaryDir);
+		createFolderWithFile(".vscode", "shouldbefiltered.yaml", temporaryDir);
+		createFolderWithFile(".settings", "shouldbefiltered2.yaml", temporaryDir);
+		createFolderWithFile(".theia", "shouldbefiltered3.yaml", temporaryDir);
+		
 		File anotherFile = new File(temporaryDir, "anotherFile.txt");
 		anotherFile.createNewFile();
 		return camelKfile;

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelPropertyFileTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelPropertyFileTest.java
@@ -68,6 +68,12 @@ class CamelKModelineCamelPropertyFileTest extends AbstractCamelLanguageServerTes
 	 *   | a.properties
 	 *   | myFolder
 	 *   --| aSecond.properties
+	 *   | .vscode
+	 *   --| shouldbefiltered.properties
+	 *   | .settings
+	 *   --| shouldbefiltered2.properties
+	 *   | .theia
+	 *   --| shouldbefiltered3.properties
 	 * 
 	 * @return The Camel K yaml file created at the root of the temporary directory
 	 * @throws IOException
@@ -77,10 +83,12 @@ class CamelKModelineCamelPropertyFileTest extends AbstractCamelLanguageServerTes
 		Files.write("# camel-k: property-file=".getBytes(), camelKfile);
 		File aSiblingPropertyFile = new File(temporaryDir, "a.properties");
 		aSiblingPropertyFile.createNewFile();
-		File aSiblingFolder = new File(temporaryDir, "myFolder");
-		aSiblingFolder.mkdir();
-		File aPropertiesFileInSiblingFolder = new File(aSiblingFolder, "aSecond.properties");
-		aPropertiesFileInSiblingFolder.createNewFile();
+		
+		createFolderWithFile("myFolder", "aSecond.properties", temporaryDir);
+		createFolderWithFile(".vscode", "shouldbefiltered.properties", temporaryDir);
+		createFolderWithFile(".settings", "shouldbefiltered2.properties", temporaryDir);
+		createFolderWithFile(".theia", "shouldbefiltered3.properties", temporaryDir);
+		
 		File anotherFile = new File(temporaryDir, "anotherFile.txt");
 		anotherFile.createNewFile();
 		return camelKfile;

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelResourceTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCamelResourceTest.java
@@ -69,6 +69,12 @@ class CamelKModelineCamelResourceTest extends AbstractCamelLanguageServerTest {
 	 *   | a.properties
 	 *   | myFolder
 	 *   --| aSecond.properties
+	 *   | .vscode
+	 *   --| shouldbefiltered.txt
+	 *   | .settings
+	 *   --| shouldbefiltered2.txt
+	 *   | .theia
+	 *   --| shouldbefiltered3.txt
 	 * 
 	 * @return The Camel K yaml file created at the root of the temporary directory
 	 * @throws IOException
@@ -78,10 +84,12 @@ class CamelKModelineCamelResourceTest extends AbstractCamelLanguageServerTest {
 		Files.write("# camel-k: resource=".getBytes(), camelKfile);
 		File aSiblingPropertyFile = new File(temporaryDir, "a.properties");
 		aSiblingPropertyFile.createNewFile();
-		File aSiblingFolder = new File(temporaryDir, "myFolder");
-		aSiblingFolder.mkdir();
-		File aPropertiesFileInSiblingFolder = new File(aSiblingFolder, "aSecond.properties");
-		aPropertiesFileInSiblingFolder.createNewFile();
+		
+		createFolderWithFile("myFolder", "aSecond.properties", temporaryDir);
+		createFolderWithFile(".vscode", "shouldbefiltered.txt", temporaryDir);
+		createFolderWithFile(".settings", "shouldbefiltered2.txt", temporaryDir);
+		createFolderWithFile(".theia", "shouldbefiltered3.txt", temporaryDir);
+		
 		File anotherFile = new File(temporaryDir, "anotherFile.txt");
 		anotherFile.createNewFile();
 		return camelKfile;


### PR DESCRIPTION
when providing completion for resource-like Camel K modeline properties.

![Screenshot from 2020-09-23 10-09-51](https://user-images.githubusercontent.com/1105127/93985284-21564100-fd85-11ea-9a4c-389e7a3f4e51.png)

list is currently limited to 3 IDEs and the most common folder for a Camel K project