### PR TITLE
FUSETOOLS2-735 - avoid NPE in Document Symbol when there is a space in

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolJavaProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolJavaProcessor.java
@@ -16,6 +16,7 @@
  */
 package com.github.cameltooling.lsp.internal.documentsymbol;
 
+import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,10 +50,10 @@ public class DocumentSymbolJavaProcessor {
 
 	public List<Either<SymbolInformation, DocumentSymbol>> getSymbolInformations() {
 		JavaClassSource clazz = (JavaClassSource) Roaster.parse(textDocumentItem.getText());
-		String rawPathOfCamelFile = URI.create(textDocumentItem.getUri()).getRawPath();
-		List<CamelNodeDetails> camelNodes = RouteBuilderParser.parseRouteBuilderTree(clazz, "", rawPathOfCamelFile, true);
+		String absolutePathOfCamelFile = new File(URI.create(textDocumentItem.getUri())).getAbsolutePath();
+		List<CamelNodeDetails> camelNodes = RouteBuilderParser.parseRouteBuilderTree(clazz, "", absolutePathOfCamelFile, true);
 		List<CamelEndpointDetails> endpoints = new ArrayList<>();
-		RouteBuilderParser.parseRouteBuilderEndpoints(clazz, "", rawPathOfCamelFile, endpoints);
+		RouteBuilderParser.parseRouteBuilderEndpoints(clazz, "", absolutePathOfCamelFile, endpoints);
 		return createSymbolInformations(camelNodes, endpoints);
 	}
 	

--- a/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
@@ -190,6 +190,10 @@ class DocumentSymbolProcessorTest extends AbstractCamelLanguageServerTest {
 	@Test
 	void testSingleRoute() throws Exception {
 		File f = new File("src/test/resources/workspace/camel.java");
+		testSingleRoute(f);
+	}
+
+	private void testSingleRoute(File f) throws URISyntaxException, InterruptedException, ExecutionException, IOException {
 		List<Either<SymbolInformation,DocumentSymbol>> documentSymbols = testRetrieveDocumentSymbol(f, 4);
 		SymbolInformation symbolInformation = documentSymbols.get(0).getLeft();
 		assertThat(symbolInformation.getName()).isEqualTo("from file:src/data");
@@ -197,6 +201,12 @@ class DocumentSymbolProcessorTest extends AbstractCamelLanguageServerTest {
 		assertThat(range.getStart().getLine()).isEqualTo(15);
 		assertThat(range.getEnd().getLine()).isEqualTo(20);
 		assertThat(range.getEnd().getCharacter()).isEqualTo(55);
+	}
+	
+	@Test
+	void testWithSpaceInPath() throws Exception {
+		File f = new File("src/test/resources/workspace with space/MyRouteBuilder.java");
+		testSingleRoute(f);
 	}
 	
 	@Test

--- a/src/test/resources/workspace with space/MyRouteBuilder.java
+++ b/src/test/resources/workspace with space/MyRouteBuilder.java
@@ -1,0 +1,23 @@
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * A Camel Java DSL Router
+ */
+public class MyRouteBuilder extends RouteBuilder {
+
+    /**
+     * Let's configure the Camel routing rules using Java code...
+     */
+    public void configure() {
+
+        // here is a sample which processes the input files
+        // (leaving them in place - see the 'noop' flag)
+        // then performs content based routing on the message using XPath
+        from("file:src/data?noop=true&antExclude=aa&antFilterCaseSensitive=true&runLoggingLevel=OFF")
+            .choice()
+                .when(xpath("/person/city = 'London'"))
+                    .to("file:target/messages/uk")
+                .otherwise()
+                    .to("file:target/messages/others");
+    }
+}


### PR DESCRIPTION
path

to check:
- create folder with a space
- create a Camel Java file in it
- ensure an access oto document symbol is done (for instance by accessing outline)