### PR TITLE
FUSETOOLS2-1057 - provide completion for kafka topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ There is document symbol for Camel Contexts and routes, on XML and Java DSL. In 
 ![Go to Symbol](./images/goToSymbol.gif "Go To Symbol")
 ![Breadcrumb](./images/breadCrumbXml.gif "Breadcrumb")
 
+## Connected mode completion for Kafka component
+
+When using the Camel Kafka component, the list of topics is dynamically retrieved from the Kafka Broker when available. By default, it tries to connect to `localhost:9092`. To connect to another instance, launch the language server with the system property `CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL`. For instance, `java -DCAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL=localhost:9093 -jar camel-lsp-server.jar`.
+
 ## Features planned
 
 * As you type reporting of parsing and compilation errors

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,8 @@
 		<awaitility.version>4.0.3</awaitility.version>
 		<tyrus.version>2.0.0</tyrus.version>
 		<commons-text.version>1.9</commons-text.version>
+		<citrus.kafka.version>3.0.0-M3</citrus.kafka.version>
+		<kafka.clients.version>2.6.0</kafka.clients.version>
 	</properties>
 
 	<distributionManagement>
@@ -332,6 +334,17 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
 			<version>${commons-text.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>${kafka.clients.version}</version>
+		</dependency>        
+		<dependency>
+			<groupId>com.consol.citrus</groupId>
+			<artifactId>citrus-kafka</artifactId>
+			<version>${citrus.kafka.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/KafkaTopicCompletionProvider.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/KafkaTopicCompletionProvider.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
+import org.eclipse.lsp4j.CompletionItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.cameltooling.lsp.internal.instancemodel.PathParamURIInstance;
+
+public class KafkaTopicCompletionProvider {
+	
+	/**
+	 * When launching a local Kafka cluster, this is the default connection provided.
+	 * Using it by default avoids users to specify a setting in this simple case.
+	 */
+	private static final String DEFAULT_CONNECTION = "localhost:9092";
+	public static final String CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL = "CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL";
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(KafkaTopicCompletionProvider.class);
+
+	public CompletableFuture<List<CompletionItem>> get(PathParamURIInstance pathParamURIInstance) {
+		String kafkaConnectionURl = System.getProperty(CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL, DEFAULT_CONNECTION);
+		Admin adminClient = null;
+		try {
+			adminClient = Admin.create(Collections.singletonMap(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConnectionURl));
+			ListTopicsOptions listTopicsOptions = new ListTopicsOptions();
+			listTopicsOptions.listInternal(true);
+			Set<String> topics = adminClient.listTopics(listTopicsOptions).names().get(500, TimeUnit.MILLISECONDS);
+			List<CompletionItem> completionItemsForKafkaTopics = topics.stream().map(topic -> {
+				CompletionItem completionItem = new CompletionItem(topic);
+				CompletionResolverUtils.applyTextEditToCompletionItem(pathParamURIInstance, completionItem);
+				return completionItem;
+			}).collect(Collectors.toList());
+			return CompletableFuture.completedFuture(completionItemsForKafkaTopics);
+		} catch (InterruptedException e) {
+			warnLog(kafkaConnectionURl, e);
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException | TimeoutException e) {
+			warnLog(kafkaConnectionURl, e);
+		} finally {
+			if(adminClient != null) {
+				adminClient.close(Duration.ofMillis(50));
+			}
+		}
+		return CompletableFuture.completedFuture(Collections.emptyList());
+	}
+
+	private void warnLog(String kafkaConnectionURl, Exception e) {
+		LOGGER.warn("Error while trying to connect to {}", kafkaConnectionURl, e);
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
@@ -40,6 +40,7 @@ import com.github.cameltooling.lsp.internal.catalog.util.ModelHelper;
 import com.github.cameltooling.lsp.internal.completion.CamelComponentSchemesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
 import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
+import com.github.cameltooling.lsp.internal.completion.KafkaTopicCompletionProvider;
 
 /**
  * For a Camel URI "timer:timerName?delay=10s", it represents "timerName"
@@ -47,6 +48,7 @@ import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
 public class PathParamURIInstance extends CamelUriElementInstance {
 	
 	private static final Logger LOGGER = LoggerFactory.getLogger(PathParamURIInstance.class);
+
 
 	private CamelComponentAndPathUriInstance uriInstance;
 	private String value;
@@ -66,7 +68,11 @@ public class PathParamURIInstance extends CamelUriElementInstance {
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem) {
 		if(pathParamIndex == 0) {
-			return getCompletionForApiName(camelCatalog, positionInCamelUri, docItem);
+			if("kafka".equals(uriInstance.getComponentName())) {
+				return new KafkaTopicCompletionProvider().get(this);
+			} else {
+				return getCompletionForApiName(camelCatalog, positionInCamelUri, docItem);
+			}
 		}
 		if(pathParamIndex == 1) {
 			return getCompletionForApiMethodName(camelCatalog, positionInCamelUri, docItem);

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/KafkaTopicCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/KafkaTopicCompletionTest.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import com.consol.citrus.kafka.embedded.EmbeddedKafkaServer;
+import com.consol.citrus.kafka.embedded.EmbeddedKafkaServerBuilder;
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class KafkaTopicCompletionTest extends AbstractCamelLanguageServerTest {
+
+	private EmbeddedKafkaServer kafkaServer;
+
+	@AfterEach
+	public void after() throws IOException {
+		System.clearProperty(KafkaTopicCompletionProvider.CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL);
+		if (kafkaServer != null) {
+			kafkaServer.stop();
+		}
+	}
+
+	@Test
+	void testBasicTopicCompletion() throws Exception {
+		String topicName = "topicName";
+		initKafkaWithTopics(topicName);
+
+		List<CompletionItem> completions = retrieveCompletionForKafkaTopicPosition();
+
+		assertThat(completions).hasSize(1);
+		assertThat(completions.get(0).getTextEdit().getLeft().getNewText()).isEqualTo(topicName);
+	}
+
+	@Test
+	@Timeout(2)
+	void testInvalidConnectionUrl() throws Exception {
+		String connectionURL = "localhost:9091";
+		System.setProperty(KafkaTopicCompletionProvider.CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL, connectionURL);
+
+		List<CompletionItem> completions = retrieveCompletionForKafkaTopicPosition();
+
+		assertThat(completions).isEmpty();
+	}
+
+	@Test
+	void testNoConnectionUrlSpecified() throws Exception {
+		String topicName = "topicName";
+		kafkaServer = new EmbeddedKafkaServerBuilder()
+				.kafkaServerPort(9092)
+				.topics(topicName)
+				.build();
+		kafkaServer.start();
+		List<CompletionItem> completions = retrieveCompletionForKafkaTopicPosition();
+
+		assertThat(completions).hasSize(1);
+		assertThat(completions.get(0).getTextEdit().getLeft().getNewText()).isEqualTo(topicName);
+	}
+
+	@Test
+	void testNoTopic() throws Exception {
+		initKafkaWithTopics("");
+		List<CompletionItem> completions = retrieveCompletionForKafkaTopicPosition();
+
+		assertThat(completions).isEmpty();
+	}
+	
+	@Test
+	void testSeveralTopics() throws Exception {
+		initKafkaWithTopics("topic1,topic2");
+		List<CompletionItem> completions = retrieveCompletionForKafkaTopicPosition();
+
+		assertThat(completions).hasSize(2);
+	}
+
+	private void initKafkaWithTopics(String topics) {
+		kafkaServer = new EmbeddedKafkaServerBuilder().topics(topics).build();
+		kafkaServer.start();
+		String connectionURL = "localhost:" + kafkaServer.getKafkaServerPort();
+		System.setProperty(KafkaTopicCompletionProvider.CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL, connectionURL);
+	}
+
+	private List<CompletionItem> retrieveCompletionForKafkaTopicPosition() throws URISyntaxException, InterruptedException, ExecutionException {
+		String text = "<from uri=\"kafka:\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n";
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".xml");
+		return getCompletionFor(languageServer, new Position(0, 17)).get().getLeft();
+	}
+
+}


### PR DESCRIPTION
first iteration:
- does not support multi-topics (which is possible for consumer
configuration)
- does not support connection that requires authentication
- use localhost:9092 by default
- use system property to override connection url (not convenient for
language server clients but useful for testing)

next iterations:
- connection url provided with a setting https://issues.redhat.com/browse/FUSETOOLS2-1059
- support credentials https://issues.redhat.com/browse/FUSETOOLS2-1060
- support of multi-topics https://issues.redhat.com/browse/FUSETOOLS2-1061
- use `brokers` attribute if provided in Camel URL property https://issues.redhat.com/browse/FUSETOOLS2-1062
- completion for some attributes that can be retrieved from a connected
instance? partitionKey? others?


https://user-images.githubusercontent.com/1105127/114393561-6f545a00-9b9a-11eb-8354-47a84ca0fd45.mp4

