### PR TITLE
FUSETOOLS2-670 - Provide completion for Camel Sink properties

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -53,7 +53,7 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 			camelPropertyFileKeyInstanceString = line;
 			camelPropertyFileValueInstanceString = null;
 		}
-		camelPropertyKeyInstance = new CamelPropertyKeyInstance(camelPropertyFileKeyInstanceString, this);
+		camelPropertyKeyInstance = new CamelPropertyKeyInstance(camelPropertyFileKeyInstanceString, this, textDocumentItem);
 		camelPropertyValueInstance = new CamelPropertyValueInstance(camelPropertyFileValueInstanceString, camelPropertyKeyInstance, textDocumentItem);
 	}
 	

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextEdit;
 
 import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
@@ -44,17 +45,21 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 	
 	static final String CAMEL_KEY_PREFIX = "camel.";
 	static final String CAMEL_COMPONENT_KEY_PREFIX = "camel.component.";
+	static final String CAMEL_SINK_KEY_PREFIX = "camel.sink.";
 	
 	private String camelPropertyKey;
 	private CamelGroupPropertyKey propertyGroup;
 	private CamelComponentPropertyKey camelComponentPropertyKey;
 	private CamelPropertyEntryInstance camelPropertyEntryInstance;
+	private CamelSinkPropertyKey camelSinkPropertyKey;
 
