### PR TITLE
Remove unused import

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/BooleanErrorMsgTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/BooleanErrorMsgTest.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.catalog.diagnostic.BooleanErrorMsg;
-
 class BooleanErrorMsgTest {
 
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/EnumErrorMsgTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/EnumErrorMsgTest.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import org.apache.camel.catalog.EndpointValidationResult;
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.catalog.diagnostic.EnumErrorMsg;
-
 class EnumErrorMsgTest {
 
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/IntegerErrorMsgTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/IntegerErrorMsgTest.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.catalog.diagnostic.IntegerErrorMsg;
-
 class IntegerErrorMsgTest {
 
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/NumberErrorMsgTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/NumberErrorMsgTest.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.catalog.diagnostic.NumberErrorMsg;
-
 class NumberErrorMsgTest {
 
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/ReferenceErrorMsgTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/catalog/diagnostic/ReferenceErrorMsgTest.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.catalog.diagnostic.ReferenceErrorMsg;
-
 class ReferenceErrorMsgTest {
 
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/catalog/util/ModelHelperTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/catalog/util/ModelHelperTest.java
@@ -24,7 +24,6 @@ import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.junit.jupiter.api.Test;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
-import com.github.cameltooling.lsp.internal.catalog.util.ModelHelper;
 
 class ModelHelperTest {
 


### PR DESCRIPTION
after merge from common, it is now in the same package, so no need to
import it

