### PR TITLE
FUSETOOLS2-788 - use a single instance of CamelKafkaConnector by Camel Language Server instance

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -68,6 +68,7 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.codeactions.InvalidEnumQuickfix;
 import com.github.cameltooling.lsp.internal.codeactions.UnknownPropertyQuickfix;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
@@ -94,6 +95,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 	private Map<String, TextDocumentItem> openedDocuments = new HashMap<>();
 	private CompletableFuture<CamelCatalog> camelCatalog;
 	private CamelLanguageServer camelLanguageServer;
+	private CamelKafkaConnectorCatalogManager camelKafkaConnectorManager = new CamelKafkaConnectorCatalogManager();
 
 	public CamelTextDocumentService(CamelLanguageServer camelLanguageServer) {
 		this.camelLanguageServer = camelLanguageServer;
@@ -129,7 +131,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 		LOGGER.info("completion: {}", uri);
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
 		if (uri.endsWith(".properties")){
-			return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+			return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		} else if(isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
 			return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		} else {
@@ -295,5 +297,13 @@ public class CamelTextDocumentService implements TextDocumentService {
 	 */
 	public CompletableFuture<CamelCatalog> getCamelCatalog() {
 		return camelCatalog;
+	}
+
+	public CamelKafkaConnectorCatalogManager getCamelKafkaConnectorManager() {
+		return camelKafkaConnectorManager;
+	}
+
+	public void setCamelKafkaConnectorManager(CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
+		this.camelKafkaConnectorManager = camelKafkaConnectorManager;
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/CamelKafkaConnectorCatalogManager.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/CamelKafkaConnectorCatalogManager.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.catalog.util;
+
+import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
+
+public class CamelKafkaConnectorCatalogManager {
+	
+	private CamelKafkaConnectorCatalog catalog = new CamelKafkaConnectorCatalog();
+		
+	public CamelKafkaConnectorCatalog getCatalog() {
+		return catalog;
+	}
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
@@ -21,24 +21,24 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
 import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
 import org.eclipse.lsp4j.CompletionItem;
 
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyValueInstance;
 
 public class CamelKafkaConnectorClassCompletionProcessor {
-	
-	private static CamelKafkaConnectorCatalog catalog = new CamelKafkaConnectorCatalog();
 
 	private CamelPropertyValueInstance camelPropertyValueInstance;
+	private CamelKafkaConnectorCatalogManager camelKafkaConnectorManager;
 
-	public CamelKafkaConnectorClassCompletionProcessor(CamelPropertyValueInstance camelPropertyValueInstance) {
+	public CamelKafkaConnectorClassCompletionProcessor(CamelPropertyValueInstance camelPropertyValueInstance, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
 		this.camelPropertyValueInstance = camelPropertyValueInstance;
+		this.camelKafkaConnectorManager = camelKafkaConnectorManager;
 	}
 
 	public CompletableFuture<List<CompletionItem>> getCompletions(String startFilter) {
-		Collection<CamelKafkaConnectorModel> camelKafkaConnectors = catalog.getConnectorsModel().values();
+		Collection<CamelKafkaConnectorModel> camelKafkaConnectors = camelKafkaConnectorManager.getCatalog().getConnectorsModel().values();
 		List<CompletionItem> completions = camelKafkaConnectors.stream()
 				.map(camelKafkaConnector -> {
 					CompletionItem completionItem = new CompletionItem(camelKafkaConnector.getConnectorClass());

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyEntryInstance;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 
@@ -32,16 +33,18 @@ public class CamelPropertiesCompletionProcessor {
 
 	private TextDocumentItem textDocumentItem;
 	private CompletableFuture<CamelCatalog> camelCatalog;
+	private CamelKafkaConnectorCatalogManager camelKafkaConnectorManager;
 
-	public CamelPropertiesCompletionProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog) {
+	public CamelPropertiesCompletionProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
 		this.textDocumentItem = textDocumentItem;
 		this.camelCatalog = camelCatalog;
+		this.camelKafkaConnectorManager = camelKafkaConnectorManager;
 	}
 
 	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
 		if (textDocumentItem != null) {
 			String line = new ParserFileHelperUtil().getLine(textDocumentItem, position);
-			return new CamelPropertyEntryInstance(line, new Position(position.getLine(), 0), textDocumentItem).getCompletions(position, camelCatalog);
+			return new CamelPropertyEntryInstance(line, new Position(position.getLine(), 0), textDocumentItem).getCompletions(position, camelCatalog, camelKafkaConnectorManager);
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 
 /**
@@ -57,12 +58,16 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 		camelPropertyValueInstance = new CamelPropertyValueInstance(camelPropertyFileValueInstanceString, camelPropertyKeyInstance, textDocumentItem);
 	}
 	
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
-		if (position.getCharacter() <= camelPropertyKeyInstance.getEndposition()) {
-			return camelPropertyKeyInstance.getCompletions(position, camelCatalog);
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
+		if (isOnPropertyKey(position)) {
+			return camelPropertyKeyInstance.getCompletions(position, camelCatalog, camelKafkaConnectorManager);
 		} else {
-			return camelPropertyValueInstance.getCompletions(position, camelCatalog);
+			return camelPropertyValueInstance.getCompletions(position, camelCatalog, camelKafkaConnectorManager);
 		}
+	}
+
+	private boolean isOnPropertyKey(Position position) {
+		return position.getCharacter() <= camelPropertyKeyInstance.getEndposition();
 	}
 	
 	CamelPropertyKeyInstance getCamelPropertyKeyInstance() {
@@ -88,7 +93,7 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 	}
 
 	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
-		if (position.getCharacter() <= camelPropertyKeyInstance.getEndposition()) {
+		if (isOnPropertyKey(position)) {
 			return camelPropertyKeyInstance.getHover(position, camelCatalog);
 		} else {
 			return CompletableFuture.completedFuture(null);

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -31,6 +31,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextEdit;
 
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 import com.google.gson.Gson;
@@ -73,7 +74,7 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 		return camelPropertyEntryInstance.getStartPositionInLine() + camelPropertyKey.length();
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
 		int indexOfFirstDot = camelPropertyKey.indexOf('.');
 		int indexOfSecondDot = indexOfFirstDot != -1 ? camelPropertyKey.indexOf('.', indexOfFirstDot + 1) : -1;
 		if(isBeforeFirstDot(position, indexOfFirstDot)) {
@@ -87,7 +88,7 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 		} else if(camelComponentPropertyKey != null && camelComponentPropertyKey.isInRange(position.getCharacter())) {
 			return camelComponentPropertyKey.getCompletions(position, camelCatalog);
 		} else if(camelSinkPropertyKey != null && camelSinkPropertyKey.isInRange(position.getCharacter())) {
-			return camelSinkPropertyKey.getCompletions(position);
+			return camelSinkPropertyKey.getCompletions(position, camelKafkaConnectorManager);
 		} else if(propertyGroup != null && propertyGroup.isInRange(position.getCharacter())) {
 			return propertyGroup.getCompletions(position, camelCatalog);
 		}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelComponentOptionValuesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelKafkaConnectorClassCompletionProcessor;
@@ -48,13 +49,13 @@ public class CamelPropertyValueInstance implements ILineRangeDefineable {
 		this.textDocumentItem = textDocumentItem;
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
 		String propertyKey = key.getCamelPropertyKey();
 		if (new CamelKafkaUtil().isCamelURIForKafka(propertyKey)) {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position);
 		} else if (new CamelKafkaUtil().isConnectorClassForCamelKafkaConnector(propertyKey)) {
 			String startFilter = computeStartFilter(position);
-			return new CamelKafkaConnectorClassCompletionProcessor(this).getCompletions(startFilter);
+			return new CamelKafkaConnectorClassCompletionProcessor(this, camelKafkaConnectorManager).getCompletions(startFilter);
 		} else {
 			String startFilter = computeStartFilter(position);
 			return camelCatalog.thenApply(new CamelComponentOptionValuesCompletionsFuture(this, startFilter));

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
@@ -25,7 +25,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
 import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
@@ -33,6 +32,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
 import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
@@ -46,8 +46,6 @@ import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
 	
 	private static final Logger LOGGER = LoggerFactory.getLogger(CamelSinkOrSourcePropertyKey.class);
-
-	private static CamelKafkaConnectorCatalog catalog = new CamelKafkaConnectorCatalog();
 	
 	private String optionKey;
 	private CamelPropertyKeyInstance camelPropertyKeyInstance;
@@ -99,9 +97,9 @@ public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
 				&& positionChar <= optionKey.length() + getStartPositionInLine();
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
 		if (connectorClass != null) {
-			Optional<CamelKafkaConnectorModel> camelKafkaConnectorModel = findConnectorModel();
+			Optional<CamelKafkaConnectorModel> camelKafkaConnectorModel = findConnectorModel(camelKafkaConnectorManager);
 			if (camelKafkaConnectorModel.isPresent()) {
 				String filterString = optionKey.substring(0, position.getCharacter() - getStartPositionInLine());
 				List<CompletionItem> completions = camelKafkaConnectorModel.get()
@@ -122,8 +120,8 @@ public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
-	private Optional<CamelKafkaConnectorModel> findConnectorModel() {
-		return catalog.getConnectorsModel()
+	private Optional<CamelKafkaConnectorModel> findConnectorModel(CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
+		return camelKafkaConnectorManager.getCatalog().getConnectorsModel()
 				.values()
 				.stream()
 				.filter(connector -> connectorClass.equals(connector.getConnectorClass()))

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
@@ -56,7 +56,7 @@ public class CamelKModelinePropertyOption implements ICamelKModelineOptionValue 
 	
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(int positionInLine, CompletableFuture<CamelCatalog> camelCatalog) {
-		return value.getCompletions(new Position(0, positionInLine), camelCatalog);
+		return value.getCompletions(new Position(0, positionInLine), camelCatalog, null);
 	}
 	
 	@Override

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/AbstractCamelKafkaConnectorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/AbstractCamelKafkaConnectorTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.camelapplicationproperties;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+public abstract class AbstractCamelKafkaConnectorTest extends AbstractCamelLanguageServerTest {
+
+	@Override
+	protected CamelLanguageServer initializeLanguageServer(String text)
+			throws URISyntaxException, InterruptedException, ExecutionException {
+		CamelLanguageServer languageServer = super.initializeLanguageServer(text, ".properties");
+		CamelKafkaConnectorCatalog catalog = languageServer.getTextDocumentService().getCamelKafkaConnectorManager().getCatalog();
+		catalog.addConnector("connector-source-used-for-test", getContentAsString("/camel-kafka-connector-catalog/connector-source-used-for-test.json"));
+		catalog.addConnector("connector-sink-used-for-test", getContentAsString("/camel-kafka-connector-catalog/connector-sink-used-for-test.json"));
+		return languageServer;
+	}
+
+	private String getContentAsString(String pathInBundle) {
+		return new BufferedReader(new InputStreamReader(AbstractCamelKafkaConnectorTest.class.getResourceAsStream(pathInBundle), StandardCharsets.UTF_8))
+				.lines()
+				.map(String::trim)
+				.collect(Collectors.joining());
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSinkPropertyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSinkPropertyCompletionTest.java
@@ -26,27 +26,26 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
-class CamelKafkaCamelSinkPropertyCompletionTest extends AbstractCamelLanguageServerTest {
+class CamelKafkaCamelSinkPropertyCompletionTest extends AbstractCamelKafkaConnectorTest {
 
 	@Test
 	void testCompletion() throws Exception {
-		String text = "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector\n"
+		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
 					+ "camel.sink.";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 11)).get().getLeft();
-		Optional<CompletionItem> optionCompletion = completions.stream().filter(completion -> "path.destinationType".equals(completion.getLabel())).findAny();
+		Optional<CompletionItem> optionCompletion = completions.stream().filter(completion -> "path.aMediumPathOption".equals(completion.getLabel())).findAny();
 		assertThat(optionCompletion).isPresent();
 		assertThat(optionCompletion.get().getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 11), new Position(1, 11)));
 	}
 	
 	@Test
 	void testCompletionWithStartedValue() throws Exception {
-		String text = "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector\n"
+		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
 					+ "camel.sink.pat";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 13)).get().getLeft();
 		assertThat(completions).hasSize(2);
 		assertThat(completions.get(0).getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 11), new Position(1, 14)));
@@ -55,7 +54,7 @@ class CamelKafkaCamelSinkPropertyCompletionTest extends AbstractCamelLanguageSer
 	@Test
 	void testNoCompletionWithNoConnectorClass() throws Exception {
 		String text = "camel.sink.";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 11)).get().getLeft();
 		assertThat(completions).isEmpty();
 	}
@@ -64,7 +63,7 @@ class CamelKafkaCamelSinkPropertyCompletionTest extends AbstractCamelLanguageSer
 	void testNoCompletionWithUnkownConnectorClass() throws Exception {
 		String text = "connector.class=unknown\n"
 					+ "camel.sink.";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 11)).get().getLeft();
 		assertThat(completions).isEmpty();
 	}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSourcePropertyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSourcePropertyCompletionTest.java
@@ -26,27 +26,26 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
-class CamelKafkaCamelSourcePropertyCompletionTest extends AbstractCamelLanguageServerTest {
+class CamelKafkaCamelSourcePropertyCompletionTest extends AbstractCamelKafkaConnectorTest {
 
 	@Test
 	void testCompletion() throws Exception {
-		String text = "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSourceConnector\n"
+		String text = "connector.class=org.test.kafkaconnector.TestSourceConnector\n"
 					+ "camel.source.";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 13)).get().getLeft();
-		Optional<CompletionItem> optionCompletion = completions.stream().filter(completion -> "path.destinationType".equals(completion.getLabel())).findAny();
+		Optional<CompletionItem> optionCompletion = completions.stream().filter(completion -> "path.aMediumPathOption".equals(completion.getLabel())).findAny();
 		assertThat(optionCompletion).isPresent();
 		assertThat(optionCompletion.get().getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 13), new Position(1, 13)));
 	}
 	
 	@Test
 	void testCompletionWithStartedValue() throws Exception {
-		String text = "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSourceConnector\n"
+		String text = "connector.class=org.test.kafkaconnector.TestSourceConnector\n"
 					+ "camel.source.pat";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 15)).get().getLeft();
 		assertThat(completions).hasSize(2);
 		assertThat(completions.get(0).getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 13), new Position(1, 16)));
@@ -55,7 +54,7 @@ class CamelKafkaCamelSourcePropertyCompletionTest extends AbstractCamelLanguageS
 	@Test
 	void testNoCompletionWithNoConnectorClass() throws Exception {
 		String text = "camel.source.";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 13)).get().getLeft();
 		assertThat(completions).isEmpty();
 	}
@@ -64,7 +63,7 @@ class CamelKafkaCamelSourcePropertyCompletionTest extends AbstractCamelLanguageS
 	void testNoCompletionWithUnkownConnectorClass() throws Exception {
 		String text = "connector.class=unknown\n"
 					+ "camel.source.";
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".properties");
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 13)).get().getLeft();
 		assertThat(completions).isEmpty();
 	}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorClassCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorClassCompletionTest.java
@@ -27,21 +27,19 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
-class CamelKafkaConnectorClassCompletionTest extends AbstractCamelLanguageServerTest {
+class CamelKafkaConnectorClassCompletionTest extends AbstractCamelKafkaConnectorTest {
 
 	@Test
 	void testProvideCompletion() throws Exception {
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 16), "connector.class=");
 		
 		List<CompletionItem> completionItems = completions.get().getLeft();
-		String connectorClassName = "org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector";
+		String connectorClassName = "org.test.kafkaconnector.TestSourceConnector";
 		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getLabel())).findAny().get();
 		assertThat(completionItem.getTextEdit().getNewText()).isEqualTo(connectorClassName);
 		assertThat(completionItem.getTextEdit().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 16)));
@@ -49,19 +47,18 @@ class CamelKafkaConnectorClassCompletionTest extends AbstractCamelLanguageServer
 	
 	@Test
 	void testFilterCompletion() throws Exception {
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 70), "connector.class=org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector");
+		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = retrieveCompletion(new Position(0, 44), "connector.class=org.test.kafkaconnector.TestSinkConnector");
 		
 		List<CompletionItem> completionItems = completions.get().getLeft();
 		assertThat(completionItems).hasSize(2);
-		String connectorClassName = "org.apache.camel.kafkaconnector.activemq.CamelActivemqSinkConnector";
+		String connectorClassName = "org.test.kafkaconnector.TestSinkConnector";
 		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getLabel())).findAny().get();
 		assertThat(completionItem.getTextEdit().getNewText()).isEqualTo(connectorClassName);
-		assertThat(completionItem.getTextEdit().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 83)));
+		assertThat(completionItem.getTextEdit().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 57)));
 	}
 	
 	protected CompletableFuture<Either<List<CompletionItem>, CompletionList>> retrieveCompletion(Position position, String text) throws URISyntaxException, InterruptedException, ExecutionException {
-		String fileName = "a.properties";
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer(".properties", new TextDocumentItem(fileName, CamelLanguageServer.LANGUAGE_ID, 0, text));
-		return getCompletionFor(camelLanguageServer, position, fileName);
+		CamelLanguageServer camelLanguageServer = initializeLanguageServer(text);
+		return getCompletionFor(camelLanguageServer, position);
 	}
 }

--- a/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
+++ b/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
@@ -1,0 +1,48 @@
+{
+	"connector": {
+		"class": "org.test.kafkaconnector.TestSinkConnector",
+		"artifactId": "camel-test-kafka-connector",
+		"groupId": "org.test.kafkaconnector",
+		"id": "connector-sink-used-for-test",
+		"type": "sink",
+		"version": "0.6.0-SNAPSHOT"
+	},
+	"properties": {
+		"camel.sink.path.aMediumPathOption": {
+			"name": "camel.sink.path.aMediumPathOption",
+			"description": "Description of camel.sink.path.aMediumPathOption",
+			"defaultValue": "a default value for medium path option",
+			"priority": "MEDIUM"
+		},
+		"camel.sink.path.aHighPathOption": {
+			"name": "camel.sink.path.aHighPathOption",
+			"description": "Description of camel.sink.path.aHighPathOption",
+			"defaultValue": "a default value for high path option",
+			"priority": "HIGH"
+		},
+		"camel.sink.endpoint.aMediumEndpointOption": {
+			"name": "camel.sink.endpoint.aMediumEndpointOption",
+			"description": "Description of camel.sink.endpoint.aMediumEndpointOption",
+			"defaultValue": "null",
+			"priority": "MEDIUM"
+		},
+		"camel.sink.endpoint.aHighEndpointOption": {
+			"name": "camel.sink.endpoint.aHighEndpointOption",
+			"description": "Description of camel.sink.endpoint.aHighComponenttOption",
+			"defaultValue": "null",
+			"priority": "HIGH"
+		},
+		"camel.component.avalue.aMediumComponentOption": {
+			"name": "camel.component.avalue.aMediumComponentOption",
+			"description": "Description of camel.component.avalue.aMediumComponentOption",
+			"defaultValue": "null",
+			"priority": "MEDIUM"
+		},
+		"camel.component.avlue.aHighComponentOption": {
+			"name": "camel.component.avalue.aHighComponentOption",
+			"description": "Description of camel.component.avalue.aHighComponentOption",
+			"defaultValue": "null",
+			"priority": "HIGH"
+		}
+	}
+}

--- a/src/test/resources/camel-kafka-connector-catalog/connector-source-used-for-test.json
+++ b/src/test/resources/camel-kafka-connector-catalog/connector-source-used-for-test.json
@@ -1,0 +1,48 @@
+{
+	"connector": {
+		"class": "org.test.kafkaconnector.TestSourceConnector",
+		"artifactId": "camel-test-kafka-connector",
+		"groupId": "org.test.kafkaconnector",
+		"id": "connector-source-used-for-test",
+		"type": "source",
+		"version": "0.6.0-SNAPSHOT"
+	},
+	"properties": {
+		"camel.source.path.aMediumPathOption": {
+			"name": "camel.source.path.aMediumPathOption",
+			"description": "Description of camel.source.path.aMediumPathOption",
+			"defaultValue": "a default value for medium path option",
+			"priority": "MEDIUM"
+		},
+		"camel.source.path.aHighPathOption": {
+			"name": "camel.source.path.aHighPathOption",
+			"description": "Description of camel.source.path.aHighPathOption",
+			"defaultValue": "a default value for high path option",
+			"priority": "HIGH"
+		},
+		"camel.source.endpoint.aMediumEndpointOption": {
+			"name": "camel.source.endpoint.aMediumEndpointOption",
+			"description": "Description of camel.source.endpoint.aMediumEndpointOption",
+			"defaultValue": "null",
+			"priority": "MEDIUM"
+		},
+		"camel.source.endpoint.aHighEndpointOption": {
+			"name": "camel.source.endpoint.aHighEndpointOption",
+			"description": "Description of camel.source.endpoint.aHighComponenttOption",
+			"defaultValue": "null",
+			"priority": "HIGH"
+		},
+		"camel.component.avalue.aMediumComponentOption": {
+			"name": "camel.component.avalue.aMediumComponentOption",
+			"description": "Description of camel.component.avalue.aMediumComponentOption",
+			"defaultValue": "null",
+			"priority": "MEDIUM"
+		},
+		"camel.component.avlue.aHighComponentOption": {
+			"name": "camel.component.avalue.aHighComponentOption",
+			"description": "Description of camel.component.avalue.aHighComponentOption",
+			"defaultValue": "null",
+			"priority": "HIGH"
+		}
+	}
+}


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-language-server/pull/474 and https://github.com/apache/camel-kafka-connector/pull/588 (and a nightly build after merge of PR)

use a single of CamelKafkaConnectorCatalog

- it allows to have test independent of Catalog version
- it allows to add specific connector in catalog to test more easily
- requirements to allow handle several version of the catalog
- requirements to let users provide their own connector definition
(which requires more work)