### PR TITLE
Fusetools2 801 provide more useful display of class names

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/AbstractConnectorClassDependentCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/AbstractConnectorClassDependentCompletionProcessor.java
@@ -57,11 +57,8 @@ public abstract class AbstractConnectorClassDependentCompletionProcessor {
 				List<String> converters = retrieveList(model.get());
 				if (converters != null) {
 					List<CompletionItem> completions = converters.stream()
-							.map(converter -> {
-								CompletionItem completionItem = new CompletionItem(converter);
-								CompletionResolverUtils.applyTextEditToCompletionItem(camelPropertyValueInstance, completionItem);
-								return completionItem;
-							}).filter(FilterPredicateUtils.matchesCompletionFilter(startFilter)).collect(Collectors.toList());
+							.map(fullyQualifiedConverterClassname -> new CompletionItemCreator().createForQualifiedClassName(fullyQualifiedConverterClassname, camelPropertyValueInstance))
+							.filter(FilterPredicateUtils.matchesCompletionFilter(startFilter)).collect(Collectors.toList());
 					return CompletableFuture.completedFuture(completions);
 				}
 			}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
@@ -42,26 +42,11 @@ public class CamelKafkaConnectorClassCompletionProcessor {
 		List<CompletionItem> completions = camelKafkaConnectors.stream()
 				.map(camelKafkaConnector -> {
 					String qualifiedConnectorClassName = camelKafkaConnector.getConnectorClass();
-					CompletionItem completionItem = new CompletionItem(extractSimpleClassName(qualifiedConnectorClassName));
-					completionItem.setDetail(qualifiedConnectorClassName);
-					completionItem.setInsertText(qualifiedConnectorClassName);
-					completionItem.setFilterText(qualifiedConnectorClassName);
-					CompletionResolverUtils.applyTextEditToCompletionItem(camelPropertyValueInstance, completionItem);
-					return completionItem;
+					return new CompletionItemCreator().createForQualifiedClassName(qualifiedConnectorClassName, camelPropertyValueInstance);
 				})
 				.filter(FilterPredicateUtils.matchesCompletionFilter(startFilter))
 				.collect(Collectors.toList());
 		
 		return CompletableFuture.completedFuture(completions);
 	}
