### PR TITLE
FUSETOOLS2-913 - add tests for validation on Camel Kafka Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 		<slf4j.version>1.7.30</slf4j.version>
 		<junit.version>5.7.0</junit.version>
 		<assertj.version>3.18.1</assertj.version>
+		<jgit.version>5.9.0.202009080501-r</jgit.version>
 		<camel.version>3.6.0</camel.version>
 		<camel.kafka.connector.version>0.6.1</camel.kafka.connector.version>
 		<roaster.version>2.21.1.Final</roaster.version>
@@ -162,6 +163,11 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
+				<configuration>
+					<systemProperties>
+						<camel.kafka.connector.version>${camel.kafka.connector.version}</camel.kafka.connector.version>
+					</systemProperties>
+				</configuration>
 			</plugin>
 			
 			<plugin>
@@ -266,6 +272,18 @@
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jgit</groupId>
+			<artifactId>org.eclipse.jgit</artifactId>
+			<version>${jgit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jgit</groupId>
+			<artifactId>org.eclipse.jgit.ssh.apache</artifactId>
+			<version>${jgit.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
@@ -138,21 +138,23 @@ public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
 	}
 
 	public Collection<Diagnostic> validate(CamelKafkaConnectorCatalogManager camelKafkaConnectorManager) {
-		Optional<CamelKafkaConnectorModel> connectorModelOptional = camelKafkaConnectorManager.findConnectorModel(connectorClass);
-		if (!"url".equals(optionKey) && connectorModelOptional.isPresent()) {
-			String propertyKey = getPrefix() + optionKey;
-			String camelCasePropertyKey = StringHelper.dashToCamelCase(propertyKey);
-			Optional<CamelKafkaConnectorOptionModel> optionModel = connectorModelOptional.get()
-					.getOptions()
-					.stream()
-					.filter(option -> camelCasePropertyKey.equals(option.getName()))
-					.findAny();
-			if(!optionModel.isPresent()) {
-				return Collections.singleton(new Diagnostic(
-						new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getEndPositionInLine())),
-						"Unknown property " + optionKey,
-						DiagnosticSeverity.Error,
-						DiagnosticService.APACHE_CAMEL_VALIDATION));
+		if (!"url".equals(optionKey) && (optionKey.startsWith("endpoint") || optionKey.startsWith("path"))) {
+			Optional<CamelKafkaConnectorModel> connectorModelOptional = camelKafkaConnectorManager.findConnectorModel(connectorClass);
+			if (connectorModelOptional.isPresent()) {
+				String propertyKey = getPrefix() + optionKey;
+				String camelCasePropertyKey = StringHelper.dashToCamelCase(propertyKey);
+				Optional<CamelKafkaConnectorOptionModel> optionModel = connectorModelOptional.get()
+						.getOptions()
+						.stream()
+						.filter(option -> camelCasePropertyKey.equals(option.getName()))
+						.findAny();
+				if (!optionModel.isPresent()) {
+					return Collections.singleton(new Diagnostic(
+							new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getEndPositionInLine())),
+							"Unknown property " + optionKey,
+							DiagnosticSeverity.Error,
+							DiagnosticService.APACHE_CAMEL_VALIDATION));
+				}
 			}
 		}
 		return Collections.emptyList();

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/AbstractDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/AbstractDiagnosticTest.java
@@ -47,7 +47,11 @@ public abstract class AbstractDiagnosticTest extends AbstractCamelLanguageServer
 
 	protected void testDiagnostic(String fileUnderTest, int expectedNumberOfError, String extension) throws FileNotFoundException {
 		File f = new File("src/test/resources/workspace/diagnostic/" + fileUnderTest + extension);
-		camelLanguageServer = initializeLanguageServer(new FileInputStream(f), extension);
+		testDiagnostic(f, expectedNumberOfError, extension);
+	}
+
+	protected void testDiagnostic(File file, int expectedNumberOfError, String extension) throws FileNotFoundException {
+		camelLanguageServer = initializeLanguageServer(new FileInputStream(file), extension);
 		
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(new TextDocumentIdentifier(DUMMY_URI+extension));
 		camelLanguageServer.getTextDocumentService().didSave(params);

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorOfficialExamplesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorOfficialExamplesDiagnosticTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.diagnostic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.InvalidRemoteException;
+import org.eclipse.jgit.api.errors.TransportException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CamelKafkaConnectorOfficialExamplesDiagnosticTest extends AbstractDiagnosticTest {
+
+	@TempDir
+	static Path folderWithExamples;
+	
+	private static String CAMEL_KAFKA_CONNECTOR_VERSION = System.getProperty("camel.kafka.connector.version");
+
+	private static Git repo;
+	
+	@BeforeAll
+	public static void beforeAll() throws InvalidRemoteException, TransportException, GitAPIException {
+		assertThat(CAMEL_KAFKA_CONNECTOR_VERSION)
+			.as("The Camel Kafka Connector version needs to be set as JVM property to play this test. It is done automatically when calling from Maven.")
+			.isNotNull();
+		repo = Git.cloneRepository()
+			.setURI("https://github.com/apache/camel-kafka-connector")
+			.setDirectory(folderWithExamples.toFile())
+			.setBranch("refs/tags/camel-kafka-connector-"+ CAMEL_KAFKA_CONNECTOR_VERSION)
+			.call();
+	}
+	
+	@AfterAll
+	public static void afterAll() {
+		if(repo != null) {
+			repo.close();
+		}
+	}
+	
+	
+	@ParameterizedTest
+	@MethodSource
+	void testExamples(File fileExample) throws Exception {
+		testDiagnostic(fileExample, 0, ".properties");
+	}
+	
+	@ValueSource
+	static Stream<File> testExamples() {
+		File[] exampleFiles = folderWithExamples.resolve("examples").toFile().listFiles();
+		assertThat(exampleFiles).as("Allows to detect if examples has moved for instance.").hasSizeGreaterThan(14);
+		return Stream.of(exampleFiles)
+				// filtering example due to https://github.com/apache/camel-kafka-connector/issues/767
+				.filter(file -> !"CamelAmqpSourceConnector.properties".equals(file.getName()));
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
@@ -55,6 +55,11 @@ class CamelKafkaConnectorPropertiesDiagnosticTest extends AbstractDiagnosticTest
 		testDiagnostic("ckc-sink-valid", 0);
 	}
 	
+	@Test
+	void testValidGenericProperty() throws Exception {
+		testDiagnostic("ckc-source-valid-with-generic-property", 0);
+	}
+	
 	private void testDiagnostic(String fileUnderTest, int expectedNumberOfError) throws FileNotFoundException {
 		super.testDiagnostic(fileUnderTest, expectedNumberOfError, ".properties");
 	}

--- a/src/test/resources/workspace/diagnostic/ckc-source-valid-with-generic-property.properties
+++ b/src/test/resources/workspace/diagnostic/ckc-source-valid-with-generic-property.properties
@@ -1,0 +1,3 @@
+connector.class=org.test.kafkaconnector.TestSourceConnector
+
+camel.source.maxPollDuration=10000


### PR DESCRIPTION
official examples

- skipping one example which is invalid. Fixed on master upstream
https://github.com/apache/camel-kafka-connector/issues/767
- fixed false positive for "generic" properties which are not part of
the connector model definition

potential improvements: the clone is taking few seconds. it might be
possible to improve that by doing a shallow clone of a specific folder.
