### PR TITLE
FUSETOOLS2-914 - quickfix for typo atributes

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickfix.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickfix.java
@@ -40,6 +40,7 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.CamelTextDocumentService;
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 
 public abstract class AbstractQuickfix {
@@ -58,7 +59,7 @@ public abstract class AbstractQuickfix {
 			if(diagnostic.getCode()!= null && getDiagnosticId().equals(diagnostic.getCode().getLeft())) {
 				CharSequence currentValueInError = retrieveCurrentErrorValue(openedDocument, diagnostic);
 				if(currentValueInError != null) {
-					List<String> possibleProperties = retrievePossibleValues(openedDocument, camelTextDocumentService.getCamelCatalog(), diagnostic.getRange().getStart());
+					List<String> possibleProperties = retrievePossibleValues(openedDocument, camelTextDocumentService.getCamelCatalog(), camelTextDocumentService.getCamelKafkaConnectorManager(), diagnostic.getRange().getStart());
 					int distanceThreshold = Math.round(currentValueInError.length() * 0.4f);
 					LevenshteinDistance levenshteinDistance = new LevenshteinDistance(distanceThreshold);
 					List<String> mostProbableProperties = possibleProperties.stream()
@@ -95,7 +96,7 @@ public abstract class AbstractQuickfix {
 		return codeAction;
 	}
 	
-	protected abstract List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, Position position);
+	protected abstract List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager, Position position);
 	protected abstract String getDiagnosticId();
 	
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/codeactions/InvalidEnumQuickfix.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/codeactions/InvalidEnumQuickfix.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.CamelTextDocumentService;
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticService;
 
@@ -42,7 +43,7 @@ public class InvalidEnumQuickfix extends AbstractQuickfix {
 	}
 
 	@Override
-	protected List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, Position position) {
+	protected List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager ckcCatalogmanager, Position position) {
 		try {
 			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog)
 					.getCompletions(position)

--- a/src/main/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfix.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfix.java
@@ -18,11 +18,14 @@ package com.github.cameltooling.lsp.internal.codeactions;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorModel;
+import org.apache.camel.kafkaconnector.model.CamelKafkaConnectorOptionModel;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
@@ -30,8 +33,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.CamelTextDocumentService;
+import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticService;
+import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyKeyInstance;
+import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
 
 public class UnknownPropertyQuickfix extends AbstractQuickfix {
 	
@@ -45,20 +51,41 @@ public class UnknownPropertyQuickfix extends AbstractQuickfix {
 		return DiagnosticService.ERROR_CODE_UNKNOWN_PROPERTIES;
 	}
 
-	protected List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, Position position) {
-		try {
-			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog)
-					.getCompletions(position)
-					.thenApply(completionItems -> completionItems.stream().map(CompletionItem::getInsertText).collect(Collectors.toList()))
-					.get();
-		} catch (InterruptedException e) {
-			LOGGER.error("Interruption while computing possible properties for quickfix", e);
-			Thread.currentThread().interrupt();
-			return Collections.emptyList();
-		} catch (ExecutionException e) {
-			LOGGER.error("Exception while computing possible properties for quickfix", e);
-			return Collections.emptyList();
+	protected List<String> retrievePossibleValues(TextDocumentItem textDocumentItem,
+			CompletableFuture<CamelCatalog> camelCatalog,
+			CamelKafkaConnectorCatalogManager camelKafkaConnectorManager,
+			Position position) {
+		if (textDocumentItem.getUri().endsWith(".properties")) {
+			Optional<CamelKafkaConnectorModel> optionalModel = camelKafkaConnectorManager.findConnectorModel(new CamelKafkaUtil().findConnectorClass(textDocumentItem));
+			if (optionalModel.isPresent()) {
+				return optionalModel.get().getOptions()
+						.stream()
+						.map(CamelKafkaConnectorOptionModel::getName)
+						.map(this::removePrefix)
+						.collect(Collectors.toList());
+			}
+		} else {
+			try {
+				return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position)
+						.thenApply(completionItems -> completionItems.stream().map(CompletionItem::getInsertText)
+								.collect(Collectors.toList()))
+						.get();
+			} catch (InterruptedException e) {
+				LOGGER.error("Interruption while computing possible properties for quickfix", e);
+				Thread.currentThread().interrupt();
+				return Collections.emptyList();
+			} catch (ExecutionException e) {
+				LOGGER.error("Exception while computing possible properties for quickfix", e);
+				return Collections.emptyList();
+			}
 		}
+		return Collections.emptyList();
+	}
+
+	private String removePrefix(String value) {
+		return value
+				.replace(CamelPropertyKeyInstance.CAMEL_SINK_KEY_PREFIX, "")
+				.replace(CamelPropertyKeyInstance.CAMEL_SOURCE_KEY_PREFIX, "");
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -49,8 +49,8 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 	
 	static final String CAMEL_KEY_PREFIX = "camel.";
 	static final String CAMEL_COMPONENT_KEY_PREFIX = "camel.component.";
-	static final String CAMEL_SINK_KEY_PREFIX = "camel.sink.";
-	static final String CAMEL_SOURCE_KEY_PREFIX = "camel.source.";
+	public static final String CAMEL_SINK_KEY_PREFIX = "camel.sink.";
+	public static final String CAMEL_SOURCE_KEY_PREFIX = "camel.source.";
 	
 	private String camelPropertyKey;
 	private CamelGroupPropertyKey propertyGroup;

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
@@ -214,7 +214,8 @@ public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
 						new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getEndPositionInLine())),
 						"Unknown property " + optionKey,
 						DiagnosticSeverity.Error,
-						DiagnosticService.APACHE_CAMEL_VALIDATION));
+						DiagnosticService.APACHE_CAMEL_VALIDATION,
+						DiagnosticService.ERROR_CODE_UNKNOWN_PROPERTIES));
 			}
 		}
 		return Collections.emptySet();

