### PR TITLE
Change the visibility of the constructor to "protected" for abstract

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/AbstractDocumentSymbolProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/documentsymbol/AbstractDocumentSymbolProcessor.java
@@ -39,7 +39,7 @@ public abstract class AbstractDocumentSymbolProcessor {
 
 	protected TextDocumentItem textDocumentItem;
 
-	public AbstractDocumentSymbolProcessor(TextDocumentItem textDocumentItem) {
+	protected AbstractDocumentSymbolProcessor(TextDocumentItem textDocumentItem) {
 		this.textDocumentItem = textDocumentItem;
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelUriElementInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelUriElementInstance.java
@@ -39,7 +39,7 @@ public abstract class CamelUriElementInstance implements ILineRangeDefineable{
 	private int endPositionInUri;
 	private TextDocumentItem document;
 
-	public CamelUriElementInstance(int startPositionInUri, int endPositionInUri) {
+	protected CamelUriElementInstance(int startPositionInUri, int endPositionInUri) {
 		this.startPositionInUri = startPositionInUri;
 		this.endPositionInUri = endPositionInUri;
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineLocalResourceRelatedOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineLocalResourceRelatedOption.java
@@ -48,7 +48,7 @@ public abstract class CamelKModelineLocalResourceRelatedOption implements ICamel
 	private String documentItemUri;
 	private int line;
 
-	public CamelKModelineLocalResourceRelatedOption(String value, int startPosition, String documentItemUri, int line) {
+	protected CamelKModelineLocalResourceRelatedOption(String value, int startPosition, String documentItemUri, int line) {
 		this.value = value;
 		this.startPosition = startPosition;
 		this.documentItemUri = documentItemUri;


### PR DESCRIPTION
class

Abstract classes should not have public constructors. Constructors of
abstract classes can only be called in constructors of their subclasses.
So there is no point in making them public. The protected modifier
should be enough.


https://sonarcloud.io/project/issues?id=camel-lsp-server&issues=AXVRD0WrqCk3s3qSG0pX&open=AXVRD0WrqCk3s3qSG0pX
https://sonarcloud.io/project/issues?id=camel-lsp-server&issues=AXUIOHL-67TsbFDQSkwe&open=AXUIOHL-67TsbFDQSkwe
https://sonarcloud.io/project/issues?id=camel-lsp-server&issues=AXWTt_LjtgwF3nOez880&open=AXWTt_LjtgwF3nOez880