### PR TITLE
FUSETOOLS2-817 - support new way to specify deprecation

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentIdsCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentIdsCompletionsFuture.java
@@ -43,7 +43,7 @@ public class CamelComponentIdsCompletionsFuture implements Function<CamelCatalog
 			.map(componentModel -> {
 				CompletionItem completionItem = new CompletionItem(componentModel.getScheme());
 				completionItem.setDocumentation(componentModel.getDescription());
-				completionItem.setDeprecated(Boolean.valueOf(componentModel.getDeprecated()));
+				CompletionResolverUtils.applyDeprecation(completionItem, componentModel.getDeprecated());
 				CompletionResolverUtils.applyTextEditToCompletionItem(camelComponentNamePropertyFileInstance, completionItem);
 				return completionItem;
 			})

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionNamesCompletionFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionNamesCompletionFuture.java
@@ -53,7 +53,7 @@ public class CamelComponentOptionNamesCompletionFuture implements Function<Camel
 					CompletionItem completionItem = new CompletionItem(parameterDisplayName);
 					completionItem.setDocumentation(parameter.getDescription());
 					completionItem.setDetail(parameter.getJavaType());
-					completionItem.setDeprecated(parameter.isDeprecated());
+					CompletionResolverUtils.applyDeprecation(completionItem, parameter.isDeprecated());
 					String insertText = parameterDisplayName;
 					if (hasValueProvided() && parameter.getDefaultValue() != null) {
 						insertText += String.format("=%s", parameter.getDefaultValue());

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentSchemesCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelComponentSchemesCompletionsFuture.java
@@ -61,7 +61,7 @@ public final class CamelComponentSchemesCompletionsFuture implements Function<Ca
 			.map(componentModel -> {
 				CompletionItem completionItem = new CompletionItem(componentModel.getSyntax());
 				completionItem.setDocumentation(componentModel.getDescription());
-				completionItem.setDeprecated(Boolean.valueOf(componentModel.getDeprecated()));
+				CompletionResolverUtils.applyDeprecation(completionItem, componentModel.getDeprecated());
 				CompletionResolverUtils.applyTextEditToCompletionItem(uriElement, completionItem);
 				return completionItem;
 			})

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelOptionNamesCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelOptionNamesCompletionsFuture.java
@@ -73,7 +73,7 @@ public class CamelOptionNamesCompletionsFuture implements Function<CamelCatalog,
 					completionItem.setInsertText(insertText);
 					completionItem.setDocumentation(parameter.getDescription());
 					completionItem.setDetail(parameter.getJavaType());
-					completionItem.setDeprecated(parameter.isDeprecated());
+					CompletionResolverUtils.applyDeprecation(completionItem, parameter.isDeprecated());
 					CompletionResolverUtils.applyTextEditToCompletionItem(uriElement, completionItem);
 					return completionItem;
 				})

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CompletionResolverUtils.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CompletionResolverUtils.java
@@ -17,10 +17,12 @@
 package com.github.cameltooling.lsp.internal.completion;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.camel.parser.helper.CamelXmlHelper;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemTag;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentItem;
@@ -75,6 +77,13 @@ public class CompletionResolverUtils {
 			}
 		}
 		return endpointIDs;
+	}
+
+	public static void applyDeprecation(CompletionItem completionItem, boolean isDeprecated) {
+		completionItem.setDeprecated(isDeprecated);
+		if (isDeprecated) {
+			completionItem.setTags(Collections.singletonList(CompletionItemTag.Deprecated));
+		}
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
@@ -31,6 +31,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 
+import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 
 /**
@@ -120,7 +121,7 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 								}
 								CompletionItem completionItem = new CompletionItem(realOptionName);
 								completionItem.setDocumentation(option.getDescription());
-								completionItem.setDeprecated(option.isDeprecated());
+								CompletionResolverUtils.applyDeprecation(completionItem, option.isDeprecated());
 								completionItem.setInsertText(realOptionName + "=");
 								return completionItem;
 							}).collect(Collectors.toList());

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
@@ -83,7 +83,7 @@ public class CamelKModelineDependencyOption implements ICamelKModelineOptionValu
 			.map(componentModel -> {
 				CompletionItem completionItem = new CompletionItem(componentModel.getArtifactId());
 				completionItem.setDocumentation(componentModel.getDescription());
-				completionItem.setDeprecated(Boolean.valueOf(componentModel.getDeprecated()));
+				CompletionResolverUtils.applyDeprecation(completionItem, componentModel.getDeprecated());
 				CompletionResolverUtils.applyTextEditToCompletionItem(this, completionItem);
 				return completionItem;
 			})

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelDeprecationIndicatorInCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelDeprecationIndicatorInCompletionTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemTag;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -40,6 +41,7 @@ class CamelDeprecationIndicatorInCompletionTest extends AbstractCamelLanguageSer
 		List<CompletionItem> items = completions.get().getLeft();
 		assertThat(items.size()).isEqualTo(1);
 		assertThat(items.get(0).getDeprecated()).isTrue();
+		assertThat(items.get(0).getTags()).contains(CompletionItemTag.Deprecated);
 	}
 	
 	@Test
@@ -49,6 +51,7 @@ class CamelDeprecationIndicatorInCompletionTest extends AbstractCamelLanguageSer
 		List<CompletionItem> items = completions.get().getLeft();
 		assertThat(items.size()).isEqualTo(1);
 		assertThat(items.get(0).getDeprecated()).isTrue();
+		assertThat(items.get(0).getTags()).contains(CompletionItemTag.Deprecated);
 	}
 	
 	@Override


### PR DESCRIPTION
- continue to also use the deprecated "deprecated" field so that it is
also working on clients that have not upgraded yet.

