### PR TITLE
FUSETOOLS2-774 - provide completion for connector.class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 		<junit.version>5.7.0</junit.version>
 		<assertj.version>3.17.2</assertj.version>
 		<camel.version>3.5.0</camel.version>
+		<camel.kafka.connector.version>0.6.0-SNAPSHOT</camel.kafka.connector.version>
 		<roaster.version>2.21.1.Final</roaster.version>
 		<awaitility.version>4.0.3</awaitility.version>
 		<tyrus.version>1.17</tyrus.version>
@@ -240,6 +241,11 @@
 			<version>${camel.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.camel.kafkaconnector</groupId>
+			<artifactId>camel-kafka-connector-catalog</artifactId>
+			<version>${camel.kafka.connector.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-route-parser</artifactId>
 			<version>${camel.version}</version>
@@ -288,4 +294,15 @@
 			<version>${commons-text.version}</version>
 		</dependency>
 	</dependencies>
+	
+	<repositories>
+		<repository>
+			<id>apache.snapshots</id>
+			<url>https://repository.apache.org/content/repositories/snapshots</url>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
+import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
+import org.eclipse.lsp4j.CompletionItem;
+
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyValueInstance;
+
+public class CamelKafkaConnectorClassCompletionProcessor {
+	
+	private static CamelKafkaConnectorCatalog catalog = new CamelKafkaConnectorCatalog();
+
+	private CamelPropertyValueInstance camelPropertyValueInstance;
+
+	public CamelKafkaConnectorClassCompletionProcessor(CamelPropertyValueInstance camelPropertyValueInstance) {
+		this.camelPropertyValueInstance = camelPropertyValueInstance;
+	}
+
+	public CompletableFuture<List<CompletionItem>> getCompletions(String startFilter) {
+		Collection<CamelKafkaConnectorModel> camelKafkaConnectors = catalog.getConnectorsModel().values();
+		List<CompletionItem> completions = camelKafkaConnectors.stream()
+				.map(camelKafkaConnector -> {
+					CompletionItem completionItem = new CompletionItem(camelKafkaConnector.getConnectorClass());
+					CompletionResolverUtils.applyTextEditToCompletionItem(camelPropertyValueInstance, completionItem);
+					return completionItem;
+				})
+				.filter(FilterPredicateUtils.matchesCompletionFilter(startFilter))
+				.collect(Collectors.toList());
+		
+		return CompletableFuture.completedFuture(completions);
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -26,6 +26,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.completion.CamelComponentOptionValuesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
+import com.github.cameltooling.lsp.internal.completion.CamelKafkaConnectorClassCompletionProcessor;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
 
@@ -48,8 +49,12 @@ public class CamelPropertyValueInstance implements ILineRangeDefineable {
 	}
 
 	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
-		if (new CamelKafkaUtil().isCamelURIForKafka(key.getCamelPropertyKey())) {
+		String propertyKey = key.getCamelPropertyKey();
+		if (new CamelKafkaUtil().isCamelURIForKafka(propertyKey)) {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position);
+		} else if (new CamelKafkaUtil().isConnectorClassForCamelKafkaConnector(propertyKey)) {
+			String startFilter = camelPropertyValue.substring(0, position.getCharacter() - key.getEndposition() -1);
+			return new CamelKafkaConnectorClassCompletionProcessor(this).getCompletions(startFilter);
 		} else {
 			String startFilter = camelPropertyValue.substring(0, position.getCharacter() - key.getEndposition() -1);
 			return camelCatalog.thenApply(new CamelComponentOptionValuesCompletionsFuture(this, startFilter));

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -53,12 +53,16 @@ public class CamelPropertyValueInstance implements ILineRangeDefineable {
 		if (new CamelKafkaUtil().isCamelURIForKafka(propertyKey)) {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position);
 		} else if (new CamelKafkaUtil().isConnectorClassForCamelKafkaConnector(propertyKey)) {
-			String startFilter = camelPropertyValue.substring(0, position.getCharacter() - key.getEndposition() -1);
+			String startFilter = computeStartFilter(position);
 			return new CamelKafkaConnectorClassCompletionProcessor(this).getCompletions(startFilter);
 		} else {
-			String startFilter = camelPropertyValue.substring(0, position.getCharacter() - key.getEndposition() -1);
+			String startFilter = computeStartFilter(position);
 			return camelCatalog.thenApply(new CamelComponentOptionValuesCompletionsFuture(this, startFilter));
 		}
+	}
+
+	private String computeStartFilter(Position position) {
+		return camelPropertyValue.substring(0, position.getCharacter() - key.getEndposition() -1);
 	}
 
 	public String getCamelPropertyFileValue() {

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaUtil.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaUtil.java
@@ -20,6 +20,7 @@ public class CamelKafkaUtil {
 
 	public static final String CAMEL_SINK_URL = "camel.sink.url";
 	public static final String CAMEL_SOURCE_URL = "camel.source.url";
+	public static final String CONNECTOR_CLASS = "connector.class";
 	
 	public boolean isCamelURIForKafka(String propertyKey) {
 		return CamelKafkaUtil.CAMEL_SINK_URL.equals(propertyKey)
@@ -29,6 +30,10 @@ public class CamelKafkaUtil {
 	public boolean isInsideACamelUri(String line, int characterPosition) {
 		return line.startsWith(CamelKafkaUtil.CAMEL_SOURCE_URL) && CamelKafkaUtil.CAMEL_SOURCE_URL.length() < characterPosition 
 				|| line.startsWith(CamelKafkaUtil.CAMEL_SINK_URL) && CamelKafkaUtil.CAMEL_SINK_URL.length() < characterPosition;
+	}
+
+	public boolean isConnectorClassForCamelKafkaConnector(String propertyKey) {
+		return CONNECTOR_CLASS.equals(propertyKey);
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorClassCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorClassCompletionTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.camelapplicationproperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class CamelKafkaConnectorClassCompletionTest extends AbstractCamelLanguageServerTest {
+
+	@Test
+	void testProvideCompletion() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 16), "connector.class=");
+		
+		List<CompletionItem> completionItems = completions.get().getLeft();
+		String connectorClassName = "org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector";
+		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getLabel())).findAny().get();
+		assertThat(completionItem.getTextEdit().getNewText()).isEqualTo(connectorClassName);
+		assertThat(completionItem.getTextEdit().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 16)));
+	}
+	
+	@Test
+	void testFilterCompletion() throws Exception {
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 70), "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector");
+		
+		List<CompletionItem> completionItems = completions.get().getLeft();
+		assertThat(completionItems).hasSize(2);
+		String connectorClassName = "org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector";
+		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getLabel())).findAny().get();
+		assertThat(completionItem.getTextEdit().getNewText()).isEqualTo(connectorClassName);
+		assertThat(completionItem.getTextEdit().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 83)));
+	}
+	
+	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position, String text) throws URISyntaxException, InterruptedException, ExecutionException {
+		String fileName = "a.properties";
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, text));
+		return getCompletionFor(camelLanguageServer, position, fileName);
+	}
+}


### PR DESCRIPTION
which is a specific Camel Kafka Connector property.
This is the first completion relying on the Camel Kafka Connector
Catalog.
Currently using a snapshot version as it is not part of a released
version

![connectorClassCompletion](https://user-images.githubusercontent.com/1105127/95568197-3b9a4b00-0a24-11eb-94d7-8df49db3940c.gif)


--> ~need to wait for Camel kafka Connector artifact to be published on Apache Snapshot repository (nightly build)~ done
--> Are we fine to use a snapshot version? or we wait fo ra release? if using snapshots, it will allow to go further more easily on other tasks related to Camel Kafka Connector. Other possibilities are to have a myriad of other PR or to create a feature branch (but needs to check how to setup the CI  for that). Or we can also wait for an official release for goign further (no date planned as far as I know)