### PR TITLE
FUSETOOLS2-815 - provide validation for invalid camel.(source|sink)

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/CamelKafkaConnectorCatalogManager.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/CamelKafkaConnectorCatalogManager.java
@@ -16,7 +16,10 @@
  */
 package com.github.cameltooling.lsp.internal.catalog.util;
 
+import java.util.Optional;
+
 import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
+import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
 
 public class CamelKafkaConnectorCatalogManager {
 	
@@ -24,5 +27,13 @@ public class CamelKafkaConnectorCatalogManager {
 		
 	public CamelKafkaConnectorCatalog getCatalog() {
 		return catalog;
+	}
+	
+	public Optional<CamelKafkaConnectorModel> findConnectorModel(String connectorClass) {
+		return catalog.getConnectorsModel()
+				.values()
+				.stream()
+				.filter(connector -> connectorClass != null && connectorClass.equals(connector.getConnectorClass()))
+				.findAny();
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKModelineDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKModelineDiagnosticService.java
@@ -37,7 +37,7 @@ import com.github.cameltooling.lsp.internal.parser.CamelKModelineParser;
 public class CamelKModelineDiagnosticService extends DiagnosticService {
 
 	public CamelKModelineDiagnosticService() {
-		super(null);
+		super(null, null);
 	}
 
 	public Collection<Diagnostic> compute(String camelText, TextDocumentItem documentItem) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorDiagnosticService.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.diagnostic;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyEntryInstance;
+import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
+
+public class CamelKafkaConnectorDiagnosticService extends DiagnosticService {
+
+	protected CamelKafkaConnectorDiagnosticService(CamelKafkaConnectorCatalogManager camelKafkaConnectorCatalogManager) {
+		super(null, camelKafkaConnectorCatalogManager);
+	}
+
+	public Collection<Diagnostic> compute(String camelText, TextDocumentItem documentItem) {
+		String docUri = documentItem.getUri();
+		if(docUri.endsWith(".properties")) {
+			String connectorClass = new CamelKafkaUtil().findConnectorClass(documentItem);
+			Optional<CamelKafkaConnectorModel> connectorModelOptional = camelKafkaConnectorCatalogManager.findConnectorModel(connectorClass);
+			if (connectorModelOptional.isPresent()) {
+				List<Diagnostic> lspDiagnostics = new ArrayList<>();
+				BufferedReader reader = new BufferedReader(new StringReader(camelText));
+				int lineNumber = 0;
+				String line;
+				try {
+					while((line = reader.readLine())!= null) {
+						CamelPropertyEntryInstance camelPropertyEntryInstance = new CamelPropertyEntryInstance(line, new Position(lineNumber, 0), documentItem);
+						lspDiagnostics.addAll(camelPropertyEntryInstance.validate(camelKafkaConnectorCatalogManager));
+						lineNumber++;
+					}
+					return lspDiagnostics;
+				} catch (IOException e) {
+					logExceptionValidatingDocument(docUri, e);
+				}
+			}
+		}
+		return Collections.emptyList();
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/ConfigurationPropertiesDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/ConfigurationPropertiesDiagnosticService.java
@@ -46,7 +46,7 @@ import com.github.cameltooling.lsp.internal.catalog.diagnostic.UnknownErrorMsg;
 public class ConfigurationPropertiesDiagnosticService extends DiagnosticService {
 
 	public ConfigurationPropertiesDiagnosticService(CompletableFuture<CamelCatalog> camelCatalog) {
-		super(camelCatalog);
+		super(camelCatalog, null);
 	}
 	
 	public Map<String, ConfigurationPropertiesValidationResult> computeCamelConfigurationPropertiesErrors(String camelText, String uri) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticRunner.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticRunner.java
@@ -37,12 +37,14 @@ public class DiagnosticRunner {
 	private EndpointDiagnosticService endpointDiagnosticService;
 	private ConfigurationPropertiesDiagnosticService configurationPropertiesDiagnosticService;
 	private CamelKModelineDiagnosticService camelKModelineDiagnosticService;
+	private CamelKafkaConnectorDiagnosticService camelKafkaConnectorDiagnosticService;
 
 	public DiagnosticRunner(CompletableFuture<CamelCatalog> camelCatalog, CamelLanguageServer camelLanguageServer) {
 		this.camelLanguageServer = camelLanguageServer;
 		endpointDiagnosticService = new EndpointDiagnosticService(camelCatalog);
 		configurationPropertiesDiagnosticService = new ConfigurationPropertiesDiagnosticService(camelCatalog);
 		camelKModelineDiagnosticService = new CamelKModelineDiagnosticService();
+		camelKafkaConnectorDiagnosticService = new CamelKafkaConnectorDiagnosticService(camelLanguageServer.getTextDocumentService().getCamelKafkaConnectorManager());
 	}
 
 	public void compute(DidSaveTextDocumentParams params) {
@@ -70,6 +72,7 @@ public class DiagnosticRunner {
 			Map<String, ConfigurationPropertiesValidationResult> configurationPropertiesErrors = configurationPropertiesDiagnosticService.computeCamelConfigurationPropertiesErrors(camelText, uri);
 			diagnostics.addAll(configurationPropertiesDiagnosticService.converToLSPDiagnostics(configurationPropertiesErrors));
 			diagnostics.addAll(camelKModelineDiagnosticService.compute(camelText, documentItem));
+			diagnostics.addAll(camelKafkaConnectorDiagnosticService.compute(camelText, documentItem));
 			camelLanguageServer.getClient().publishDiagnostics(new PublishDiagnosticsParams(uri, diagnostics));
 		});
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
@@ -17,8 +17,8 @@
 package com.github.cameltooling.lsp.internal.diagnostic;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
@@ -26,18 +26,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.CamelDiagnosticMessage;
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 
 public abstract class DiagnosticService {
 	
-	protected static final String APACHE_CAMEL_VALIDATION = "Apache Camel validation";
+	public static final String APACHE_CAMEL_VALIDATION = "Apache Camel validation";
 	protected static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticService.class);
 	public static final String ERROR_CODE_UNKNOWN_PROPERTIES = "camel.diagnostic.unknown.properties";
 	public static final String ERROR_CODE_INVALID_ENUM = "camel.diagnostic.invalid.enum";
 	
 	protected CompletableFuture<CamelCatalog> camelCatalog;
+	protected CamelKafkaConnectorCatalogManager camelKafkaConnectorCatalogManager;
 
-	protected DiagnosticService(CompletableFuture<CamelCatalog> camelCatalog) {
+	protected DiagnosticService(CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorCatalogManager) {
 		this.camelCatalog = camelCatalog;
+		this.camelKafkaConnectorCatalogManager = camelKafkaConnectorCatalogManager;
 	}
 
 	protected void logExceptionValidatingDocument(String docUri, Exception e) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/EndpointDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/EndpointDiagnosticService.java
@@ -57,7 +57,7 @@ import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 public class EndpointDiagnosticService extends DiagnosticService {
 
 	public EndpointDiagnosticService(CompletableFuture<CamelCatalog> camelCatalog) {
-		super(camelCatalog);
+		super(camelCatalog, null);
 	}
 	
 	Map<CamelEndpointDetails, EndpointValidationResult> computeCamelEndpointErrors(String camelText, String uri) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -16,11 +16,14 @@
  */
 package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
@@ -103,6 +106,13 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 	public boolean shouldUseDashedCase() {
 		return textDocumentItem != null
 				&& new DashedCaseDetector().hasDashedCaseInCamelPropertyOption(textDocumentItem.getText());
+	}
+
+	public Collection<Diagnostic> validate(CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
+		if (camelPropertyKeyInstance != null) {
+			return camelPropertyKeyInstance.validate(camelKafkaConnectorManager);
+		}
+		return Collections.emptyList();
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -17,6 +17,7 @@
 package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.tooling.model.MainModel;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -182,6 +184,13 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 
 	public boolean shouldUseDashedCase() {
 		return camelPropertyEntryInstance.shouldUseDashedCase();
+	}
+
+	public Collection<Diagnostic> validate(CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
+		if(camelSinkOrSourcePropertyKey != null) {
+			return camelSinkOrSourcePropertyKey.validate(camelKafkaConnectorManager);
+		}
+		return Collections.emptyList();
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.diagnostic;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelKafkaConnectorTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+import com.github.cameltooling.lsp.internal.RangeChecker;
+
+class CamelKafkaConnectorPropertiesDiagnosticTest extends AbstractDiagnosticTest {
+
+	@Test
+	void testInvalidpropertyKey() throws Exception {
+		testDiagnostic("ckc-sink-invalid-property", 1);
+		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
+		new RangeChecker().check(diagnostic.getRange(), 2, 11, 2, 39);
+	}
+	
+	@Test
+	void testValidPropertyUrl() throws Exception {
+		testDiagnostic("ckc-sink-valid-url", 0);
+	}
+	
+	@Test
+	void testValidPropertyKeyDashedCase() throws Exception {
+		testDiagnostic("ckc-sink-valid-dashed-case", 0);
+	}
+	
+	@Test
+	void testValidPropertyKeyCamelCased() throws Exception {
+		testDiagnostic("ckc-sink-valid", 0);
+	}
+	
+	private void testDiagnostic(String fileUnderTest, int expectedNumberOfError) throws FileNotFoundException {
+		super.testDiagnostic(fileUnderTest, expectedNumberOfError, ".properties");
+	}
+	
+	@Override
+	protected CamelLanguageServer initializeLanguageServer(FileInputStream stream, String extension) {
+		CamelLanguageServer languageServer = super.initializeLanguageServer(stream, extension);
+		CamelKafkaConnectorCatalog catalog = languageServer.getTextDocumentService().getCamelKafkaConnectorManager().getCatalog();
+		catalog.addConnector("connector-source-used-for-test", getContentAsString("/camel-kafka-connector-catalog/connector-source-used-for-test.json"));
+		catalog.addConnector("connector-sink-used-for-test", getContentAsString("/camel-kafka-connector-catalog/connector-sink-used-for-test.json"));
+		return languageServer;
+	}
+	
+	private String getContentAsString(String pathInBundle) {
+		return new BufferedReader(new InputStreamReader(AbstractCamelKafkaConnectorTest.class.getResourceAsStream(pathInBundle), StandardCharsets.UTF_8))
+				.lines()
+				.map(String::trim)
+				.collect(Collectors.joining());
+	}
+}

--- a/src/test/resources/workspace/diagnostic/ckc-sink-invalid-property.properties
+++ b/src/test/resources/workspace/diagnostic/ckc-sink-invalid-property.properties
@@ -1,0 +1,3 @@
+connector.class=org.test.kafkaconnector.TestSinkConnector
+
+camel.sink.endpoint.notExistingProperty=aValue

--- a/src/test/resources/workspace/diagnostic/ckc-sink-valid-dashed-case.properties
+++ b/src/test/resources/workspace/diagnostic/ckc-sink-valid-dashed-case.properties
@@ -1,0 +1,3 @@
+connector.class=org.test.kafkaconnector.TestSinkConnector
+
+camel.sink.endpoint.a-medium-endpoint-option=aValue

--- a/src/test/resources/workspace/diagnostic/ckc-sink-valid-url.properties
+++ b/src/test/resources/workspace/diagnostic/ckc-sink-valid-url.properties
@@ -1,0 +1,3 @@
+connector.class=org.test.kafkaconnector.TestSinkConnector
+
+camel.sink.endpoint.aMediumEndpointOption=aValue

--- a/src/test/resources/workspace/diagnostic/ckc-sink-valid.properties
+++ b/src/test/resources/workspace/diagnostic/ckc-sink-valid.properties
@@ -1,0 +1,3 @@
+connector.class=org.test.kafkaconnector.TestSinkConnector
+
+camel.sink.url=testsink?aMediumEndpointOptionaValue


### PR DESCRIPTION
properties keys
![diagnosticCamlkafkaConnectorInvalidproperty](https://user-images.githubusercontent.com/1105127/101377192-d04ce800-38b1-11eb-9338-01854195caad.png)
