### PR TITLE
FUSETOOLS2-558 - fix insert and replace when there is no space between

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTest.java
@@ -20,9 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
 
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 
 class CamelKModelineTest {
 	
@@ -62,6 +66,24 @@ class CamelKModelineTest {
 	void testGetNumberOfOptions(String modelineString) throws Exception {
 		CamelKModeline modeline = new CamelKModeline(modelineString, null);
 		assertThat(modeline.getOptions()).hasSize(1);
+	}
+	
+	@Test
+	void testWithXmlCommentWithoutSpaceWhenNoValue() {
+		String modelineText = "<!-- camel-k: dependency=-->";
+		CamelKModeline modeline = new CamelKModeline(modelineText, new TextDocumentItem("dummy.xml", CamelLanguageServer.LANGUAGE_ID, 0, modelineText));
+		int endPositionInLine = modeline.getOptions().get(0).getOptionValue().getEndPositionInLine();
+		assertThat(endPositionInLine).isEqualTo("<!-- camel-k: dependency=".length());
+	}
+	
+	@Test
+	void testWithXmlCommentWithoutSpaceWithValue() {
+		String modelineText = "<!-- camel-k: dependency=test-->";
+		CamelKModeline modeline = new CamelKModeline(modelineText, new TextDocumentItem("dummy.xml", CamelLanguageServer.LANGUAGE_ID, 0, modelineText));
+		ICamelKModelineOptionValue optionValue = modeline.getOptions().get(0).getOptionValue();
+		int endPositionInLine = optionValue.getEndPositionInLine();
+		assertThat(endPositionInLine).isEqualTo("<!-- camel-k: dependency=test".length());
+		assertThat(optionValue.getValueAsString()).isEqualTo("test");
 	}
 
 }


### PR DESCRIPTION
the xml comment tag and the content of Camel k modeline

one noticeable impact is with completion:
![completionWithXmlEndOfLine](https://user-images.githubusercontent.com/1105127/96690782-666d9300-1384-11eb-9535-c007bd60db7d.gif)
