### PR TITLE
FUSETOOLS2-808 - fix test

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineDependencyCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineDependencyCompletionTest.java
@@ -63,7 +63,7 @@ class CamelKModelineDependencyCompletionTest extends AbstractCamelLanguageServer
 		
 		List<CompletionItem> completionItems = completions.get().getLeft();
 		assertThat(completionItems).isNotEmpty();
-		assertThat(completionItems.stream().filter(completionItem -> !completionItem.getLabel().startsWith("mvn")).map(completionitem -> completionitem.getLabel())).allMatch(compleItemLabel -> compleItemLabel.startsWith("camel-"));
+		assertThat(completionItems.stream().filter(isNotMvnOrJitPack()).map(completionitem -> completionitem.getLabel())).allMatch(compleItemLabel -> compleItemLabel.startsWith("camel-"));
 		CompletionItem timerCompletionItem = completionItems.stream().filter(completionItem -> "camel-timer".equals(completionItem.getLabel())).findFirst().get();
 		assertThat(timerCompletionItem.getDocumentation().getLeft()).isEqualTo("Generate messages in specified intervals using java.util.Timer.");
 		assertThat(timerCompletionItem.getTextEdit().getRange().getStart().getLine()).isEqualTo(1);


### PR DESCRIPTION
it was due to merge collision without conflict.

in one PR, several tests were modified to adapt to new behavior.
in a second PR, a test was added without benefiting from the modification of the first one.
