### PR TITLE
FUSETOOLS2-686 - completion for converters

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConverterCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConverterCompletionProcessor.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyValueInstance;
+import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
+
+public class CamelKafkaConverterCompletionProcessor {
+
+	private CamelPropertyValueInstance camelPropertyValueInstance;
+	private CamelKafkaConnectorCatalogManager camelKafkaConnectorManager;
+	private TextDocumentItem textDocumentItem;
+
+	public CamelKafkaConverterCompletionProcessor(TextDocumentItem textDocumentItem, CamelPropertyValueInstance camelPropertyValueInstance, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
+		this.textDocumentItem = textDocumentItem;
+		this.camelPropertyValueInstance = camelPropertyValueInstance;
+		this.camelKafkaConnectorManager = camelKafkaConnectorManager;
+	}
+
+	public CompletableFuture<List<CompletionItem>> getCompletions(String startFilter) {
+		String connectorClass = new CamelKafkaUtil().findConnectorClass(textDocumentItem);
+		if (connectorClass != null) {
+			Collection<CamelKafkaConnectorModel> camelKafkaConnectors = camelKafkaConnectorManager.getCatalog().getConnectorsModel().values();
+			Optional<CamelKafkaConnectorModel> model = camelKafkaConnectors.stream()
+					.filter(iteratorModel -> connectorClass.equals(iteratorModel.getConnectorClass()))
+					.findAny();
+			if (model.isPresent()) {
+				List<String> converters = model.get().getConverters();
+				if (converters != null) {
+					List<CompletionItem> completions = converters.stream()
+							.map(converter -> {
+								CompletionItem completionItem = new CompletionItem(converter);
+								CompletionResolverUtils.applyTextEditToCompletionItem(camelPropertyValueInstance, completionItem);
+								return completionItem;
+							}).filter(FilterPredicateUtils.matchesCompletionFilter(startFilter)).collect(Collectors.toList());
+					return CompletableFuture.completedFuture(completions);
+				}
+			}
+		}
+		return CompletableFuture.completedFuture(Collections.emptyList());
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -28,6 +28,7 @@ import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCata
 import com.github.cameltooling.lsp.internal.completion.CamelComponentOptionValuesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelKafkaConnectorClassCompletionProcessor;
+import com.github.cameltooling.lsp.internal.completion.CamelKafkaConverterCompletionProcessor;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
 
@@ -56,6 +57,9 @@ public class CamelPropertyValueInstance implements ILineRangeDefineable {
 		} else if (new CamelKafkaUtil().isConnectorClassForCamelKafkaConnector(propertyKey)) {
 			String startFilter = computeStartFilter(position);
 			return new CamelKafkaConnectorClassCompletionProcessor(this, camelKafkaConnectorManager).getCompletions(startFilter);
+		} else if (new CamelKafkaUtil().isConverterForCamelKafkaConnector(propertyKey)) {
+			String startFilter = computeStartFilter(position);
+			return new CamelKafkaConverterCompletionProcessor(textDocumentItem, this, camelKafkaConnectorManager).getCompletions(startFilter);
 		} else {
 			String startFilter = computeStartFilter(position);
 			return camelCatalog.thenApply(new CamelComponentOptionValuesCompletionsFuture(this, startFilter));

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
@@ -16,12 +16,9 @@
  */
 package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -29,13 +26,12 @@ import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
 import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
+import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
 
 /**
  * Represents the subpart of the key after camel.sink. or camel.source.
@@ -44,9 +40,7 @@ import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
  * 
  */
 public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
-	
-	private static final Logger LOGGER = LoggerFactory.getLogger(CamelSinkOrSourcePropertyKey.class);
-	
+
 	private String optionKey;
 	private CamelPropertyKeyInstance camelPropertyKeyInstance;
 	private String connectorClass;
@@ -55,22 +49,8 @@ public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
 	public CamelSinkOrSourcePropertyKey(String optionKey, CamelPropertyKeyInstance camelPropertyKeyInstance, TextDocumentItem textDocumentItem, String prefix) {
 		this.optionKey = optionKey;
 		this.camelPropertyKeyInstance = camelPropertyKeyInstance;
-		this.connectorClass = findConnectorClass(textDocumentItem);
+		this.connectorClass = new CamelKafkaUtil().findConnectorClass(textDocumentItem);
 		this.prefix = prefix;
-	}
-
-	private String findConnectorClass(TextDocumentItem textDocumentItem) {
-		Properties properties = new Properties();
-		try {
-			properties.load(new ByteArrayInputStream(textDocumentItem.getText().getBytes()));
-			Object connectorClassValue = properties.get("connector.class");
-			if (connectorClassValue != null) {
-				return connectorClassValue.toString();
-			}
-		} catch (IOException e) {
-			LOGGER.error("Cannot load Properties file to search for 'connector.class' property value.", e);
-		}
-		return null;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaUtil.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaUtil.java
@@ -16,11 +16,23 @@
  */
 package com.github.cameltooling.lsp.internal.parser;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class CamelKafkaUtil {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(CamelKafkaUtil.class);
 
 	public static final String CAMEL_SINK_URL = "camel.sink.url";
 	public static final String CAMEL_SOURCE_URL = "camel.source.url";
 	public static final String CONNECTOR_CLASS = "connector.class";
+	public static final String KEY_CONVERTER = "key.converter";
+	public static final String VALUE_CONVERTER = "value.converter";
 	
 	public boolean isCamelURIForKafka(String propertyKey) {
 		return CamelKafkaUtil.CAMEL_SINK_URL.equals(propertyKey)
@@ -34,6 +46,25 @@ public class CamelKafkaUtil {
 
 	public boolean isConnectorClassForCamelKafkaConnector(String propertyKey) {
 		return CONNECTOR_CLASS.equals(propertyKey);
+	}
+
+	public boolean isConverterForCamelKafkaConnector(String propertyKey) {
+		return KEY_CONVERTER.equals(propertyKey)
+				|| VALUE_CONVERTER.equals(propertyKey);
+	}
+	
+	public String findConnectorClass(TextDocumentItem textDocumentItem) {
+		Properties properties = new Properties();
+		try {
+			properties.load(new ByteArrayInputStream(textDocumentItem.getText().getBytes()));
+			Object connectorClassValue = properties.get(CONNECTOR_CLASS);
+			if (connectorClassValue != null) {
+				return connectorClassValue.toString();
+			}
+		} catch (IOException e) {
+			LOGGER.error("Cannot load Properties file to search for 'connector.class' property value.", e);
+		}
+		return null;
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorConverterCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorConverterCompletionTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion.camelapplicationproperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class CamelKafkaConnectorConverterCompletionTest extends AbstractCamelKafkaConnectorTest {
+
+	@Test
+	void testProvideCompletionForValueConverter() throws Exception {
+		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
+					+ "value.converter=";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 16)).get().getLeft();
+		assertThat(completions).hasSize(1);
+	}
+	
+	@Test
+	void testProvideCompletionForPartialItems() throws Exception {
+		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
+					+ "value.converter=org.test";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 22)).get().getLeft();
+		assertThat(completions).hasSize(1);
+		assertThat(completions.get(0).getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 16), new Position(1, 24)));
+	}
+
+	@Test
+	void testProvideCompletionForKeyConverter() throws Exception {
+		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
+					+ "key.converter=";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 14)).get().getLeft();
+		assertThat(completions).hasSize(1);
+	}
+	
+	@Test
+	void testProvideNoCompletionWhenNoConverter() throws Exception {
+		String text = "connector.class=org.test.kafkaconnector.TestSourceConnector\n"
+					+ "value.converter=";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 16)).get().getLeft();
+		assertThat(completions).isEmpty();
+	}
+	
+	@Test
+	void testProvideNoCompletionWhenNoConnectorClass() throws Exception {
+		String text = "value.converter=";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 16)).get().getLeft();
+		assertThat(completions).isEmpty();
+	}
+	
+	@Test
+	void testProvideNoCompletionWithUnknownConnectorClass() throws Exception {
+		String text = "connector.class=unknown\n"
+					+ "value.converter=";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 16)).get().getLeft();
+		assertThat(completions).isEmpty();
+	}
+
+}

--- a/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
+++ b/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
@@ -44,5 +44,8 @@
 			"defaultValue": "null",
 			"priority": "HIGH"
 		}
-	}
+	},
+	"converters": [
+		"org.test.kafkaconnector.converters.TestSinkObjectConverter"
+	]
 }


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-language-server/pull/475

![Screenshot from 2020-10-15 11-36-47](https://user-images.githubusercontent.com/1105127/96105795-b9ee6580-0eda-11eb-89de-ff39a1c2b70e.png)

nota: the completion is not very readable in VS Code. I woudl prefer to handle it in a specific PR https://issues.redhat.com/browse/FUSETOOLS2-801