### PR TITLE
FUSETOOLS2-1107 - provide cached KameletCatalog

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.catalog.runtimeprovider.CamelRuntimeProvider;
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.codeactions.CodeActionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelPropertiesCompletionProcessor;
@@ -95,6 +96,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 	private CompletableFuture<CamelCatalog> camelCatalog;
 	private CamelLanguageServer camelLanguageServer;
 	private CamelKafkaConnectorCatalogManager camelKafkaConnectorManager = new CamelKafkaConnectorCatalogManager();
+	private KameletsCatalogManager kameletsCatalogManager = new KameletsCatalogManager();
 
 	public CamelTextDocumentService(CamelLanguageServer camelLanguageServer) {
 		this.camelLanguageServer = camelLanguageServer;
@@ -148,11 +150,11 @@ public class CamelTextDocumentService implements TextDocumentService {
 		LOGGER.info("completion: {}", uri);
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
 		if (uri.endsWith(".properties")){
-			return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition(), getSettingsManager()).thenApply(Either::forLeft);
+			return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition(), getSettingsManager(), getKameletsCatalogManager()).thenApply(Either::forLeft);
 		} else if(isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
 			return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 		} else {
-			return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition(), getSettingsManager()).thenApply(Either::forLeft);
+			return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog(), getKameletsCatalogManager()).getCompletions(completionParams.getPosition(), getSettingsManager()).thenApply(Either::forLeft);
 		}
 	}
 
