### PR TITLE
Fusetools2 866 second iteration sonar on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,23 @@ jobs:
       - checkout
       - run: mvn verify -V
 
+  sonar:
+    docker:
+      - image: circleci/openjdk:8-stretch
+    steps:
+      - checkout
+      - run: > 
+          mvn verify
+          -P !build-extras
+          -Dtest="*,!RunnerStandardIOTest,!RunnerWebSocketTest"
+          -B
+          sonar:sonar
+          -Dsonar.login=${SONAR_TOKEN}
+          -Dsonar.organization="camel-tooling"
+          -Dsonar.projectKey="camel-lsp-server"
+          -Dsonar.projectName="Camel LSP Server"
+          -Dsonar.host.url=https://sonarcloud.io
+
 workflows:
   version: 2
 
@@ -30,3 +47,13 @@ workflows:
       - jdk8
       - jdk11
       - jdk15
+      - sonar:
+          requires:
+            - jdk8
+            - jdk11
+            - jdk15
+          filters:
+            branches:
+              only:
+                master
+          context: sonarcloud


### PR DESCRIPTION
requires https://github.com/camel-tooling/camel-language-server/pull/506

- use context sonarcloud which is providing SONAR_TOKEN
- compared to Travis, requires to specify the sonar.host.url