### PR TITLE
FUSETOOLS2-885 - avoid ClassCastException for interface java file

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/EndpointDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/EndpointDiagnosticService.java
@@ -41,6 +41,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.BooleanErrorMsg;
@@ -95,8 +96,11 @@ public class EndpointDiagnosticService extends DiagnosticService {
 				logExceptionValidatingDocument(uri, e);
 			}
 		} else if(uri.endsWith(".java")) {
-			JavaClassSource clazz = (JavaClassSource) Roaster.parse(camelText);
-			RouteBuilderParser.parseRouteBuilderEndpoints(clazz, "", "/"+uri, endpoints);
+			JavaType<?> parsedJavaFile = Roaster.parse(camelText);
+			if (parsedJavaFile instanceof JavaClassSource) {
+				JavaClassSource clazz = (JavaClassSource) parsedJavaFile;
+				RouteBuilderParser.parseRouteBuilderEndpoints(clazz, "", "/"+uri, endpoints);
+			}
 		}
 		return endpoints;
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolJavaProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolJavaProcessor.java
@@ -19,6 +19,7 @@ package com.github.cameltooling.lsp.internal.documentsymbol;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.camel.parser.RouteBuilderParser;
@@ -29,6 +30,7 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.JavaType;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
 
 public class DocumentSymbolJavaProcessor extends AbstractDocumentSymbolProcessor {
@@ -38,12 +40,17 @@ public class DocumentSymbolJavaProcessor extends AbstractDocumentSymbolProcessor
 	}
 
 	public List<Either<SymbolInformation, DocumentSymbol>> getSymbolInformations() {
-		JavaClassSource clazz = (JavaClassSource) Roaster.parse(textDocumentItem.getText());
-		String absolutePathOfCamelFile = new File(URI.create(textDocumentItem.getUri())).getAbsolutePath();
-		List<CamelNodeDetails> camelNodes = RouteBuilderParser.parseRouteBuilderTree(clazz, "", absolutePathOfCamelFile, true);
-		List<CamelEndpointDetails> endpoints = new ArrayList<>();
-		RouteBuilderParser.parseRouteBuilderEndpoints(clazz, "", absolutePathOfCamelFile, endpoints);
-		return createSymbolInformations(camelNodes, endpoints);
+		JavaType<?> parsedJavaFile = Roaster.parse(textDocumentItem.getText());
+		if(parsedJavaFile instanceof JavaClassSource) {
+			JavaClassSource clazz = (JavaClassSource) parsedJavaFile;
+			String absolutePathOfCamelFile = new File(URI.create(textDocumentItem.getUri())).getAbsolutePath();
+			List<CamelNodeDetails> camelNodes = RouteBuilderParser.parseRouteBuilderTree(clazz, "", absolutePathOfCamelFile, true);
+			List<CamelEndpointDetails> endpoints = new ArrayList<>();
+			RouteBuilderParser.parseRouteBuilderEndpoints(clazz, "", absolutePathOfCamelFile, endpoints);
+			return createSymbolInformations(camelNodes, endpoints);
+		} else {
+			return Collections.emptyList();
+		}
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelDiagnosticTest.java
@@ -186,4 +186,9 @@ class CamelDiagnosticTest extends AbstractDiagnosticTest {
 	void testUnknowPropertyOnLenientPropertiesComponent() throws Exception {
 		testDiagnostic("camel-with-unknownParameter-forlenientcomponent", 0, ".xml");
 	}
+	
+	@Test
+	void testJavaInterface() throws Exception {
+		testDiagnostic("AnInterface", 0, ".java");
+	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/documentsymbol/DocumentSymbolProcessorTest.java
@@ -274,6 +274,12 @@ class DocumentSymbolProcessorTest extends AbstractCamelLanguageServerTest {
 		assertThat(range.getEnd().getCharacter()).isEqualTo(40);
 	}
 	
+	@Test
+	void testInterfaceNotThrowingException() throws Exception {
+		File f = new File("src/test/resources/workspace/AnInterface.java");
+		testRetrieveDocumentSymbol(f, 0);
+	}
+	
 	private List<Either<SymbolInformation, DocumentSymbol>> testRetrieveDocumentSymbol(String textTotest, int expectedSize) throws URISyntaxException, InterruptedException, ExecutionException, IOException {
 		File camelFile = new File(tempDir, "DocumentSymbolInformation.xml");
 		Files.write(textTotest.getBytes(), camelFile);

--- a/src/test/resources/workspace/AnInterface.java
+++ b/src/test/resources/workspace/AnInterface.java
@@ -1,0 +1,3 @@
+interface AnInterface {
+	
+}

--- a/src/test/resources/workspace/diagnostic/AnInterface.java
+++ b/src/test/resources/workspace/diagnostic/AnInterface.java
@@ -1,0 +1,3 @@
+interface AnInterface {
+	
+}


### PR DESCRIPTION
- avoid in document symbol
- avoid in Diagnostic service

initial issue reported by user https://github.com/camel-tooling/camel-lsp-client-vscode/issues/475