-
-	private String extractSimpleClassName(String qualifiedConnectorClassName) {
-		int lastDotIndex = qualifiedConnectorClassName.lastIndexOf('.');
-		if(lastDotIndex != -1) {
-			return qualifiedConnectorClassName.substring(lastDotIndex + 1);
-		} else {
-			return qualifiedConnectorClassName;
-		}
-	}
-
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
@@ -41,7 +41,11 @@ public class CamelKafkaConnectorClassCompletionProcessor {
 		Collection<CamelKafkaConnectorModel> camelKafkaConnectors = camelKafkaConnectorManager.getCatalog().getConnectorsModel().values();
 		List<CompletionItem> completions = camelKafkaConnectors.stream()
 				.map(camelKafkaConnector -> {
-					CompletionItem completionItem = new CompletionItem(camelKafkaConnector.getConnectorClass());
+					String qualifiedConnectorClassName = camelKafkaConnector.getConnectorClass();
+					CompletionItem completionItem = new CompletionItem(extractSimpleClassName(qualifiedConnectorClassName));
+					completionItem.setDetail(qualifiedConnectorClassName);
+					completionItem.setInsertText(qualifiedConnectorClassName);
+					completionItem.setFilterText(qualifiedConnectorClassName);
 					CompletionResolverUtils.applyTextEditToCompletionItem(camelPropertyValueInstance, completionItem);
 					return completionItem;
 				})
@@ -49,6 +53,15 @@ public class CamelKafkaConnectorClassCompletionProcessor {
 				.collect(Collectors.toList());
 		
 		return CompletableFuture.completedFuture(completions);
+	}
+
+	private String extractSimpleClassName(String qualifiedConnectorClassName) {
+		int lastDotIndex = qualifiedConnectorClassName.lastIndexOf('.');
+		if(lastDotIndex != -1) {
+			return qualifiedConnectorClassName.substring(lastDotIndex + 1);
+		} else {
+			return qualifiedConnectorClassName;
+		}
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CompletionItemCreator.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CompletionItemCreator.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import org.eclipse.lsp4j.CompletionItem;
+
+import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
+
+public class CompletionItemCreator {
+
+	public CompletionItem createForQualifiedClassName(String qualifiedClassname, ILineRangeDefineable modelElement) {
+		CompletionItem completionItem = new CompletionItem(extractSimpleClassName(qualifiedClassname));
+		completionItem.setDetail(qualifiedClassname);
+		completionItem.setInsertText(qualifiedClassname);
+		completionItem.setFilterText(qualifiedClassname);
+		CompletionResolverUtils.applyTextEditToCompletionItem(modelElement, completionItem);
+		return completionItem;
+	}
+	
+	private String extractSimpleClassName(String qualifiedConnectorClassName) {
+		int lastDotIndex = qualifiedConnectorClassName.lastIndexOf('.');
+		if(lastDotIndex != -1) {
+			return qualifiedConnectorClassName.substring(lastDotIndex + 1);
+		} else {
+			return qualifiedConnectorClassName;
+		}
+	}
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/FilterPredicateUtils.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/FilterPredicateUtils.java
@@ -39,7 +39,8 @@ public class FilterPredicateUtils {
 	public static Predicate<CompletionItem> matchesCompletionFilter(String filterString) {
 		return item -> {
 			if (filterString != null && filterString.trim().length() > 0) {
-				return item.getLabel().startsWith(filterString);
+				return item.getLabel().startsWith(filterString)
+						|| item.getInsertText() != null && item.getInsertText().startsWith(filterString);
 			} else {
 				return true;
 			}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorClassCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorClassCompletionTest.java
@@ -41,7 +41,9 @@ class CamelKafkaConnectorClassCompletionTest extends AbstractCamelKafkaConnector
 		
 		List<CompletionItem> completionItems = completions.get().getLeft();
 		String connectorClassName = "org.test.kafkaconnector.TestSourceConnector";
-		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getLabel())).findAny().get();
+		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getInsertText())).findAny().get();
+		assertThat(completionItem.getLabel()).isEqualTo("TestSourceConnector");
+		assertThat(completionItem.getDetail()).isEqualTo(connectorClassName);
 		assertThat(completionItem.getTextEdit().getNewText()).isEqualTo(connectorClassName);
 		assertThat(completionItem.getTextEdit().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 16)));
 	}
@@ -53,7 +55,8 @@ class CamelKafkaConnectorClassCompletionTest extends AbstractCamelKafkaConnector
 		List<CompletionItem> completionItems = completions.get().getLeft();
 		assertThat(completionItems).hasSize(2);
 		String connectorClassName = "org.test.kafkaconnector.TestSinkConnector";
-		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getLabel())).findAny().get();
+		CompletionItem completionItem = completionItems.stream().filter(ci -> connectorClassName.equals(ci.getInsertText())).findAny().get();
+		assertThat(completionItem.getFilterText()).isEqualTo(connectorClassName);
 		assertThat(completionItem.getTextEdit().getNewText()).isEqualTo(connectorClassName);
 		assertThat(completionItem.getTextEdit().getRange()).isEqualTo(new Range(new Position(0, 16), new Position(0, 57)));
 	}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorConverterCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorConverterCompletionTest.java
@@ -37,6 +37,10 @@ class CamelKafkaConnectorConverterCompletionTest extends AbstractCamelKafkaConne
 		CamelLanguageServer languageServer = initializeLanguageServer(text);
 		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 16)).get().getLeft();
 		assertThat(completions).hasSize(1);
+		CompletionItem completionItem = completions.get(0);
+		assertThat(completionItem.getLabel()).isEqualTo("TestSinkObjectConverter");
+		assertThat(completionItem.getDetail()).isEqualTo("org.test.kafkaconnector.converters.TestSinkObjectConverter");
+		assertThat(completionItem.getFilterText()).isEqualTo("org.test.kafkaconnector.converters.TestSinkObjectConverter");
 	}
 	
 	@Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorTransformerCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/camelapplicationproperties/CamelKafkaConnectorTransformerCompletionTest.java
