### PR TITLE
FUSETOOLS2-866 - add --batch to gpg

### DIFF
--- a/cd/before-deploy.sh
+++ b/cd/before-deploy.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 mv ~/.gnupg ~/dot.gnupg  
 openssl aes-256-cbc -K $encrypted_5b0511f84952_key -iv $encrypted_5b0511f84952_iv -in $GPG_DIR/codesigning.gpg.enc -out $GPG_DIR/codesigning.gpg -d
-gpg --import $GPG_DIR/codesigning.gpg
+gpg --batch --import $GPG_DIR/codesigning.gpg


### PR DESCRIPTION
as mentioned here
https://superuser.com/questions/1325862/gnupg2-suddenly-throwing-error-building-skey-array-no-such-file-or-directory
newer versions requires it.

missed the transfer of it from the test branch https://github.com/camel-tooling/camel-language-server/commit/46da62c5d3d2c01dc696e36658680f0eed0a7842
