### PR TITLE
Fusetools2 739 add test for partial route in java for document symbol

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
@@ -225,6 +225,22 @@ class DocumentSymbolProcessorTest extends AbstractCamelLanguageServerTest {
 		assertThat(range.getEnd().getCharacter()).isEqualTo(55);
 	}
 	
+	@Test
+	void testPartialRoute() throws Exception {
+		File f = new File("src/test/resources/workspace/PartialRoute.java");
+		List<Either<SymbolInformation,DocumentSymbol>> documentSymbols = testRetrieveDocumentSymbol(f, 1);
+		
+		List<SymbolInformation> fromSymbolInformations = documentSymbols.stream()
+				.filter(either -> "from file:src/data".equals(either.getLeft().getName()))
+				.map(Either::getLeft)
+				.collect(Collectors.toList());
+		SymbolInformation secondFrom = fromSymbolInformations.get(0);
+		Range range = secondFrom.getLocation().getRange();
+		assertThat(range.getStart().getLine()).isEqualTo(3);
+		assertThat(range.getEnd().getLine()).isEqualTo(3);
+		assertThat(range.getEnd().getCharacter()).isEqualTo(40);
+	}
+	
 	private List<Either<SymbolInformation, DocumentSymbol>> testRetrieveDocumentSymbol(String textTotest, int expectedSize) throws URISyntaxException, InterruptedException, ExecutionException {
 		CamelLanguageServer camelLanguageServer = initializeLanguageServer(textTotest);
 		return testRetrieveDocumentSymbol(expectedSize, camelLanguageServer, DUMMY_URI+".xml");

--- a/src/test/resources/workspace/PartialRoute.java
+++ b/src/test/resources/workspace/PartialRoute.java
@@ -1,0 +1,6 @@
+public class PartialRoute extends RouteBuilder {
+
+    public void configure() {
+        from("file:src/data?noop=true");
+    }
+}


### PR DESCRIPTION
![Screenshot from 2020-10-21 09-12-48](https://user-images.githubusercontent.com/1105127/96685578-9bc2b280-137d-11eb-972b-477e2ce99176.png)
