### PR TITLE
Sonar will soon end support of analysis done with Java 8, so do it with

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
 
   sonar:
     docker:
-      - image: circleci/openjdk:8-stretch
+      - image: circleci/openjdk:11-stretch
     steps:
       - checkout
       - run: > 


### PR DESCRIPTION
java 11

see https://sonarcloud.io/documentation/appendices/end-of-support/

