### PR TITLE
FUSETOOLS2-848 - remove filtered example in test

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorOfficialExamplesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorOfficialExamplesDiagnosticTest.java
@@ -93,9 +93,7 @@ class CamelKafkaConnectorOfficialExamplesDiagnosticTest extends AbstractDiagnost
 	static Stream<File> testMainGitRepoExamples() {
 		File[] exampleFiles = new File(mainRepoDirectory, "examples").listFiles();
 		assertThat(exampleFiles).as("Allows to detect if examples has moved for instance.").hasSizeGreaterThan(14);
-		return Stream.of(exampleFiles)
-				// filtering example due to https://github.com/apache/camel-kafka-connector/issues/767
-				.filter(file -> !"CamelAmqpSourceConnector.properties".equals(file.getName()));
+		return Stream.of(exampleFiles);
 	}
 	
 	@ValueSource


### PR DESCRIPTION
as it is now fixed upstream with newly integrated version 0.7.0 of Camel
Kafka Connector

