### PR TITLE
FUSETOOLS2-1097 - provide completion for kamelet id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 		<jgit.version>5.11.0.202103091610-r</jgit.version>
 		<camel.version>3.9.0</camel.version>
 		<camel.kafka.connector.version>0.9.0</camel.kafka.connector.version>
+		<camel.kamelet.catalog.version>main-SNAPSHOT</camel.kamelet.catalog.version>
 		<camel.quarkus.version>1.8.1</camel.quarkus.version>
 		<roaster.version>2.21.1.Final</roaster.version>
 		<awaitility.version>4.0.3</awaitility.version>
@@ -261,6 +262,11 @@
 			<version>${camel.kafka.connector.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.camel.kamelets</groupId>
+			<artifactId>camel-kamelets-catalog</artifactId>
+			<version>${camel.kamelet.catalog.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.camel.karaf</groupId>
 			<artifactId>camel-catalog-provider-karaf</artifactId>
 			<version>${camel.version}</version>
@@ -347,4 +353,17 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<repositories>
+        <repository>
+            <id>apache.snapshots</id>
+            <url>https://repository.apache.org/snapshots/</url>
+            <name>Apache Snapshot Repo</name>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
 </project>

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/KameletTemplateIdCompletionProvider.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/KameletTemplateIdCompletionProvider.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import org.apache.camel.kamelets.catalog.KameletsCatalog;
+import org.eclipse.lsp4j.CompletionItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.cameltooling.lsp.internal.instancemodel.PathParamURIInstance;
+
+public class KameletTemplateIdCompletionProvider {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(KameletTemplateIdCompletionProvider.class);
+
+	public CompletableFuture<List<CompletionItem>> get(PathParamURIInstance pathParamURIInstance) {
+		KameletsCatalog kameletsCatalog;
+		try {
+			kameletsCatalog = new KameletsCatalog();
+			List<String> kameletsName = kameletsCatalog.getKameletsName();
+			List<CompletionItem> completionItems = kameletsName
+					.stream()
+					.map(name -> {
+						CompletionItem completionItem = new CompletionItem(name);
+						CompletionResolverUtils.applyTextEditToCompletionItem(pathParamURIInstance, completionItem);
+						return completionItem;
+					})
+					.collect(Collectors.toList());
+			return CompletableFuture.completedFuture(completionItems);
+		} catch (IOException e) {
+			LOGGER.warn("Cannot determine completion for Kamelet template Ids", e);
+		}
+		return CompletableFuture.completedFuture(Collections.emptyList());
+		
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
@@ -41,6 +41,7 @@ import com.github.cameltooling.lsp.internal.completion.CamelComponentSchemesComp
 import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
 import com.github.cameltooling.lsp.internal.completion.FilterPredicateUtils;
 import com.github.cameltooling.lsp.internal.completion.KafkaTopicCompletionProvider;
+import com.github.cameltooling.lsp.internal.completion.KameletTemplateIdCompletionProvider;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
 /**
@@ -69,8 +70,11 @@ public class PathParamURIInstance extends CamelUriElementInstance {
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
 		if(pathParamIndex == 0) {
-			if("kafka".equals(uriInstance.getComponentName())) {
+			String componentName = uriInstance.getComponentName();
+			if("kafka".equals(componentName)) {
 				return new KafkaTopicCompletionProvider().get(this, settingsManager);
+			} else if("kamelet".equals(componentName)){
+				return new KameletTemplateIdCompletionProvider().get(this);
 			} else {
 				return getCompletionForApiName(camelCatalog, positionInCamelUri, docItem);
 			}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/KameletCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/KameletCompletionTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class KameletCompletionTest extends AbstractCamelLanguageServerTest {
+	
+	@Test
+	void testKameletTemplateIdCompletion() throws Exception {
+		CamelLanguageServer languageServer = initLanguageServer();
+		
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 19)).get().getLeft();
+		
+		CompletionItem completionItem = new CompletionItem("aws-ddb-streams-source");
+		completionItem.setTextEdit(
+				Either.forLeft(
+						new TextEdit(
+								new Range(new Position(0, 19), new Position(0, 19)),
+								"aws-ddb-streams-source")));
+		assertThat(completions)
+			.hasSizeGreaterThan(10)
+			.contains(completionItem);
+	}
+		
+	private CamelLanguageServer initLanguageServer() throws URISyntaxException, InterruptedException, ExecutionException {
+		String text = "<from uri=\"kamelet:\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n";
+		return initializeLanguageServer(text, ".xml");
+	}
+	
+}


### PR DESCRIPTION
first iteration:
- ~requires locally built version until version is published on Apache
Snapshots. the version is currently main-SNAPSHOT, this will need to be updated.~ https://repository.apache.org/content/repositories/snapshots/org/apache/camel/kamelets/camel-kamelets-catalog/main-SNAPSHOT/
- no distinction between source and sink
- no description
- Catalog is reloaded on each completion call in a kamelet template Id
part

![Screenshot from 2021-05-04 09-30-56](https://user-images.githubusercontent.com/1105127/116972544-7236fc00-acbb-11eb-8eb2-a8d66e6aca5f.png)
