### PR TITLE
FUSETOOLS2-1106 - provide completion for Kamelet properties

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ComponentNameConstants.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ComponentNameConstants.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.instancemodel;
+
+public class ComponentNameConstants {
+
+	public static final String COMPONENT_NAME_KAFKA = "kafka";
+	public static final String COMPONENT_NAME_KAMELET = "kamelet";
+	
+	private ComponentNameConstants() {}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamKeyURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/OptionParamKeyURIInstance.java
@@ -56,7 +56,13 @@ public class OptionParamKeyURIInstance extends CamelUriElementInstance {
 	@Override
 	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if(getStartPositionInUri() <= positionInCamelUri && positionInCamelUri <= getEndPositionInUri()) {
-			return camelCatalog.thenApply(new CamelOptionNamesCompletionsFuture(this, getComponentName(), optionParamURIInstance.isProducer(), getFilter(positionInCamelUri), positionInCamelUri, getAlreadyDefinedUriOptions()));
+			return camelCatalog.thenApply(new CamelOptionNamesCompletionsFuture(this,
+					getComponentName(),
+					optionParamURIInstance.isProducer(),
+					getFilter(positionInCamelUri),
+					positionInCamelUri,
+					getAlreadyDefinedUriOptions(),
+					kameletsCatalogManager));
 		} else {
 			return CompletableFuture.completedFuture(Collections.emptyList());
 		}

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/PathParamURIInstance.java
@@ -52,11 +52,7 @@ import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
  */
 public class PathParamURIInstance extends CamelUriElementInstance {
 	
-	private static final String COMPONENT_NAME_KAMELET = "kamelet";
-
-
 	private static final Logger LOGGER = LoggerFactory.getLogger(PathParamURIInstance.class);
-
 
 	private CamelComponentAndPathUriInstance uriInstance;
 	private String value;
@@ -77,9 +73,9 @@ public class PathParamURIInstance extends CamelUriElementInstance {
 	public CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if(pathParamIndex == 0) {
 			String componentName = uriInstance.getComponentName();
-			if("kafka".equals(componentName)) {
+			if(ComponentNameConstants.COMPONENT_NAME_KAFKA.equals(componentName)) {
 				return new KafkaTopicCompletionProvider().get(this, settingsManager);
-			} else if(COMPONENT_NAME_KAMELET.equals(componentName)){
+			} else if(ComponentNameConstants.COMPONENT_NAME_KAMELET.equals(componentName)){
 				return new KameletTemplateIdCompletionProvider(kameletsCatalogManager).get(this);
 			} else {
 				return getCompletionForApiName(camelCatalog, positionInCamelUri, docItem);
@@ -194,7 +190,7 @@ public class PathParamURIInstance extends CamelUriElementInstance {
 	
 	@Override
 	public String getDescription(ComponentModel componentModel, KameletsCatalogManager kameletCatalogManager) {
-		if(pathParamIndex == 0 && COMPONENT_NAME_KAMELET.equals(getComponentName())) {
+		if(pathParamIndex == 0 && ComponentNameConstants.COMPONENT_NAME_KAMELET.equals(getComponentName())) {
 			JSONSchemaProps kamelet = kameletCatalogManager.getCatalog().getKameletDefinition(getValue());
 			if(kamelet != null) {
 				return kamelet.getDescription();
@@ -228,5 +224,9 @@ public class PathParamURIInstance extends CamelUriElementInstance {
 			LOGGER.warn("Cannot retrieve Path parameter name", ee);
 			return null;
 		}
+	}
+
+	public int getPathParamIndex() {
+		return pathParamIndex;
 	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/KameletCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/KameletCompletionTest.java
@@ -57,6 +57,29 @@ class KameletCompletionTest extends AbstractCamelLanguageServerTest {
 			.contains(createAwsKinesisSinkCompletionItem())
 			.doesNotContain(createAwsddbSourceCompletionItem());
 	}
+	
+	@Test
+	void testKameletPropertyCompletionForSource() throws Exception {
+		CamelLanguageServer languageServer = initLanguageServer("<from uri=\"kamelet:aws-ddb-streams-source?\" xmlns=\"http://camel.apache.org/schema/blueprint\"></from>\n");
+		
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 42)).get().getLeft();
+		
+		assertThat(completions)
+			.hasSizeGreaterThan(5)
+			.contains(createTablePropertyCompletionItem());
+	}
+
+	private CompletionItem createTablePropertyCompletionItem() {
+		CompletionItem completionItem = new CompletionItem("table");
+		completionItem.setInsertText("table=");
+		completionItem.setTextEdit(
+				Either.forLeft(
+						new TextEdit(
+								new Range(new Position(0, 42), new Position(0, 42)),
+								"table=")));
+		completionItem.setDocumentation("Name of the DynamoDB table to look at");
+		return completionItem;
+	}
 
 	private CompletionItem createAwsddbSourceCompletionItem() {
 		CompletionItem completionItem = new CompletionItem("aws-ddb-streams-source");


### PR DESCRIPTION
~one point not clear if some "common" properties needs to be kept or not https://chat.google.com/room/AAAAeFFdN0E/YCC1TvufStA (there were provided before so not changing the behavio rinthis PR. it can still be changed later)~ it is normal to have them

![completionKamaletPropertyName](https://user-images.githubusercontent.com/1105127/117966844-ab5b1600-b324-11eb-9283-1a3283f556ff.gif)
