### PR TITLE
FUSETOOLS2-719 - include component path in outline for Java DSL

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
@@ -192,7 +192,7 @@ class DocumentSymbolProcessorTest extends AbstractCamelLanguageServerTest {
 		File f = new File("src/test/resources/workspace/camel.java");
 		List<Either<SymbolInformation,DocumentSymbol>> documentSymbols = testRetrieveDocumentSymbol(f, 4);
 		SymbolInformation symbolInformation = documentSymbols.get(0).getLeft();
-		assertThat(symbolInformation.getName()).isEqualTo("from");
+		assertThat(symbolInformation.getName()).isEqualTo("from file:src/data");
 		Range range = symbolInformation.getLocation().getRange();
 		assertThat(range.getStart().getLine()).isEqualTo(15);
 		assertThat(range.getEnd().getLine()).isEqualTo(20);
@@ -205,10 +205,10 @@ class DocumentSymbolProcessorTest extends AbstractCamelLanguageServerTest {
 		List<Either<SymbolInformation,DocumentSymbol>> documentSymbols = testRetrieveDocumentSymbol(f, 12);
 		
 		List<SymbolInformation> fromSymbolInformations = documentSymbols.stream()
-				.filter(either -> "from".equals(either.getLeft().getName()))
+				.filter(either -> "from direct:route2".equals(either.getLeft().getName()))
 				.map(Either::getLeft)
 				.collect(Collectors.toList());
-		SymbolInformation secondFrom = fromSymbolInformations.get(1);
+		SymbolInformation secondFrom = fromSymbolInformations.get(0);
 		Range range = secondFrom.getLocation().getRange();
 		assertThat(range.getStart().getLine()).isEqualTo(13);
 		assertThat(range.getEnd().getLine()).isEqualTo(18);


### PR DESCRIPTION
![Screenshot from 2020-09-29 14-27-32](https://user-images.githubusercontent.com/1105127/94558576-53254700-0260-11eb-9691-c22487301bbf.png)

limitation: doesn't support having several level of camel nodes on the same line. I have nerver seen a route written this way. so thought to be okay to not handle it