@@ -316,5 +318,9 @@ public class CamelTextDocumentService implements TextDocumentService {
 
 	public SettingsManager getSettingsManager() {
 		return camelLanguageServer.getSettingsManager();
+	}
+	
+	public KameletsCatalogManager getKameletsCatalogManager() {
+		return kameletsCatalogManager;
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/KameletsCatalogManager.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/KameletsCatalogManager.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.catalog.util;
+
+import java.io.IOException;
+
+import org.apache.camel.kamelets.catalog.KameletsCatalog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KameletsCatalogManager {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(KameletsCatalogManager.class);
+	
+	private KameletsCatalog kameletsCatalog;
+
+	public KameletsCatalogManager() {
+		try {
+			kameletsCatalog = new KameletsCatalog();
+		} catch (IOException e) {
+			LOGGER.error("Cannot load Kamelet Catalog", e);
+		}
+	}
+
+	public KameletsCatalog getCatalog() {
+		return kameletsCatalog;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickfix.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/codeactions/AbstractQuickfix.java
@@ -41,6 +41,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import com.github.cameltooling.lsp.internal.CamelTextDocumentService;
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
@@ -60,7 +61,7 @@ public abstract class AbstractQuickfix {
 			if(diagnostic.getCode()!= null && getDiagnosticId().equals(diagnostic.getCode().getLeft())) {
 				CharSequence currentValueInError = retrieveCurrentErrorValue(openedDocument, diagnostic);
 				if(currentValueInError != null) {
-					List<String> possibleProperties = retrievePossibleValues(openedDocument, camelTextDocumentService.getCamelCatalog(), camelTextDocumentService.getCamelKafkaConnectorManager(), diagnostic.getRange().getStart(), camelTextDocumentService.getSettingsManager());
+					List<String> possibleProperties = retrievePossibleValues(openedDocument, camelTextDocumentService.getCamelCatalog(), camelTextDocumentService.getCamelKafkaConnectorManager(), diagnostic.getRange().getStart(), camelTextDocumentService.getSettingsManager(), camelTextDocumentService.getKameletsCatalogManager());
 					int distanceThreshold = Math.round(currentValueInError.length() * 0.4f);
 					LevenshteinDistance levenshteinDistance = new LevenshteinDistance(distanceThreshold);
 					List<String> mostProbableProperties = possibleProperties.stream()
@@ -97,7 +98,7 @@ public abstract class AbstractQuickfix {
 		return codeAction;
 	}
 	
-	protected abstract List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager, Position position, SettingsManager settingsManager);
+	protected abstract List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager, Position position, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager);
 	protected abstract String getDiagnosticId();
 	
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/codeactions/InvalidEnumQuickfix.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/codeactions/InvalidEnumQuickfix.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.CamelTextDocumentService;
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticService;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
@@ -44,9 +45,9 @@ public class InvalidEnumQuickfix extends AbstractQuickfix {
 	}
 
 	@Override
-	protected List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager ckcCatalogmanager, Position position, SettingsManager settingsManager) {
+	protected List<String> retrievePossibleValues(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager ckcCatalogmanager, Position position, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		try {
-			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog)
+			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog, kameletsCatalogManager)
 					.getCompletions(position, settingsManager)
 					.thenApply(completionItems -> completionItems.stream().map(CompletionItem::getLabel).collect(Collectors.toList()))
 					.get();

--- a/src/main/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfix.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/codeactions/UnknownPropertyQuickfix.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.CamelTextDocumentService;
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticService;
 import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyKeyInstance;
@@ -57,7 +58,8 @@ public class UnknownPropertyQuickfix extends AbstractQuickfix {
 			CompletableFuture<CamelCatalog> camelCatalog,
 			CamelKafkaConnectorCatalogManager camelKafkaConnectorManager,
 			Position position,
-			SettingsManager settingsManager) {
+			SettingsManager settingsManager,
+			KameletsCatalogManager kameletsCatalogManager) {
 		if (textDocumentItem.getUri().endsWith(".properties")) {
 			Optional<CamelKafkaConnectorModel> optionalModel = camelKafkaConnectorManager.findConnectorModel(new CamelKafkaUtil().findConnectorClass(textDocumentItem));
 			if (optionalModel.isPresent()) {
@@ -69,7 +71,7 @@ public class UnknownPropertyQuickfix extends AbstractQuickfix {
 			}
 		} else {
 			try {
-				return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position, settingsManager)
+				return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog, kameletsCatalogManager).getCompletions(position, settingsManager)
 						.thenApply(completionItems -> completionItems.stream().map(CompletionItem::getInsertText)
 								.collect(Collectors.toList()))
 						.get();

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelEndpointCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelEndpointCompletionProcessor.java
@@ -27,6 +27,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.instancemodel.CamelURIInstance;
 import com.github.cameltooling.lsp.internal.instancemodel.CamelUriElementInstance;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelper;
@@ -39,10 +40,12 @@ public class CamelEndpointCompletionProcessor {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CamelEndpointCompletionProcessor.class);
 	private TextDocumentItem textDocumentItem;
 	private CompletableFuture<CamelCatalog> camelCatalog;
+	private KameletsCatalogManager kameletsCatalogManager;
 
-	public CamelEndpointCompletionProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog) {
+	public CamelEndpointCompletionProcessor(TextDocumentItem textDocumentItem, CompletableFuture<CamelCatalog> camelCatalog, KameletsCatalogManager kameletsCatalogManager) {
 		this.textDocumentItem = textDocumentItem;
 		this.camelCatalog = camelCatalog;
+		this.kameletsCatalogManager = kameletsCatalogManager;
 	}
 
 	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, SettingsManager settingsManager) {
@@ -66,7 +69,7 @@ public class CamelEndpointCompletionProcessor {
 
 	private CompletableFuture<List<CompletionItem>> getCompletions(CamelURIInstance camelURIInstance, int positionInCamelUri, SettingsManager settingsManager) {
 		CamelUriElementInstance camelUriElementInstance = camelURIInstance.getSpecificElement(positionInCamelUri);
-		return camelUriElementInstance.getCompletions(camelCatalog, positionInCamelUri, textDocumentItem, settingsManager);
+		return camelUriElementInstance.getCompletions(camelCatalog, positionInCamelUri, textDocumentItem, settingsManager, kameletsCatalogManager);
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
@@ -26,6 +26,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyEntryInstance;
 import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
@@ -42,10 +43,10 @@ public class CamelPropertiesCompletionProcessor {
 		this.camelKafkaConnectorManager = camelKafkaConnectorManager;
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if (textDocumentItem != null) {
 			String line = new ParserFileHelperUtil().getLine(textDocumentItem, position);
-			return new CamelPropertyEntryInstance(line, new Position(position.getLine(), 0), textDocumentItem).getCompletions(position, camelCatalog, camelKafkaConnectorManager, settingsManager);
+			return new CamelPropertyEntryInstance(line, new Position(position.getLine(), 0), textDocumentItem).getCompletions(position, camelCatalog, camelKafkaConnectorManager, settingsManager, kameletsCatalogManager);
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelComponentAndPathUriInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelComponentAndPathUriInstance.java
@@ -27,6 +27,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelComponentSchemesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
@@ -135,10 +136,10 @@ public class CamelComponentAndPathUriInstance extends CamelUriElementInstance {
 	}
 	
 	@Override
-	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		CamelUriElementInstance specificElement = getSpecificElement(positionInCamelUri);
 		if (specificElement != null && specificElement != component && specificElement != this) {
-			return specificElement.getCompletions(camelCatalog, positionInCamelUri, docItem, settingsManager);
+			return specificElement.getCompletions(camelCatalog, positionInCamelUri, docItem, settingsManager, kameletsCatalogManager);
 		} else if(getStartPositionInUri() <= positionInCamelUri && positionInCamelUri <= getEndPositionInUri()) {
 			return camelCatalog.thenApply(new CamelComponentSchemesCompletionsFuture(this, getFilter(positionInCamelUri), docItem));
 		} else {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelComponentURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelComponentURIInstance.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
 /**
@@ -46,8 +47,8 @@ public class CamelComponentURIInstance extends CamelUriElementInstance {
 	}
 
 	@Override
-	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
-		return parent.getCompletions(camelCatalog, positionInCamelUri, docItem, settingsManager);		
+	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
+		return parent.getCompletions(camelCatalog, positionInCamelUri, docItem, settingsManager, kameletsCatalogManager);		
 	}
 	
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstance.java
@@ -31,6 +31,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.w3c.dom.Node;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelComponentSchemesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
@@ -118,7 +119,7 @@ public class CamelURIInstance extends CamelUriElementInstance {
 	}
 
 	@Override
-	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if(getStartPositionInUri() <= positionInCamelUri && positionInCamelUri <= getEndPositionInUri()) {
 			return camelCatalog.thenApply(new CamelComponentSchemesCompletionsFuture(this, getFilter(), docItem));
 		} else {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelUriElementInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelUriElementInstance.java
@@ -32,6 +32,7 @@ import com.github.cameltooling.lsp.internal.catalog.model.ApiPropertyMethodOptio
 import com.github.cameltooling.lsp.internal.catalog.model.ApiPropertyOptionModel;
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
 import com.github.cameltooling.lsp.internal.catalog.model.EndpointOptionModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
 public abstract class CamelUriElementInstance implements ILineRangeDefineable{
@@ -77,7 +78,7 @@ public abstract class CamelUriElementInstance implements ILineRangeDefineable{
 		return getCamelUriInstance().getAbsoluteBounds().getStart().getLine();
 	}
 	
-	public abstract CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager);
+	public abstract CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager);
 	
 	public abstract String getComponentName();
 	

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamKeyURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamKeyURIInstance.java
@@ -26,6 +26,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelOptionNamesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
@@ -53,7 +54,7 @@ public class OptionParamKeyURIInstance extends CamelUriElementInstance {
 	}
 	
 	@Override
-	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if(getStartPositionInUri() <= positionInCamelUri && positionInCamelUri <= getEndPositionInUri()) {
 			return camelCatalog.thenApply(new CamelOptionNamesCompletionsFuture(this, getComponentName(), optionParamURIInstance.isProducer(), getFilter(positionInCamelUri), positionInCamelUri, getAlreadyDefinedUriOptions()));
 		} else {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamURIInstance.java
@@ -27,6 +27,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
 import com.github.cameltooling.lsp.internal.catalog.model.EndpointOptionModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
 /**
@@ -71,7 +72,7 @@ public class OptionParamURIInstance extends CamelUriElementInstance {
 	}
 	
 	@Override
-	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamValueURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamValueURIInstance.java
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelOptionValuesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
@@ -48,7 +49,7 @@ public class OptionParamValueURIInstance extends CamelUriElementInstance {
 	}
 
 	@Override
-	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if(getStartPositionInUri() <= positionInCamelUri && positionInCamelUri <= getEndPositionInUri()) {
 			return camelCatalog.thenApply(new CamelOptionValuesCompletionsFuture(this, getFilter(positionInCamelUri)));
 		} else {

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.github.cameltooling.lsp.internal.catalog.model.ApiOptionMethodsModel;
 import com.github.cameltooling.lsp.internal.catalog.model.ApiOptionModel;
 import com.github.cameltooling.lsp.internal.catalog.model.ComponentModel;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.catalog.util.ModelHelper;
 import com.github.cameltooling.lsp.internal.completion.CamelComponentSchemesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.completion.CompletionResolverUtils;
@@ -68,13 +69,13 @@ public class PathParamURIInstance extends CamelUriElementInstance {
 	}
 	
 	@Override
-	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if(pathParamIndex == 0) {
 			String componentName = uriInstance.getComponentName();
 			if("kafka".equals(componentName)) {
 				return new KafkaTopicCompletionProvider().get(this, settingsManager);
 			} else if("kamelet".equals(componentName)){
-				return new KameletTemplateIdCompletionProvider().get(this);
+				return new KameletTemplateIdCompletionProvider(kameletsCatalogManager).get(this);
 			} else {
 				return getCompletionForApiName(camelCatalog, positionInCamelUri, docItem);
 			}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.instancemodel.ILineRangeDefineable;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
 
@@ -63,11 +64,11 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 		camelPropertyValueInstance = new CamelPropertyValueInstance(camelPropertyFileValueInstanceString, camelPropertyKeyInstance, textDocumentItem);
 	}
 	
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if (isOnPropertyKey(position)) {
 			return camelPropertyKeyInstance.getCompletions(position, camelCatalog, camelKafkaConnectorManager);
 		} else {
-			return camelPropertyValueInstance.getCompletions(position, camelCatalog, camelKafkaConnectorManager, settingsManager);
+			return camelPropertyValueInstance.getCompletions(position, camelCatalog, camelKafkaConnectorManager, settingsManager, kameletsCatalogManager);
 		}
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.completion.CamelComponentOptionValuesCompletionsFuture;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelKafkaConnectorClassCompletionProcessor;
@@ -56,10 +57,10 @@ public class CamelPropertyValueInstance implements ILineRangeDefineable {
 		this.textDocumentItem = textDocumentItem;
 	}
 
-	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager, SettingsManager settingsManager) {
+	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, CompletableFuture<CamelCatalog> camelCatalog, CamelKafkaConnectorCatalogManager camelKafkaConnectorManager, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		String propertyKey = key.getCamelPropertyKey();
 		if (new CamelKafkaUtil().isCamelURIForKafka(propertyKey)) {
-			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog).getCompletions(position, settingsManager);
+			return new CamelEndpointCompletionProcessor(textDocumentItem, camelCatalog, kameletsCatalogManager).getCompletions(position, settingsManager);
 		} else if (new CamelKafkaUtil().isConnectorClassForCamelKafkaConnector(propertyKey)) {
 			String startFilter = computeStartFilter(position);
 			return new CamelKafkaConnectorClassCompletionProcessor(this, camelKafkaConnectorManager).getCompletions(startFilter);

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
@@ -58,7 +58,7 @@ public class CamelKModelinePropertyOption implements ICamelKModelineOptionValue 
 	
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(int positionInLine, CompletableFuture<CamelCatalog> camelCatalog) {
-		return value.getCompletions(new Position(0, positionInLine), camelCatalog, null, null);
+		return value.getCompletions(new Position(0, positionInLine), camelCatalog, null, null, null);
 	}
 	
 	@Override


### PR DESCRIPTION
nota: it requires a lot of changes just to propagate the Catalog. I
think I need to change the way it is provided to various model elements
to avoid that (pass the textDocumentService maybe instead of teh specifc
catalogs?) but work for a distinct PR

no notable changes from use rpoint of view (few milliseconds gain speed) but it allows to have a structure more coherent to other catalogs and open possibility to have a dynamic one