@@ -31,56 +31,52 @@ import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 class CamelKafkaConnectorTransformerCompletionTest extends AbstractCamelKafkaConnectorTest {
 
 	@Test
-	void testProvideCompletionForValueConverter() throws Exception {
+	void testProvideCompletionForValueTransformer() throws Exception {
 		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
-					+ "value.converter=";
+					+ "transforms.demo.type=";
 		CamelLanguageServer languageServer = initializeLanguageServer(text);
-		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 16)).get().getLeft();
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 21)).get().getLeft();
 		assertThat(completions).hasSize(1);
+		CompletionItem completionItem = completions.get(0);
+		assertThat(completionItem.getLabel()).isEqualTo("TestSinkTransformer");
+		String fullyQualifiedTransformerClassName = "org.test.kafkaconnector.transformers.TestSinkTransformer";
+		assertThat(completionItem.getDetail()).isEqualTo(fullyQualifiedTransformerClassName);
+		assertThat(completionItem.getFilterText()).isEqualTo(fullyQualifiedTransformerClassName);
 	}
 	
 	@Test
 	void testProvideCompletionForPartialItems() throws Exception {
 		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
-					+ "value.converter=org.test";
+					+ "transforms.demo.type=org.test";
 		CamelLanguageServer languageServer = initializeLanguageServer(text);
-		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 22)).get().getLeft();
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 27)).get().getLeft();
 		assertThat(completions).hasSize(1);
-		assertThat(completions.get(0).getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 16), new Position(1, 24)));
-	}
-
-	@Test
-	void testProvideCompletionForKeyConverter() throws Exception {
-		String text = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
-					+ "key.converter=";
-		CamelLanguageServer languageServer = initializeLanguageServer(text);
-		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 14)).get().getLeft();
-		assertThat(completions).hasSize(1);
+		assertThat(completions.get(0).getTextEdit().getRange()).isEqualTo(new Range(new Position(1, 21), new Position(1, 29)));
 	}
 	
 	@Test
-	void testProvideNoCompletionWhenNoConverter() throws Exception {
+	void testProvideNoCompletionWhenNoTransformer() throws Exception {
 		String text = "connector.class=org.test.kafkaconnector.TestSourceConnector\n"
-					+ "value.converter=";
+					+ "transforms.demo.type=";
 		CamelLanguageServer languageServer = initializeLanguageServer(text);
-		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 16)).get().getLeft();
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 21)).get().getLeft();
 		assertThat(completions).isEmpty();
 	}
 	
 	@Test
 	void testProvideNoCompletionWhenNoConnectorClass() throws Exception {
-		String text = "value.converter=";
+		String text = "transforms.demo.type=";
 		CamelLanguageServer languageServer = initializeLanguageServer(text);
-		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 16)).get().getLeft();
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 21)).get().getLeft();
 		assertThat(completions).isEmpty();
 	}
 	
 	@Test
 	void testProvideNoCompletionWithUnknownConnectorClass() throws Exception {
 		String text = "connector.class=unknown\n"
-					+ "value.converter=";
+					+ "transforms.demo.type==";
 		CamelLanguageServer languageServer = initializeLanguageServer(text);
-		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 16)).get().getLeft();
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(1, 21)).get().getLeft();
 		assertThat(completions).isEmpty();
 	}
 

--- a/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
+++ b/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
@@ -48,7 +48,7 @@
 	"converters": [
 		"org.test.kafkaconnector.converters.TestSinkObjectConverter"
 	],
-	"transformers": [
-		"org.test.kafkaconnector.converters.TestSinkTransformer"
+	"transforms": [
+		"org.test.kafkaconnector.transformers.TestSinkTransformer"
 	]
 }


### PR DESCRIPTION
- use simple name in label
- use fully qualified name in details

![completionWithSimpleName](https://user-images.githubusercontent.com/1105127/96875123-2b985780-1477-11eb-9151-c54d9baef330.gif)
