### PR TITLE
FUSETOOLS2-787 - support dashed notation for camel.sink and camel.source

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -102,7 +102,7 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 
 	public boolean shouldUseDashedCase() {
 		return textDocumentItem != null
-				&& new DashedCaseDetector().hasDashedCaseInCamelComponentOption(textDocumentItem.getText());
+				&& new DashedCaseDetector().hasDashedCaseInCamelPropertyOption(textDocumentItem.getText());
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetector.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetector.java
@@ -18,7 +18,7 @@ package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
 public class DashedCaseDetector {
 
-	public boolean hasDashedCaseInCamelComponentOption(String text) {
+	public boolean hasDashedCaseInCamelPropertyOption(String text) {
 		String[] lines = text.split("\\r?\\n");
 		for (String line : lines) {
 			String camelProperty = "camel.\\w+.\\w+.\\w+-.*";

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSinkPropertyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSinkPropertyCompletionTest.java
@@ -43,6 +43,18 @@ class CamelKafkaCamelSinkPropertyCompletionTest extends AbstractCamelKafkaConnec
 	}
 	
 	@Test
+	void testCompletionWithDashedNotation() throws Exception {
+		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
+					+ "camel.sink.a-high-path-option=test\n"
+					+ "camel.sink.";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(2, 11)).get().getLeft();
+		Optional<CompletionItem> optionCompletion = completions.stream().filter(completion -> "path.a-medium-path-option".equals(completion.getLabel())).findAny();
+		assertThat(optionCompletion).isPresent();
+		assertThat(optionCompletion.get().getTextEdit().getRange()).isEqualTo(new Range(new Position(2, 11), new Position(2, 11)));
+	}
+	
+	@Test
 	void testCompletionWithStartedValue() throws Exception {
 		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
 					+ "camel.sink.pat";

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSourcePropertyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaCamelSourcePropertyCompletionTest.java
@@ -43,6 +43,18 @@ class CamelKafkaCamelSourcePropertyCompletionTest extends AbstractCamelKafkaConn
 	}
 	
 	@Test
+	void testCompletionWithDashedNotation() throws Exception {
+		String text = "connector.class=org.test.kafkaconnector.TestSourceConnector\n"
+					+ "camel.source.a-high-path-option=test\n"
+					+ "camel.source.";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(2, 13)).get().getLeft();
+		Optional<CompletionItem> optionCompletion = completions.stream().filter(completion -> "path.a-medium-path-option".equals(completion.getLabel())).findAny();
+		assertThat(optionCompletion).isPresent();
+		assertThat(optionCompletion.get().getTextEdit().getRange()).isEqualTo(new Range(new Position(2, 13), new Position(2, 13)));
+	}
+	
+	@Test
 	void testCompletionWithStartedValue() throws Exception {
 		String text = "connector.class=org.test.kafkaconnector.TestSourceConnector\n"
 					+ "camel.source.pat";

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKafkaConnectorSourceSinkHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelKafkaConnectorSourceSinkHoverTest.java
@@ -44,6 +44,18 @@ class CamelKafkaConnectorSourceSinkHoverTest extends AbstractCamelKafkaConnector
 	}
 	
 	@Test
+	void testHoverOnDashedProperty() throws Exception {
+		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
+					+ "camel.sink.path.a-medium-path-option=";
+		CamelLanguageServer languageServer = initializeLanguageServer(text);
+		
+		HoverParams hoverParams = new HoverParams(new TextDocumentIdentifier(DUMMY_URI+".properties"), new Position(1, 17));
+		CompletableFuture<Hover> hover = languageServer.getTextDocumentService().hover(hoverParams);
+		
+		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("Description of camel.sink.path.aMediumPathOption");
+	}
+	
+	@Test
 	void testHoverOnSourceProperty() throws Exception {
 		String text = "connector.class=org.test.kafkaconnector.TestSourceConnector\n"
 					+ "camel.source.path.aMediumPathOption=";

--- a/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetectorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/DashedCaseDetectorTest.java
@@ -42,7 +42,7 @@ class DashedCaseDetectorTest {
 	}
 
 	@Test
-	void testHasDashedCaseInCamelComponentOption() throws Exception {
+	void testHasDashedCaseInCamelPropertyOption() throws Exception {
 		assertThat(hasDashed("camel.component.id.my-name-dashed=123")).isTrue();
 	}
 	
@@ -52,7 +52,7 @@ class DashedCaseDetectorTest {
 	}
 	
 	@Test
-	void testHasDashedCaseInCamelComponentOptionWithSeveralLines() throws Exception {
+	void testHasDashedCaseInCamelPropertyOptionWithSeveralLines() throws Exception {
 		assertThat(hasDashed(
 				"camel.component.id.myNameNotDashed=123\n" +
 				"camel.component.id.my-name-dashed=123")).isTrue();
@@ -74,7 +74,7 @@ class DashedCaseDetectorTest {
 	}
 	
 	private boolean hasDashed(String text) {
-		return new DashedCaseDetector().hasDashedCaseInCamelComponentOption(text);
+		return new DashedCaseDetector().hasDashedCaseInCamelPropertyOption(text);
 	}
 	
 }


### PR DESCRIPTION
options

![dashedNotationForCamelSinkAndSourceOptions](https://user-images.githubusercontent.com/1105127/96864254-6ba40e00-1468-11eb-8cf4-74a213c56d4f.gif)