-	public CamelPropertyKeyInstance(String camelPropertyFileKey, CamelPropertyEntryInstance camelPropertyEntryInstance) {
+	public CamelPropertyKeyInstance(String camelPropertyFileKey, CamelPropertyEntryInstance camelPropertyEntryInstance, TextDocumentItem textDocumentItem) {
 		this.camelPropertyKey = camelPropertyFileKey;
 		this.camelPropertyEntryInstance = camelPropertyEntryInstance;
 		if (camelPropertyFileKey.startsWith(CAMEL_COMPONENT_KEY_PREFIX)) {
 			camelComponentPropertyKey = new CamelComponentPropertyKey(camelPropertyFileKey.substring(CAMEL_COMPONENT_KEY_PREFIX.length()), this);
+		} else if(camelPropertyFileKey.startsWith(CAMEL_SINK_KEY_PREFIX)) {
+			camelSinkPropertyKey = new CamelSinkPropertyKey(camelPropertyFileKey.substring(CAMEL_SINK_KEY_PREFIX.length()), this, textDocumentItem);
 		}
 		if(camelPropertyKey.startsWith(CAMEL_KEY_PREFIX)) {
 			propertyGroup = new CamelGroupPropertyKey(camelPropertyFileKey.substring(CAMEL_KEY_PREFIX.length()), this);
@@ -78,6 +83,8 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 			return getTopLevelCamelCompletion(camelCatalog, indexOfSecondDot, position.getCharacter());
 		} else if(camelComponentPropertyKey != null && camelComponentPropertyKey.isInRange(position.getCharacter())) {
 			return camelComponentPropertyKey.getCompletions(position, camelCatalog);
+		} else if(camelSinkPropertyKey != null && camelSinkPropertyKey.isInRange(position.getCharacter())) {
+			return camelSinkPropertyKey.getCompletions(position);
 		} else if(propertyGroup != null && propertyGroup.isInRange(position.getCharacter())) {
 			return propertyGroup.getCompletions(position, camelCatalog);
 		}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkPropertyKey.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
+import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
+import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
+import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
+
+/**
+ * Represents the subpart of the key after camel.sink.
+ * For instance, with "camel.sink.timer.delay=1000",
+ * it is used to represents "timer.delay"
+ * 
+ */
+public class CamelSinkPropertyKey implements ILineRangeDefineable {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(CamelSinkPropertyKey.class);
+
+	private static CamelKafkaConnectorCatalog catalog = new CamelKafkaConnectorCatalog();
+	
+	private String sinkParameter;
+	private CamelPropertyKeyInstance camelPropertyKeyInstance;
+	private String connectorClass;
+
+	public CamelSinkPropertyKey(String sinkParameter, CamelPropertyKeyInstance camelPropertyKeyInstance, TextDocumentItem textDocumentItem) {
+		this.sinkParameter = sinkParameter;
+		this.camelPropertyKeyInstance = camelPropertyKeyInstance;
+		this.connectorClass = findConnectorClass(textDocumentItem);
+	}
+
+	private String findConnectorClass(TextDocumentItem textDocumentItem) {
+		Properties properties = new Properties();
+		try {
+			properties.load(new ByteArrayInputStream(textDocumentItem.getText().getBytes()));
+			Object connectorClassValue = properties.get("connector.class");
+			if (connectorClassValue != null) {
+				return connectorClassValue.toString();
+			}
+		} catch (IOException e) {
+			LOGGER.error("Cannot load Properties file to search for 'connector.class' property value.", e);
+		}
+		return null;
+	}
+
+	@Override
+	public int getLine() {
+		return camelPropertyKeyInstance.getLine();
+	}
+
+	@Override
+	public int getStartPositionInLine() {
+		return camelPropertyKeyInstance.getStartPositionInLine() + CamelPropertyKeyInstance.CAMEL_SINK_KEY_PREFIX.length();
+	}
+
+	@Override
+	public int getEndPositionInLine() {
+		return getStartPositionInLine() + sinkParameter.length();
+	}
+	
+	public boolean isInRange(int positionChar) {
+		return getStartPositionInLine() <= positionChar
+				&& positionChar <= sinkParameter.length() + getStartPositionInLine();
+	}
+
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
+		if (connectorClass != null) {
+			Optional<CamelKafkaConnectorModel> camelKafkaConnectorModel = findConnectorModel();
+			if (camelKafkaConnectorModel.isPresent()) {
+				String filterString = sinkParameter.substring(0, position.getCharacter() - getStartPositionInLine());
+				List<CompletionItem> completions = camelKafkaConnectorModel.get()
+						.getOptions()
+						.stream()
+						.filter(option -> option.getName().startsWith(CamelPropertyKeyInstance.CAMEL_SINK_KEY_PREFIX))
+						.map(option -> {
+							CompletionItem completionItem = new CompletionItem(option.getName().replace(CamelPropertyKeyInstance.CAMEL_SINK_KEY_PREFIX, ""));
+							CompletionResolverUtils.applyTextEditToCompletionItem(this, completionItem);
+							completionItem.setDocumentation(option.getDescription());
+							return completionItem;
+						})
+						.filter(FilterPredicateUtils.matchesCompletionFilter(filterString))
+						.collect(Collectors.toList());
+				return CompletableFuture.completedFuture(completions);
+			}
+		}
+		return CompletableFuture.completedFuture(Collections.emptyList());
+	}
+
+	private Optional<CamelKafkaConnectorModel> findConnectorModel() {
+		return catalog.getConnectorsModel()
+				.values()
+				.stream()
+				.filter(connector -> connectorClass.equals(connector.getConnectorClass()))
+				.findAny();
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSinkPropertyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSinkPropertyCompletionTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.camelapplicationproperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class CamelKafkaCamelSinkPropertyCompletionTest extends AbstractCamelLanguageServerTest {
+
+	@Test
+	void testCompletion() throws Exception {
+		String text = "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector\n"
+					+ "camel.sink.";
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 11)).get().getLeft();
+		Optional<CompletionItem> optionCompletion = completions.stream().filter(completion -> "path.destinationType".equals(completion.getLabel())).findAny();
+		assertThat(optionCompletion).isPresent();
+		assertThat(optionCompletion.get().getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 11), new Position(1, 11)));
+	}
+	
+	@Test
+	void testCompletionWithStartedValue() throws Exception {
+		String text = "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector\n"
+					+ "camel.sink.pat";
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 13)).get().getLeft();
+		assertThat(completions).hasSize(2);
+		assertThat(completions.get(0).getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 11), new Position(1, 14)));
+	}
+	
+	@Test
+	void testNoCompletionWithNoConnectorClass() throws Exception {
+		String text = "camel.sink.";
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 11)).get().getLeft();
+		assertThat(completions).isEmpty();
+	}
+	
+	@Test
+	void testNoCompletionWithUnkownConnectorClass() throws Exception {
+		String text = "connector.class=unknown\n"
+					+ "camel.sink.";
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 11)).get().getLeft();
+		assertThat(completions).isEmpty();
+	}
+	
+}


### PR DESCRIPTION
user needs to type camel.sink. and the connector.class property value
must be provided and part of the Catalog.

![Screenshot from 2020-10-13 15-57-23](https://user-images.githubusercontent.com/1105127/95870884-50047d80-0d6d-11eb-96be-35a45c84ed33.png)

Should come soon in next Pull Requests:
- same for camel.source
- a centralized Camel Kafka Connector Catalog to factorize code and test
more easily


