### PR TITLE
Update internal timeout to have clearer error message

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/AbstractDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/AbstractDiagnosticTest.java
@@ -37,7 +37,7 @@ import com.github.cameltooling.lsp.internal.RangeChecker;
 
 public abstract class AbstractDiagnosticTest extends AbstractCamelLanguageServerTest {
 
-	protected static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(10000);
+	protected static final Duration AWAIT_TIMEOUT = Duration.ofMillis(10000);
 	private static final Duration AWAIT_POLL_INTERVAL = Duration.ofMillis(5);
 	protected CamelLanguageServer camelLanguageServer;
 


### PR DESCRIPTION
instead for a timeout from the CI, there will be the list o fall tests
that are failing

