### PR TITLE
FUSETOOLS2-717 - Provide Document Symbol for Java DSL

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolJavaProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolJavaProcessor.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.documentsymbol;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
+
+import org.apache.camel.parser.RouteBuilderParser;
+import org.apache.camel.parser.model.CamelNodeDetails;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
+
+public class DocumentSymbolJavaProcessor {
+
+	private TextDocumentItem textDocumentItem;
+
+	public DocumentSymbolJavaProcessor(TextDocumentItem textDocumentItem) {
+		this.textDocumentItem = textDocumentItem;
+	}
+
+	public List<Either<SymbolInformation, DocumentSymbol>> getSymbolInformations() {
+		JavaClassSource clazz = (JavaClassSource) Roaster.parse(textDocumentItem.getText());
+		String rawPathOfCamelFile = URI.create(textDocumentItem.getUri()).getRawPath();
+		List<CamelNodeDetails> camelNodes = RouteBuilderParser.parseRouteBuilderTree(clazz, "", rawPathOfCamelFile, true);
+		return createSymbolInformations(camelNodes);
+	}
+	
+	private List<Either<SymbolInformation, DocumentSymbol>> createSymbolInformations(List<CamelNodeDetails> camelNodes) {
+		List<Either<SymbolInformation, DocumentSymbol>> symbolInformations = new ArrayList<>();
+		if (camelNodes != null) {
+			for (CamelNodeDetails camelNodeDetails : camelNodes) {
+				Range range = computeRange(camelNodeDetails);
+				symbolInformations.add(createSymbolInformation(camelNodeDetails, range));
+				symbolInformations.addAll(createSymbolInformations(camelNodeDetails.getOutputs()));
+			}
+		}
+		return symbolInformations;
+	}
+
+	private Either<SymbolInformation, DocumentSymbol> createSymbolInformation(CamelNodeDetails camelNodeDetails, Range range) {
+		return Either.forLeft(
+				new SymbolInformation(
+						camelNodeDetails.getName(),
+						SymbolKind.Field,
+						new Location(textDocumentItem.getUri(), range)));
+	}
+
+	private Range computeRange(CamelNodeDetails camelNodeDetails) {
+		int endLine = retrieveEndline(camelNodeDetails);
+		Position startPosition = new Position(Integer.valueOf(camelNodeDetails.getLineNumber()) - 1, 0);
+		Position endPosition = new Position(endLine, new ParserFileHelperUtil().getLine(textDocumentItem, endLine).length());
+		return new Range(startPosition, endPosition);
+	}
+
+	private int retrieveEndline(CamelNodeDetails camelNodeDetails) {
+		OptionalInt endLineComputedFromChildren = retrieveAllChildrenOutputs(camelNodeDetails)
+				.mapToInt(output -> Integer.valueOf(output.getLineNumberEnd()) - 1)
+				.max();
+		return endLineComputedFromChildren.orElse(Integer.valueOf(camelNodeDetails.getLineNumberEnd()) - 1);
+	}
+
+	private Stream<CamelNodeDetails> retrieveAllChildrenOutputs(CamelNodeDetails camelNodeDetails) {
+		List<CamelNodeDetails> children = camelNodeDetails.getOutputs();
+		if (children != null) {
+			return Stream.concat(Stream.of(camelNodeDetails), children.stream().flatMap(this::retrieveAllChildrenOutputs));
+		} else {
+			return Stream.of(camelNodeDetails);
+		}
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolXMLProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolXMLProcessor.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.documentsymbol;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.github.cameltooling.lsp.internal.parser.ParserXMLFileHelper;
+
+public class DocumentSymbolXMLProcessor {
+	
+	static final String CANNOT_DETERMINE_DOCUMENT_SYMBOLS = "Cannot determine document symbols";
+	private static final String ATTRIBUTE_ID = "id";
+	private static final Logger LOGGER = LoggerFactory.getLogger(DocumentSymbolXMLProcessor.class);
+	
+	private ParserXMLFileHelper parserFileHelper = new ParserXMLFileHelper();
+	private TextDocumentItem textDocumentItem;
+
+	public DocumentSymbolXMLProcessor(TextDocumentItem textDocumentItem) {
+		this.textDocumentItem = textDocumentItem;
+	}
+
+	public List<Either<SymbolInformation, DocumentSymbol>> getSymbolInformations() {
+		List<Either<SymbolInformation, DocumentSymbol>> symbolInformations = new ArrayList<>();
+		try {
+			NodeList routeNodes = parserFileHelper.getRouteNodes(textDocumentItem);
+			if (routeNodes != null) {
+				symbolInformations.addAll(convertToSymbolInformation(routeNodes));
+			}
+			NodeList camelContextNodes = parserFileHelper.getCamelContextNodes(textDocumentItem);
+			if (camelContextNodes != null) {
+				symbolInformations.addAll(convertToSymbolInformation(camelContextNodes));
+			}
+		} catch (Exception e) {
+			LOGGER.error(CANNOT_DETERMINE_DOCUMENT_SYMBOLS, e);
+		}
+		return symbolInformations;
+	}
+	
+	private List<Either<SymbolInformation, DocumentSymbol>> convertToSymbolInformation(NodeList routeNodes) {
+		List<Either<SymbolInformation, DocumentSymbol>> res = new ArrayList<>();
+		for (int i = 0; i < routeNodes.getLength(); i++) {
+			Node routeNode = routeNodes.item(i);
+			Location location = parserFileHelper.retrieveLocation(routeNode, textDocumentItem);
+			String displayNameOfSymbol = computeDisplayNameOfSymbol(routeNode);
+			res.add(Either.forLeft(new SymbolInformation(displayNameOfSymbol, SymbolKind.Field, location)));
+		}
+		return res;
+	}
+
+	private String computeDisplayNameOfSymbol(Node node) {
+		Node routeIdAttribute = node.getAttributes().getNamedItem(ATTRIBUTE_ID);
+		String displayNameOfSymbol;
+		if (routeIdAttribute != null) {
+			displayNameOfSymbol = routeIdAttribute.getNodeValue();
+		} else {
+			displayNameOfSymbol = "<no id>";
+		}
+		return displayNameOfSymbol;
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -216,8 +216,12 @@ public abstract class AbstractCamelLanguageServerTest {
 	}
 	
 	protected CompletableFuture<List<Either<SymbolInformation,DocumentSymbol>>> getDocumentSymbolFor(CamelLanguageServer camelLanguageServer) {
+		return getDocumentSymbolFor(camelLanguageServer, DUMMY_URI+extensionUsed);
+	}
+	
+	protected CompletableFuture<List<Either<SymbolInformation,DocumentSymbol>>> getDocumentSymbolFor(CamelLanguageServer camelLanguageServer, String uri) {
 		TextDocumentService textDocumentService = camelLanguageServer.getTextDocumentService();
-		DocumentSymbolParams params = new DocumentSymbolParams(new TextDocumentIdentifier(DUMMY_URI+extensionUsed));
+		DocumentSymbolParams params = new DocumentSymbolParams(new TextDocumentIdentifier(uri));
 		return textDocumentService.documentSymbol(params);
 	}
 

--- a/src/test/resources/workspace/My3RoutesBuilder.java
+++ b/src/test/resources/workspace/My3RoutesBuilder.java
@@ -1,0 +1,28 @@
+import org.apache.camel.builder.RouteBuilder;
+
+public class My3RouteBuilder extends RouteBuilder {
+
+    public void configure() {
+
+        from("file:src/data?noop=true&antExclude=aa&antFilterCaseSensitive=true&runLoggingLevel=OFF")
+            .choice()
+                .when(xpath("/person/city = 'London'"))
+                    .to("file:target/messages/uk")
+                .otherwise()
+                    .to("file:target/messages/others");
+
+        from("direct:route2")
+            .choice()
+                .when(xpath("/person/city = 'London'"))
+                    .to("file:target/messages/uk")
+                .otherwise()
+                    .to("file:target/messages/others");
+
+        from("direct:route3")
+            .choice()
+                .when(xpath("/person/city = 'London'"))
+                    .to("file:target/messages/uk")
+                .otherwise()
+                    .to("file:target/messages/others");
+    }
+}


### PR DESCRIPTION
- first iteration allowing to have a high-level overview
- ideas for future:
  - includes when/otherwise information
  - provide route id if available
  - provide component name

![outlineDocumentSymbol](https://user-images.githubusercontent.com/1105127/94244506-44b1f500-ff19-11ea-8f7d-15e27f9a5977.gif)

/!\ tricky part in VS Code. By default, the outline is sorting by "category" (why the hell??) needs to change to sort by position to have a better overview of the flow. The Language Server is providing the right information. After it is a problem of the Client implementation that is choosing how to display stuff. In this case, their outline is not really meant to display a flow unfortunately.
![trickyVSCode](https://user-images.githubusercontent.com/1105127/94244877-cc97ff00-ff19-11ea-9470-dfec1dbdcd45.gif)
Well, even with this choice, it remains convenient to have the route available in outline with their children elements.