### PR TITLE
FUSETOOLS2-755 - Provide range on Hover

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverFuture.java
@@ -21,6 +21,8 @@ import java.util.function.Function;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
@@ -42,6 +44,8 @@ public class CamelURIHoverFuture implements Function<CamelCatalog, Hover> {
 			Hover hover = new Hover();
 			ComponentModel componentModel = ModelHelper.generateComponentModel(componentJSonSchema, true);
 			hover.setContents(Collections.singletonList((Either.forLeft(uriElement.getDescription(componentModel)))));
+			Position start = new Position(uriElement.getLine(), uriElement.getStartPositionInLine());
+			hover.setRange(new Range(start, new Position(uriElement.getLine(), uriElement.getEndPositionInLine())));
 			return hover;
 		}
 		return null;

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ILineRangeDefineable.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ILineRangeDefineable.java
@@ -16,9 +16,23 @@
  */
 package com.github.cameltooling.lsp.internal.instancemodel;
 
+import java.util.Collections;
+
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
 public interface ILineRangeDefineable {
 	
 	public int getLine();
 	public int getStartPositionInLine();
 	public int getEndPositionInLine();
+	
+	public default Hover createHover(String description) {
+		Hover hover = new Hover();
+		hover.setContents(Collections.singletonList((Either.forLeft(description))));
+		hover.setRange(new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getEndPositionInLine())));
+		return hover;
+	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentNamePropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentNamePropertyInstance.java
@@ -16,7 +16,6 @@
  */
 package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -24,7 +23,6 @@ import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
 import com.github.cameltooling.lsp.internal.catalog.util.ModelHelper;
@@ -80,9 +78,7 @@ public class CamelComponentNamePropertyInstance implements ILineRangeDefineable 
 				if (componentModel != null) {
 					String description = componentModel.getDescription();
 					if (description != null) {
-						Hover hover = new Hover();
-						hover.setContents(Collections.singletonList((Either.forLeft(description))));
-						return hover;
+						return createHover(description);
 					}
 				}
 			}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
@@ -16,7 +16,6 @@
  */
 package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -25,7 +24,6 @@ import org.apache.camel.util.StringHelper;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentOptionModel;
@@ -87,9 +85,7 @@ public class CamelComponentParameterPropertyInstance implements ILineRangeDefine
 					if (componentOptionModel != null) {
 						String description = componentOptionModel.getDescription();
 						if (description != null) {
-							Hover hover = new Hover();
-							hover.setContents(Collections.singletonList((Either.forLeft(description))));
-							return hover;
+							return createHover(description);
 						}
 					}
 				}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
@@ -30,7 +30,6 @@ import org.apache.camel.util.StringHelper;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 
@@ -87,9 +86,7 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 						mainOptionModel = findFirstOption(mainModel,StringHelper.dashToCamelCase(fullName));
 					}
 					if (mainOptionModel.isPresent()) {
-						Hover hover = new Hover();
-						hover.setContents(Collections.singletonList((Either.forLeft(mainOptionModel.get().getDescription()))));
-						return hover;
+						return createHover(mainOptionModel.get().getDescription());
 					}
 				}
 				return null;

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
@@ -16,7 +16,6 @@
  */
 package com.github.cameltooling.lsp.internal.modelinemodel;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -27,7 +26,6 @@ import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.InsertTextFormat;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
 import com.github.cameltooling.lsp.internal.catalog.util.ModelHelper;
