### PR TITLE
FUSETOOLS2-909 - diagnostic for duplicated keys when dash and camel case

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
@@ -72,6 +72,11 @@ class CamelKafkaConnectorPropertiesDiagnosticTest extends AbstractDiagnosticTest
 		testDiagnostic("ckc-sink-invalid-source-property", 1);
 	}
 	
+	@Test
+	void testDuplicatedKeyMixingDashedAndCamelCase() throws Exception {
+		testDiagnostic("ckc-with-duplicatedKeyMixingDashedAndCamelCase", 2);
+	}
+	
 	private void testDiagnostic(String fileUnderTest, int expectedNumberOfError) throws FileNotFoundException {
 		super.testDiagnostic(fileUnderTest, expectedNumberOfError, ".properties");
 	}

--- a/src/test/resources/workspace/diagnostic/ckc-with-duplicatedKeyMixingDashedAndCamelCase.properties
+++ b/src/test/resources/workspace/diagnostic/ckc-with-duplicatedKeyMixingDashedAndCamelCase.properties
@@ -1,0 +1,4 @@
+connector.class=org.test.kafkaconnector.TestSinkConnector
+
+camel.sink.endpoint.aMediumEndpointOption=aValue
+camel.sink.endpoint.a-medium-endpoint-option=aValue


### PR DESCRIPTION
mixed up

potential improvements for another iteration:
- indicate line number of the duplicated one (not just the name)
- provide quickfix to delete one or the other
- do it for non Camel Kafka Connector Properties file (if supported by
runtime)

![duplicatedKeyWithMixDashAndCamelCaseDetection](https://user-images.githubusercontent.com/1105127/102084594-b06b7600-3e15-11eb-8e6f-294d3ea9d052.png)
