### PR TITLE
FUSETOOLS2-906 - validate match of (sink|source) properties with

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -48,8 +48,8 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 	
 	static final String CAMEL_KEY_PREFIX = "camel.";
 	static final String CAMEL_COMPONENT_KEY_PREFIX = "camel.component.";
-	private static final String CAMEL_SINK_KEY_PREFIX = "camel.sink.";
-	private static final String CAMEL_SOURCE_KEY_PREFIX = "camel.source.";
+	static final String CAMEL_SINK_KEY_PREFIX = "camel.sink.";
+	static final String CAMEL_SOURCE_KEY_PREFIX = "camel.source.";
 	
 	private String camelPropertyKey;
 	private CamelGroupPropertyKey propertyGroup;

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
@@ -60,6 +60,11 @@ class CamelKafkaConnectorPropertiesDiagnosticTest extends AbstractDiagnosticTest
 		testDiagnostic("ckc-source-valid-with-generic-property", 0);
 	}
 	
+	@Test
+	void testInvalidSourcePropertyForSinkConnectorClass() throws Exception {
+		testDiagnostic("ckc-sink-invalid-source-property", 1);
+	}
+	
 	private void testDiagnostic(String fileUnderTest, int expectedNumberOfError) throws FileNotFoundException {
 		super.testDiagnostic(fileUnderTest, expectedNumberOfError, ".properties");
 	}

--- a/src/test/resources/workspace/diagnostic/ckc-sink-invalid-source-property.properties
+++ b/src/test/resources/workspace/diagnostic/ckc-sink-invalid-source-property.properties
@@ -1,0 +1,3 @@
+connector.class=org.test.kafkaconnector.TestSinkConnector
+
+camel.source.maxPollDuration=1000


### PR DESCRIPTION
connector.class type

![diagnosticSinkSourcepropertyTypematchConnectorClassType](https://user-images.githubusercontent.com/1105127/101506285-7dd4ff80-3975-11eb-9962-09a180eb03e7.png)
