### PR TITLE
FUSETOOLS2-951 - use tag on personal repo to match embeddedlib version

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorOfficialExamplesDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKafkaConnectorOfficialExamplesDiagnosticTest.java
@@ -62,8 +62,9 @@ class CamelKafkaConnectorOfficialExamplesDiagnosticTest extends AbstractDiagnost
 		
 		specificExampleRepoDirectory = new File(folderWithExamples.toFile(), "camel-kafka-connector-examples");
 		specificExampleGitrepo = Git.cloneRepository()
-				.setURI("https://github.com/apache/camel-kafka-connector-examples")
+				.setURI("https://github.com/apupier/camel-kafka-connector-examples")
 				.setDirectory(specificExampleRepoDirectory)
+				.setBranch("refs/tags/"+ CAMEL_KAFKA_CONNECTOR_VERSION)
 				.call();
 	}
 	


### PR DESCRIPTION
for example test

there is no branch or tag for Camel Kafka Connector examples currently.
Using tag on personal repo to avoid breaking tests for newer components
that are not part of the embedded catalog version.

set PRIO as it is to fix the master