@@ -107,7 +105,7 @@ public class CamelKModelineDependencyOption implements ICamelKModelineOptionValu
 		return camelCatalog.thenApply(catalog -> {
 			Optional<ComponentModel> model = findComponentModel(catalog);
 			if (model.isPresent()) {
-				return new Hover(Collections.singletonList((Either.forLeft(model.get().getDescription()))));
+				return createHover(model.get().getDescription());
 			} else {
 				return null;
 			}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -110,7 +112,10 @@ public class CamelKModelineOption implements ILineRangeDefineable {
 		if(getStartPositionInLine() <= characterPosition && characterPosition <= getStartPositionInLine() + optionName.length()) {
 			String description = CamelKModelineOptionNames.getDescription(optionName);
 			if(description != null) {
-				return CompletableFuture.completedFuture(new Hover(Collections.singletonList((Either.forLeft(description)))));
+				Hover hover = new Hover();
+				hover.setContents(Collections.singletonList((Either.forLeft(description))));
+				hover.setRange(new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getStartPositionInLine() + optionName.length())));
+				return CompletableFuture.completedFuture(hover);
 			}
 		}
 		if(optionValue != null && optionValue.isInRange(characterPosition)) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinition.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinition.java
@@ -16,14 +16,12 @@
  */
 package com.github.cameltooling.lsp.internal.modelinemodel;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.completion.modeline.CamelKTraitManager;
 
@@ -68,9 +66,7 @@ public class CamelKModelineTraitDefinition implements ICamelKModelineOptionValue
 	public CompletableFuture<Hover> getHover(int characterPosition, CompletableFuture<CamelCatalog> camelCatalog) {
 		String description = CamelKTraitManager.getDescription(traitDefinitionName);
 		if (description != null) {
-			Hover hover = new Hover();
-			hover.setContents(Collections.singletonList((Either.forLeft(description))));
-			return CompletableFuture.completedFuture(hover);
+			return CompletableFuture.completedFuture(createHover(description));
 		}
 		return ICamelKModelineOptionValue.super.getHover(characterPosition, camelCatalog);
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinitionProperty.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinitionProperty.java
@@ -16,14 +16,12 @@
  */
 package com.github.cameltooling.lsp.internal.modelinemodel;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.completion.modeline.CamelKTraitManager;
 
@@ -68,9 +66,7 @@ public class CamelKModelineTraitDefinitionProperty implements ICamelKModelineOpt
 	public CompletableFuture<Hover> getHover(int characterPosition, CompletableFuture<CamelCatalog> camelCatalog) {
 		String description = CamelKTraitManager.getPropertyDescription(getTraitOption().getTraitDefinition().getValueAsString(), traitDefinitionProperty);
 		if (description != null) {
-			Hover hover = new Hover();
-			hover.setContents(Collections.singletonList((Either.forLeft(description))));
-			return CompletableFuture.completedFuture(hover);
+			return CompletableFuture.completedFuture(createHover(description));
 		}
 		return ICamelKModelineOptionValue.super.getHover(characterPosition, camelCatalog);
 	}

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineCamelComponentDependencyTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineCamelComponentDependencyTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,16 @@ class CamelKModelineCamelComponentDependencyTest extends AbstractCamelLanguageSe
 		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
 		
 		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("Generate messages in specified intervals using java.util.Timer.");
+	}
+	
+	@Test
+	void testRangeOnHover() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: dependency=camel-timer", ".java");
+		
+		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".java"), new Position(0, 24));
+		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
+		
+		assertThat(hover.get().getRange()).isEqualTo(new Range(new Position(0, 23), new Position(0, 34)));
 	}
 	
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineComponentPropertyHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineComponentPropertyHoverTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +59,13 @@ class CamelKModelineComponentPropertyHoverTest extends AbstractCamelLanguageServ
 		testProvideDocumentationOnHover("// camel-k: property=camel.component.timer.unknown", 50, null);
 	}
 	
-	private void testProvideDocumentationOnHover(String modeline, int position, String expectedDescription) throws URISyntaxException, InterruptedException, ExecutionException {
+	@Test
+	void testRange() throws Exception {
+		Hover hover = testProvideDocumentationOnHover("// camel-k: property=camel.component.timer.basicPropertyBinding=true", 50, "Whether the component should use basic property binding (Camel 2.x) or the newer property binding with additional capabilities");
+		assertThat(hover.getRange()).isEqualTo(new Range(new Position(0, 43), new Position(0, 63)));
+	}
+	
+	private Hover testProvideDocumentationOnHover(String modeline, int position, String expectedDescription) throws URISyntaxException, InterruptedException, ExecutionException {
 		CamelLanguageServer camelLanguageServer = initializeLanguageServer(modeline, ".java");
 		
 		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".java"), new Position(0, position));
@@ -66,8 +73,10 @@ class CamelKModelineComponentPropertyHoverTest extends AbstractCamelLanguageServ
 		
 		if (expectedDescription != null) {
 			assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo(expectedDescription);
+			return hover.get();
 		} else {
 			assertThat(hover.get()).isNull();
+			return null;
 		}
 	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineOptionNamesHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineOptionNamesHoverTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +40,16 @@ class CamelKModelineOptionNamesHoverTest extends AbstractCamelLanguageServerTest
 		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
 		
 		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("Configure a trait. E.g. \"trait=service.enabled=false\"");
+	}
+	
+	@Test
+	void testRangeOnHover() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: trait=quarkus.enabled=true", ".java");
+		
+		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".java"), new Position(0, 14));
+		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
+		
+		assertThat(hover.get().getRange()).isEqualTo(new Range(new Position(0, 12), new Position(0, 17)));
 	}
 	
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineTraitHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineTraitHoverTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.Test;
 
@@ -39,8 +40,20 @@ class CamelKModelineTraitHoverTest extends AbstractCamelLanguageServerTest {
 	}
 	
 	@Test
