### PR TITLE
Fusetools2 835 hover for camel url in properties file

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -96,7 +96,7 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 		if (isOnPropertyKey(position)) {
 			return camelPropertyKeyInstance.getHover(position, camelCatalog, camelKafkaConnectorCatalog);
 		} else {
-			return CompletableFuture.completedFuture(null);
+			return camelPropertyValueInstance.getHover(position, camelCatalog);
 		}
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
@@ -30,6 +31,7 @@ import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionPr
 import com.github.cameltooling.lsp.internal.completion.CamelKafkaConnectorClassCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelKafkaConverterCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.KafkaConnectTransformerTypeCompletionProcessor;
+import com.github.cameltooling.lsp.internal.hover.CamelURIHoverProcessor;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
 
@@ -95,6 +97,15 @@ public class CamelPropertyValueInstance implements ILineRangeDefineable {
 	@Override
 	public int getEndPositionInLine() {
 		return getStartPositionInLine() + (camelPropertyValue != null ? camelPropertyValue.length() : 0);
+	}
+
+	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
+		String propertyKey = key.getCamelPropertyKey();
+		if (new CamelKafkaUtil().isCamelURIForKafka(propertyKey)) {
+			return new CamelURIHoverProcessor(textDocumentItem, camelCatalog).getHover(position);
+		} else {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/TestExtraComponentUtil.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/TestExtraComponentUtil.java
@@ -43,6 +43,7 @@ public class TestExtraComponentUtil {
 			"\"aSecondComponentProperty\": { \"kind\": \"parameter\", \"displayName\": \"A Second Component property \", \"group\": \"common\", \"required\": false, \"type\": \"string\", \"javaType\": \"java.lang.String\", \"deprecated\": false, \"secret\": false, \"defaultValue\": \"aDefaultValue\", \"configurationClass\": \"org.apache.camel.component.knative.KnativeConfiguration\", \"configurationField\": \"configuration\", \"description\": \"A second parameter description\" }\n" +
 			"  },\n" + 
 			"  \"properties\": {\n" +
+			"\"aProperty\": { \"kind\": \"parameter\", \"displayName\": \"A Component property \", \"group\": \"common\", \"required\": false, \"type\": \"string\", \"javaType\": \"java.lang.String\", \"deprecated\": false, \"secret\": false, \"defaultValue\": \"aDefaultValue\", \"configurationClass\": \"org.apache.camel.component.knative.KnativeConfiguration\", \"configurationField\": \"configuration\", \"description\": \"A parameter description of a property\" }\n" +
 			"  }\n" + 
 			"}";
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverTest.java
@@ -94,8 +94,24 @@ class CamelPropertiesFileHoverTest extends AbstractCamelLanguageServerTest {
 	}
 	
 	@Test
+	void testHoverOnPropertyInCamelURL() throws Exception {
+		String propertyEntry = "camel.sink.url=acomponent:withsyntax?aProperty=test";
+		CompletableFuture<Hover> hover = getHover(propertyEntry, 42);
+		
+		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("A parameter description of a property");
+	}
+	
+	@Test
+	void testHoverOnSchemaInCamelURL() throws Exception {
+		String propertyEntry = "camel.sink.url=acomponent:withsyntax";
+		CompletableFuture<Hover> hover = getHover(propertyEntry, 17);
+		
+		assertThat(hover.get().getContents().getLeft().get(0).getLeft()).isEqualTo("Description of my component.");
+	}
+	
+	@Test
 	void testNoHoverOnUnknownCamelMainOptions() throws Exception {
-		String propertyEntry = "camel.main.unknown=true";
+		String propertyEntry = "camel.main.unknown=";
 		CompletableFuture<Hover> hover = getHover(propertyEntry, 13);
 		
 		assertThat(hover.get()).isNull();


### PR DESCRIPTION
requires 
![hoverForcamelUrlInPropertiesFile](https://user-images.githubusercontent.com/1105127/98131978-2944ed00-1ebc-11eb-98f0-5d79eb8520fc.gif)