--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
@@ -168,7 +168,7 @@ public abstract class AbstractCamelLanguageServerTest {
 		return Collections.emptyMap();
 	}
 	
-	protected CamelLanguageServer initializeLanguageServer(FileInputStream stream, String suffixFileName) {
+	protected CamelLanguageServer initializeLanguageServer(InputStream stream, String suffixFileName) {
 		try (BufferedReader buffer = new BufferedReader(new InputStreamReader(stream))) {
             return initializeLanguageServer(buffer.lines().collect(Collectors.joining("\n")), suffixFileName);
         } catch (ExecutionException | InterruptedException | URISyntaxException | IOException ex) {
@@ -176,7 +176,7 @@ public abstract class AbstractCamelLanguageServerTest {
         }
 	}
 	
-	protected CamelLanguageServer initializeLanguageServerWithFileName(FileInputStream stream, String fileName) {
+	protected CamelLanguageServer initializeLanguageServerWithFileName(InputStream stream, String fileName) {
 		try (BufferedReader buffer = new BufferedReader(new InputStreamReader(stream))) {
             return initializeLanguageServerWithFileName(buffer.lines().collect(Collectors.joining("\n")), fileName);
         } catch (ExecutionException | InterruptedException | URISyntaxException | IOException ex) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickFixTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickFixTest.java
@@ -22,6 +22,7 @@ import static org.awaitility.Awaitility.await;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -60,9 +61,19 @@ public abstract class AbstractQuickFixTest extends AbstractCamelLanguageServerTe
 		return createdChanges.get(0);
 	}
 	
+	/**
+	 * @param fileName inside src/test/resources/workspace/diagnostic/ folder
+	 * @return
+	 * @throws FileNotFoundException
+	 */
 	protected TextDocumentIdentifier initAnLaunchDiagnostic(String fileName) throws FileNotFoundException {
 		File f = new File("src/test/resources/workspace/diagnostic/"+fileName);
-		camelLanguageServer = initializeLanguageServerWithFileName(new FileInputStream(f), fileName);
+		FileInputStream streamWithContentToTest = new FileInputStream(f);
+		return initAndLaunchDiagnostic(fileName, streamWithContentToTest);
+	}
+
+	protected TextDocumentIdentifier initAndLaunchDiagnostic(String fileName, InputStream streamWithContentToTest) {
+		camelLanguageServer = initializeLanguageServerWithFileName(streamWithContentToTest, fileName);
 		
 		TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(fileName);
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(textDocumentIdentifier);

--- a/src/test/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickFixTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickFixTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.codeactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.awaitility.core.ConditionFactory;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+public abstract class AbstractQuickFixTest extends AbstractCamelLanguageServerTest {
+	
+	private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(10);
+	private static final Duration AWAIT_POLL_INTERVAL = Duration.ofMillis(5);
+	protected CamelLanguageServer camelLanguageServer;
+
+	protected TextEdit retrieveTextEdit(TextDocumentIdentifier textDocumentIdentifier, Diagnostic diagnostic, CompletableFuture<List<Either<Command, CodeAction>>> codeActions)
+			throws InterruptedException, ExecutionException {
+		assertThat(codeActions.get()).hasSize(1);
+		CodeAction codeAction = codeActions.get().get(0).getRight();
+		assertThat(codeAction.getDiagnostics()).containsOnly(diagnostic);
+		assertThat(codeAction.getKind()).isEqualTo(CodeActionKind.QuickFix);
+		List<TextEdit> createdChanges = codeAction.getEdit().getChanges().get(textDocumentIdentifier.getUri());
+		assertThat(createdChanges).isNotEmpty();
+		return createdChanges.get(0);
+	}
+	
+	protected TextDocumentIdentifier initAnLaunchDiagnostic(String fileName) throws FileNotFoundException {
+		File f = new File("src/test/resources/workspace/diagnostic/"+fileName);
+		camelLanguageServer = initializeLanguageServerWithFileName(new FileInputStream(f), fileName);
+		
+		TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(fileName);
+		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(textDocumentIdentifier);
+		camelLanguageServer.getTextDocumentService().didSave(params);
+		
+		createAwait().untilAsserted(() -> assertThat(lastPublishedDiagnostics).isNotNull());
+		await().timeout(AWAIT_TIMEOUT).untilAsserted(() -> assertThat(lastPublishedDiagnostics.getDiagnostics()).hasSize(1));
+		return textDocumentIdentifier;
+	}
+	
+	protected CompletableFuture<List<Either<Command, CodeAction>>> retrieveCodeActions(TextDocumentIdentifier textDocumentIdentifier, Diagnostic diagnostic) {
+		CodeActionContext context = new CodeActionContext(lastPublishedDiagnostics.getDiagnostics(), Collections.singletonList(CodeActionKind.QuickFix));
+		return camelLanguageServer.getTextDocumentService().codeAction(new CodeActionParams(textDocumentIdentifier, diagnostic.getRange(), context));
+	}
+	
+	protected ConditionFactory createAwait() {
+		return await().pollDelay(Duration.ZERO).pollInterval(AWAIT_POLL_INTERVAL).timeout(AWAIT_TIMEOUT);
+	}
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/codeactions/CamelKafkaConnectorUnknownPropertyQuickfixTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/codeactions/CamelKafkaConnectorUnknownPropertyQuickfixTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.codeactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.apache.camel.kafkaconnector.catalog.CamelKafkaConnectorCatalog;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelKafkaConnectorTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+import com.github.cameltooling.lsp.internal.RangeChecker;
+
+class CamelKafkaConnectorUnknownPropertyQuickfixTest extends AbstractQuickFixTest {
+
+	@Test
+	void testReturnCodeActionForQuickfix() throws Exception {
+		String contentToTest = "connector.class=org.test.kafkaconnector.TestSinkConnector\n"
+				+ "camel.sink.endpoint.withAnEnoughDifferentameToTestQuickfix=with a typo";
+		TextDocumentIdentifier textDocumentIdentifier = initAndLaunchDiagnostic("camel-with-unknownParameter.properties", new ByteArrayInputStream(contentToTest.getBytes()));
+		
+		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
+		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = retrieveCodeActions(textDocumentIdentifier, diagnostic);
+		
+		checkRetrievedCodeAction(textDocumentIdentifier, diagnostic, codeActions);
+	}
+	
+	private void checkRetrievedCodeAction(TextDocumentIdentifier textDocumentIdentifier, Diagnostic diagnostic, CompletableFuture<List<Either<Command, CodeAction>>> codeActions)
+			throws InterruptedException, ExecutionException {
+		TextEdit textEdit = retrieveTextEdit(textDocumentIdentifier, diagnostic, codeActions);
+		Range range = textEdit.getRange();
+		new RangeChecker().check(range, 1, 11, 1, 58);
+		assertThat(textEdit.getNewText()).isEqualTo("endpoint.withAnEnoughDifferentNameToTestQuickfix");
+	}
+	
+	@Override
+	protected CamelLanguageServer initializeLanguageServerWithFileName(InputStream stream, String fileName) {
+		CamelLanguageServer languageServer = super.initializeLanguageServerWithFileName(stream, fileName);
+		CamelKafkaConnectorCatalog catalog = languageServer.getTextDocumentService().getCamelKafkaConnectorManager().getCatalog();
+		catalog.addConnector("connector-source-used-for-test", getContentAsString("/camel-kafka-connector-catalog/connector-sink-used-for-test.json"));
+		return languageServer;
+	}
+	
+	private String getContentAsString(String pathInBundle) {
+		return new BufferedReader(new InputStreamReader(AbstractCamelKafkaConnectorTest.class.getResourceAsStream(pathInBundle), StandardCharsets.UTF_8))
+				.lines()
+				.map(String::trim)
+				.collect(Collectors.joining());
+	}
+	
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfixTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfixTest.java
@@ -17,28 +17,21 @@
 package com.github.cameltooling.lsp.internal.codeactions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.awaitility.core.ConditionFactory;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -46,44 +39,36 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 
-import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
-import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 import com.github.cameltooling.lsp.internal.RangeChecker;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticService;
 
-class UnknownPropertyQuickfixTest extends AbstractCamelLanguageServerTest {
+class UnknownPropertyQuickfixTest extends AbstractQuickFixTest {
 
-	private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(10);
-	private static final Duration AWAIT_POLL_INTERVAL = Duration.ofMillis(5);
-	private CamelLanguageServer camelLanguageServer;
-	
 	@Test
 	void testReturnCodeActionForQuickfix() throws FileNotFoundException, InterruptedException, ExecutionException {
-		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic();
+		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic("camel-with-unknownParameter.xml");
 	
 		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
-		CodeActionContext context = new CodeActionContext(lastPublishedDiagnostics.getDiagnostics(), Collections.singletonList(CodeActionKind.QuickFix));
-		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = camelLanguageServer.getTextDocumentService().codeAction(new CodeActionParams(textDocumentIdentifier, diagnostic.getRange(), context));
+		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = retrieveCodeActions(textDocumentIdentifier, diagnostic);
 		
 		checkRetrievedCodeAction(textDocumentIdentifier, diagnostic, codeActions);
 	}
 	
 	@Test
 	void testReturnCodeActionForQuickfixWhenNoCodeActionKindSpecified() throws FileNotFoundException, InterruptedException, ExecutionException {
-		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic();
+		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic("camel-with-unknownParameter.xml");
 	
 		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
-		CodeActionContext context = new CodeActionContext(lastPublishedDiagnostics.getDiagnostics());
-		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = camelLanguageServer.getTextDocumentService().codeAction(new CodeActionParams(textDocumentIdentifier, diagnostic.getRange(), context));
+		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = retrieveCodeActions(textDocumentIdentifier, diagnostic);
 		
 		checkRetrievedCodeAction(textDocumentIdentifier, diagnostic, codeActions);
 	}
 	
 	@Test
 	void testReturnNoCodeActionForOtherThanQuickfix() throws FileNotFoundException, InterruptedException, ExecutionException {
-		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic();
+		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic("camel-with-unknownParameter.xml");
 		
-		 List<String> codeActionKinds = Stream.of(CodeActionKind.Refactor, CodeActionKind.RefactorExtract, CodeActionKind.RefactorInline, CodeActionKind.RefactorRewrite, CodeActionKind.Source, CodeActionKind.SourceOrganizeImports)
+		List<String> codeActionKinds = Stream.of(CodeActionKind.Refactor, CodeActionKind.RefactorExtract, CodeActionKind.RefactorInline, CodeActionKind.RefactorRewrite, CodeActionKind.Source, CodeActionKind.SourceOrganizeImports)
 			      .collect(Collectors.toList());
 		
 		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
@@ -95,7 +80,7 @@ class UnknownPropertyQuickfixTest extends AbstractCamelLanguageServerTest {
 	
 	@Test
 	void testReturnCodeActionForQuickfixEvenWithInvalidRangeDiagnostic() throws FileNotFoundException, InterruptedException, ExecutionException {
-		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic();
+		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic("camel-with-unknownParameter.xml");
 		
 		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
 	
@@ -105,15 +90,14 @@ class UnknownPropertyQuickfixTest extends AbstractCamelLanguageServerTest {
 		diagnostics.add(diagnosticWithInvalidRange);
 		diagnostics.addAll(lastPublishedDiagnostics.getDiagnostics());
 		
-		CodeActionContext context = new CodeActionContext(diagnostics, Collections.singletonList(CodeActionKind.QuickFix));
-		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = camelLanguageServer.getTextDocumentService().codeAction(new CodeActionParams(textDocumentIdentifier, diagnostic.getRange(), context));
+		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = retrieveCodeActions(textDocumentIdentifier, diagnostic);
 		
 		checkRetrievedCodeAction(textDocumentIdentifier, diagnostic, codeActions);
 	}
 	
 	@Test
 	void testNoErrorWithDiagnosticWithoutCode() throws FileNotFoundException, InterruptedException, ExecutionException {
-		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic();
+		TextDocumentIdentifier textDocumentIdentifier = initAnLaunchDiagnostic("camel-with-unknownParameter.xml");
 		
 		Diagnostic diagnostic = lastPublishedDiagnostics.getDiagnostics().get(0);
 	
@@ -122,40 +106,17 @@ class UnknownPropertyQuickfixTest extends AbstractCamelLanguageServerTest {
 		diagnostics.add(diagnosticWithoutCode);
 		diagnostics.addAll(lastPublishedDiagnostics.getDiagnostics());
 		
-		CodeActionContext context = new CodeActionContext(diagnostics, Collections.singletonList(CodeActionKind.QuickFix));
-		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = camelLanguageServer.getTextDocumentService().codeAction(new CodeActionParams(textDocumentIdentifier, diagnostic.getRange(), context));
+		CompletableFuture<List<Either<Command,CodeAction>>> codeActions = retrieveCodeActions(textDocumentIdentifier, diagnostic);
 		
 		checkRetrievedCodeAction(textDocumentIdentifier, diagnostic, codeActions);
 	}
 	
 	private void checkRetrievedCodeAction(TextDocumentIdentifier textDocumentIdentifier, Diagnostic diagnostic, CompletableFuture<List<Either<Command, CodeAction>>> codeActions)
 			throws InterruptedException, ExecutionException {
-		assertThat(codeActions.get()).hasSize(1);
-		CodeAction codeAction = codeActions.get().get(0).getRight();
-		assertThat(codeAction.getDiagnostics()).containsOnly(diagnostic);
-		assertThat(codeAction.getKind()).isEqualTo(CodeActionKind.QuickFix);
-		List<TextEdit> createdChanges = codeAction.getEdit().getChanges().get(textDocumentIdentifier.getUri());
-		assertThat(createdChanges).isNotEmpty();
-		TextEdit textEdit = createdChanges.get(0);
+		TextEdit textEdit = retrieveTextEdit(textDocumentIdentifier, diagnostic, codeActions);
 		Range range = textEdit.getRange();
 		new RangeChecker().check(range, 9, 33, 9, 37);
 		assertThat(textEdit.getNewText()).isEqualTo("delay");
 	}
 
-	private TextDocumentIdentifier initAnLaunchDiagnostic() throws FileNotFoundException {
-		File f = new File("src/test/resources/workspace/diagnostic/camel-with-unknownParameter.xml");
-		camelLanguageServer = initializeLanguageServer(new FileInputStream(f), ".xml");
-		
-		TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(DUMMY_URI+".xml");
-		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(textDocumentIdentifier);
-		camelLanguageServer.getTextDocumentService().didSave(params);
-		
-		createAwait().untilAsserted(() -> assertThat(lastPublishedDiagnostics).isNotNull());
-		createAwait().untilAsserted(() -> assertThat(lastPublishedDiagnostics.getDiagnostics()).hasSize(1));
-		return textDocumentIdentifier;
-	}
-	
-	private ConditionFactory createAwait() {
-		return await().pollDelay(Duration.ZERO).pollInterval(AWAIT_POLL_INTERVAL).timeout(AWAIT_TIMEOUT);
-	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorPropertiesDiagnosticTest.java
@@ -17,8 +17,8 @@
 package com.github.cameltooling.lsp.internal.diagnostic;
 
 import java.io.BufferedReader;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
@@ -77,7 +77,7 @@ class CamelKafkaConnectorPropertiesDiagnosticTest extends AbstractDiagnosticTest
 	}
 	
 	@Override
-	protected CamelLanguageServer initializeLanguageServer(FileInputStream stream, String extension) {
+	protected CamelLanguageServer initializeLanguageServer(InputStream stream, String extension) {
 		CamelLanguageServer languageServer = super.initializeLanguageServer(stream, extension);
 		CamelKafkaConnectorCatalog catalog = languageServer.getTextDocumentService().getCamelKafkaConnectorManager().getCatalog();
 		catalog.addConnector("connector-source-used-for-test", getContentAsString("/camel-kafka-connector-catalog/connector-source-used-for-test.json"));

--- a/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
+++ b/src/test/resources/camel-kafka-connector-catalog/connector-sink-used-for-test.json
@@ -32,6 +32,11 @@
 			"defaultValue": "null",
 			"priority": "HIGH"
 		},
+		"camel.sink.endpoint.withAnEnoughDifferentNameToTestQuickfix": {
+			"name": "camel.sink.endpoint.withAnEnoughDifferentNameToTestQuickfix",
+			"description": "Description of camel.sink.endpoint.withAnEnoughDifferentNameToTestQuickfix",
+			"priority": "HIGH"
+		},
 		"camel.component.avalue.aMediumComponentOption": {
 			"name": "camel.component.avalue.aMediumComponentOption",
 			"description": "Description of camel.component.avalue.aMediumComponentOption",


### PR DESCRIPTION
![quickfixCamelCaseCamelkafkaConnectorunknownProperties](https://user-images.githubusercontent.com/1105127/102223461-08bd7900-3ee5-11eb-81e9-cc1ac07e29ae.gif)

it is suggesting only camel cased properties. Suggesting dashed case properties would be nice to be done in another iteration