+	void testRangeForTraitDefinitionOnHover() throws Exception {
+		Hover hover = testHover(20, "The Quarkus trait activates the Quarkus runtime.It's disabled by default.");
+		assertThat(hover.getRange()).isEqualTo(new Range(new Position(0, 18), new Position(0, 25)));
+	}
+	
+	@Test
 	void testProvideDocumentationForTraitPropertyNameOnHover() throws Exception {
 		testHover(28, "Can be used to enable or disable a trait. All traits share this common property.");
+	}
+	
+	@Test
+	void testRangeForTraitPropertyNameOnHover() throws Exception {
+		Hover hover = testHover(28, "Can be used to enable or disable a trait. All traits share this common property.");
+		assertThat(hover.getRange()).isEqualTo(new Range(new Position(0, 26), new Position(0, 33)));
 	}
 	
 	@Test
@@ -76,13 +89,14 @@ class CamelKModelineTraitHoverTest extends AbstractCamelLanguageServerTest {
 		assertThat(hover.get()).isNull();
 	}
 	
-	private void testHover(int positionInLine, String expectedHoverContent)
+	private Hover testHover(int positionInLine, String expectedHoverContent)
 			throws URISyntaxException, InterruptedException, ExecutionException {
 		CamelLanguageServer camelLanguageServer = initializeLanguageServer("// camel-k: trait=quarkus.enabled=true", ".java");
 		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".java"), new Position(0, positionInLine));
 		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
 		
 		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo(expectedHoverContent);
+		return hover.get();
 	}
 	
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelLanguageServerHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelLanguageServerHoverTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +41,16 @@ class CamelLanguageServerHoverTest extends AbstractCamelLanguageServerTest {
 		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
 		
 		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo(AHC_DOCUMENTATION);
+	}
+	
+	@Test
+	void testRangeForCamelComponentOnHover() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("<from uri=\"ahc:httpUri\" xmlns=\"http://camel.apache.org/schema/spring\"></from>\n");
+		
+		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".xml"), new Position(0, 13));
+		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
+		
+		assertThat(hover.get().getRange()).isEqualTo(new Range(new Position(0, 11), new Position(0, 14)));
 	}
 	
 	@Test
@@ -116,6 +127,16 @@ class CamelLanguageServerHoverTest extends AbstractCamelLanguageServerTest {
 		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
 		
 		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo(FILE_FILTER_DOCUMENTATION);		
+	}
+	
+	@Test
+	void testRangeForParameterOnHover() throws Exception {
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer("<from uri=\"file:bla?filter=test\" xmlns=\"http://camel.apache.org/schema/spring\"></from>\n");
+		
+		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".xml"), new Position(0, 26));
+		CompletableFuture<Hover> hover = camelLanguageServer.getTextDocumentService().hover(hoverParams);
+		
+		assertThat(hover.get().getRange()).isEqualTo(new Range(new Position(0, 20), new Position(0, 26)));		
 	}
 	
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,14 @@ class CamelPropertiesFileHoverTest extends AbstractCamelLanguageServerTest {
 	}
 	
 	@Test
+	void testRangeHoverOnCamelComponentOptions() throws Exception {
+		String propertyEntry = "camel.component.acomponent.aComponentProperty=true";
+		CompletableFuture<Hover> hover = getHover(propertyEntry, 29);
+		
+		assertThat(hover.get().getRange()).isEqualTo(new Range(new Position(0, 27), new Position(0, 45)));
+	}
+	
+	@Test
 	void testHoverOnCamelComponentOptionsWithDashedNames() throws Exception {
 		String propertyEntry = "camel.component.acomponent.a-component-property=true";
 		CompletableFuture<Hover> hover = getHover(propertyEntry, 29);
@@ -74,6 +83,14 @@ class CamelPropertiesFileHoverTest extends AbstractCamelLanguageServerTest {
 		CompletableFuture<Hover> hover = getHover(propertyEntry, 17);
 		
 		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("Description of my component.");
+	}
+	
+	@Test
+	void testRangeHoverOnCamelComponentNames() throws Exception {
+		String propertyEntry = "camel.component.acomponent.aComponentProperty=true";
+		CompletableFuture<Hover> hover = getHover(propertyEntry, 17);
+		
+		assertThat(hover.get().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 26)));
 	}
 	
 	@Test


### PR DESCRIPTION
- it ensures clients to correctly updates the tooltip when several
language servers are contributing hovers on the same parts. (especially
Eclipse Desktop)
- it potentially avoids recalling the language server by the client when
the hover for the range was already provided.

on master without this PR:
![wrongTooltip](https://user-images.githubusercontent.com/1105127/95303963-32727800-0884-11eb-85f9-7edaf0ea9136.gif)
with this PR:
![correctlyUpdatedTooltip](https://user-images.githubusercontent.com/1105127/95303972-34d4d200-0884-11eb-844d-22fe0e9f849c.gif)
