### PR TITLE
FUSETOOLS2-1188 - provide metrics

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -1,0 +1,15 @@
+# Telemetry data collection
+
+Telemetry events can be collected by the LSP client program.
+
+The following information is emitted when the language server starts:
+
+ * JVM information:
+    * Whether it is being run with Java or as a GraalVM native image (binary)
+    * The name of the vm (`java.vm.name`)
+    * The name of the runtime (`java.runtime.name`)
+    * The version of the JVM (`java.version`)
+    * The free, total, and max VM memory
+ * Note: Does NOT include the `JAVA_HOME` environment variable for privacy reasons
+
+Currently, the startup event is the only telemetry event that is emitted.

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ServerCapabilities;
@@ -36,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
+import com.github.cameltooling.lsp.internal.telemetry.TelemetryManager;
 
 /**
  * this is the actual server implementation
@@ -49,6 +51,7 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 	
 	private LanguageClient client;
 	private SettingsManager settingsManager;
+	private TelemetryManager telemetryManager;
 	
 	public CamelLanguageServer() {
 		CamelTextDocumentService textDocumentService = new CamelTextDocumentService(this);
@@ -60,6 +63,7 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 	@Override
 	public void connect(LanguageClient client) {
 		this.client = client;
+		telemetryManager = new TelemetryManager(client);
 	}
 	
 	@Override
@@ -83,6 +87,14 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 		ServerCapabilities capabilities = createServerCapabilities();
 		InitializeResult result = new InitializeResult(capabilities);
 		return CompletableFuture.completedFuture(result);
+	}
+	
+	@Override
+	public void initialized(InitializedParams params) {
+		LanguageServer.super.initialized(params);
+		if(telemetryManager != null) {
+			telemetryManager.onInitialized();
+		}
 	}
 
 	private ServerCapabilities createServerCapabilities() {

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/InitializationTelemetryInfo.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/InitializationTelemetryInfo.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.cameltooling.lsp.internal.telemetry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Telemetry data to collect.
+ *
+ * <ul>
+ * <li>Server version information</li>
+ * <li>JVM information</li>
+ * </ul>
+ *
+ * @author Angelo ZERR
+ *
+ * Mostly duplicated from Eclipse Lemminx, the xml language server
+ */
+public class InitializationTelemetryInfo {
+
+	public static final String JVM_MEMORY_MAX = "jvm.memory.max";
+	public static final String JVM_MEMORY_TOTAL = "jvm.memory.total";
+	public static final String JVM_MEMORY_FREE = "jvm.memory.free";
+	public static final String JVM_IS_NATIVE_IMAGE = "server.is.native";
+	public static final String JVM_RUNTIME = "jvm.runtime";
+	public static final String JVM_VERSION = "jvm.version";
+	public static final String JVM_NAME = "jvm.name";
+	public static final String SERVER_VERSION_NUMBER = "server.version";
+	
+	private InitializationTelemetryInfo() {
+		// Static util method only
+	}
+	
+	/**
+	 * Returns the init telemetry as a map
+	 *
+	 * @return the init telemetry as a map
+	 */
+	public static Map<String, Object> getInitializationTelemetryInfo() {
+		Map<String, Object> initTelemetry = new HashMap<>();
+
+		JVM jvm = Platform.getJVM();
+
+		initTelemetry.put(JVM_NAME, jvm.getName());
+		initTelemetry.put(JVM_VERSION, jvm.getVersion());
+		initTelemetry.put(JVM_RUNTIME, jvm.getRuntime());
+		initTelemetry.put(JVM_IS_NATIVE_IMAGE, jvm.isNativeImage());
+
+		Memory memory = jvm.getMemory();
+
+		initTelemetry.put(JVM_MEMORY_FREE, memory.getFree());
+		initTelemetry.put(JVM_MEMORY_TOTAL, memory.getTotal());
+		initTelemetry.put(JVM_MEMORY_MAX, memory.getMax());
+
+		return initTelemetry;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/JVM.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/JVM.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.cameltooling.lsp.internal.telemetry;
+
+/**
+ * JVM information
+ *
+ * Mostly duplicated from Eclipse Lemminx, the xml language server
+ */
+public class JVM {
+
+	private final String name;
+
+	private final String runtime;
+
+	private final String version;
+
+	private final boolean isNativeImage;
+
+	private final Memory memory;
+
+	private final String javaHome;
+
+	public JVM() {
+		this.name = Platform.getSystemProperty("java.vm.name"); // ex : OpenJDK 64-Bit Server VM
+		this.runtime = Platform.getSystemProperty("java.runtime.name"); // ex : OpenJDK Runtime Environment
+		this.version = Platform.getSystemProperty("java.version"); // ex : 11
+		this.memory = new Memory();
+		this.isNativeImage = "Substrate VM".equals(System.getProperty("java.vm.name"));
+		this.javaHome = Platform.getSystemProperty("java.home");
+	}
+
+	/**
+	 * Returns the JVM name
+	 *
+	 * @return the JVM name
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Returns the JVM version
+	 *
+	 * @return the JVM version
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * Returns the JVM runtime name.
+	 *
+	 * @return the JVM runtime name.
+	 */
+	public String getRuntime() {
+		return runtime;
+	}
+
+	/**
+	 * Returns the information on the memory
+	 *
+	 * @return the information on the memory
+	 */
+	public Memory getMemory() {
+		return memory;
+	}
+
+	/**
+	 * Returns the value of the JAVA_HOME environment variable
+	 *
+	 * Do not include this information in telemetry, as it likely includes the
+	 * user's name
+	 *
+	 * @return the value of the JAVA_HOME environment variable
+	 */
+	public String getJavaHome() {
+		return javaHome;
+	}
+
+	/**
+	 * Returns true if the server is a native image and false otherwise
+	 *
+	 * @return true if the server is a native image and false otherwise
+	 */
+	public boolean isNativeImage() {
+		return isNativeImage;
+	}
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/Memory.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/Memory.java
@@ -1,0 +1,35 @@
+package com.github.cameltooling.lsp.internal.telemetry;
+
+/**
+ * JVM memory information
+ *
+ * Mostly duplicated from Eclipse Lemminx, the xml language server
+ */
+public class Memory {
+
+	private final long free;
+
+	private final long total;
+
+	private final long max;
+
+	Memory() {
+		super();
+		this.free = Runtime.getRuntime().freeMemory();
+		this.total = Runtime.getRuntime().totalMemory();
+		this.max = Runtime.getRuntime().maxMemory();
+	}
+
+	public long getFree() {
+		return free;
+	}
+
+	public long getTotal() {
+		return total;
+	}
+
+	public long getMax() {
+		return max;
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/OS.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/OS.java
@@ -1,0 +1,60 @@
+package com.github.cameltooling.lsp.internal.telemetry;
+
+/**
+ * OS information
+ * 
+ * Mostly duplicated from Eclipse Lemminx, the xml language server
+ */
+public class OS {
+
+	private final String name;
+
+	private final String version;
+
+	private final String arch;
+
+	private final transient boolean isWindows;
+
+	public OS() {
+		this.name = Platform.getSystemProperty("os.name");
+		this.version = Platform.getSystemProperty("os.version");
+		this.arch = Platform.getSystemProperty("os.arch");
+		isWindows = name != null && name.toLowerCase().contains("win");
+	}
+
+	/**
+	 * Returns the OS name.
+	 *
+	 * @return the OS name.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Returns the OS version.
+	 *
+	 * @return the OS version.
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * Returns the OS arch.
+	 *
+	 * @return the OS arch.
+	 */
+	public String getArch() {
+		return arch;
+	}
+
+	/**
+	 * Returns true if the operating system is Windows and false otherwise
+	 *
+	 * @return true if the operating system is Windows and false otherwise
+	 */
+	public boolean isWindows() {
+		return isWindows;
+	}
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/Platform.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/Platform.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.cameltooling.lsp.internal.telemetry;
+
+/**
+ * Platform information about OS and JVM.
+ * 
+ * Mostly duplicated from Eclipse Lemminx, the xml language server
+ */
+public class Platform {
+
+	private static final String UNKNOWN_VALUE = "unknown";
+
+	private static final OS os = new OS();
+	private static final JVM jvm = new JVM();
+
+	private Platform() {
+	}
+
+	/**
+	 * Returns the OS information
+	 *
+	 * @return the OS information
+	 */
+	public static OS getOS() {
+		return os;
+	}
+
+	/**
+	 * Returns the JVM information
+	 *
+	 * @return the JVM information
+	 */
+	public static JVM getJVM() {
+		return jvm;
+	}
+
+	/**
+	 * Returns the system property from the given key and "unknown" otherwise.
+	 *
+	 * @param key the property system key
+	 * @return the system property from the given key and "unknown" otherwise.
+	 */
+	static String getSystemProperty(String key) {
+		try {
+			String property = System.getProperty(key);
+			return property == null || property.isEmpty() ? UNKNOWN_VALUE : property;
+		} catch (SecurityException e) {
+			return UNKNOWN_VALUE;
+		}
+	}
+
+	/**
+	 * Returns the server details, using the format:
+	 *
+	 * <pre>
+	 * Camel Language Server info:
+	 *  - Java : (path to java.home])
+	 * </pre>
+	 *
+	 * @return the formatted server details
+	 */
+	public static String details() {
+		StringBuilder details = new StringBuilder();
+		append(details, "Java", jvm.getJavaHome());
+		append(details, "VM Version", jvm.getVersion());
+		return details.toString();
+	}
+
+	private static void append(StringBuilder sb, String key, String value) {
+		sb.append(System.lineSeparator()).append(" - ").append(key);
+		if (value != null) {
+			sb.append(" : ").append(value);
+		}
+	}
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryEvent.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryEvent.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.cameltooling.lsp.internal.telemetry;
+
+import java.util.Map;
+
+/**
+ * Telemetry event
+ * 
+ * Mostly duplicated from Eclipse Lemminx, the xml language server
+ */
+public class TelemetryEvent {
+
+	public final String name;
+	public final Map<String, Object> properties;
+
+	TelemetryEvent() {
+		this("", null);
+	}
+
+	TelemetryEvent(String name, Map<String, Object> properties) {
+		this.name = name;
+		this.properties = properties;
+	}
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryManager.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryManager.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.github.cameltooling.lsp.internal.telemetry;
+
+import java.util.Map;
+
+import org.eclipse.lsp4j.services.LanguageClient;
+
+/**
+ * Telemetry manager.
+ * 
+ * Mostly duplicated from Eclipse Lemminx, the xml language server
+ *
+ * @author Angelo ZERR
+ */
+public class TelemetryManager {
+
+	/**
+	 * "startup" telemetry event name
+	 */
+	public static final String STARTUP_EVENT_NAME = "camel.lsp.server.initialized";
+
+	private final LanguageClient languageClient;
+
+	public TelemetryManager(LanguageClient languageClient) {
+		this.languageClient = languageClient;
+	}
+
+	/**
+	 * Send a telemetry event on start of the XML server
+	 *
+	 */
+	public void onInitialized() {
+		telemetryEvent(STARTUP_EVENT_NAME, InitializationTelemetryInfo.getInitializationTelemetryInfo());
+	}
+
+	/**
+	 * The telemetry notification is sent from the server to the client to ask the
+	 * client to log a telemetry event.
+	 */
+	private void telemetryEvent(String eventName, Map<String, Object> object) {
+		languageClient.telemetryEvent(new TelemetryEvent(eventName, object));
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -43,6 +44,7 @@ import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.MessageActionItem;
@@ -61,6 +63,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.junit.jupiter.api.AfterEach;
 
+import com.github.cameltooling.lsp.internal.telemetry.TelemetryEvent;
 import com.google.common.io.Files;
 import com.google.gson.Gson;
 
@@ -73,6 +76,7 @@ public abstract class AbstractCamelLanguageServerTest {
 	protected static final String DUMMY_URI = "dummyUri";
 	private String extensionUsed;
 	protected PublishDiagnosticsParams lastPublishedDiagnostics;
+	protected List<TelemetryEvent> telemetryEvents = new ArrayList<>();
 	protected CamelLanguageServer camelLanguageServer;
 
 	public AbstractCamelLanguageServerTest() {
@@ -84,6 +88,7 @@ public abstract class AbstractCamelLanguageServerTest {
 		if (camelLanguageServer != null) {
 			camelLanguageServer.stopServer();
 		}
+		telemetryEvents.clear();
 	}
 
 	protected CompletionItem createExpectedAhcCompletionItem(int lineStart, int characterStart, int lineEnd, int characterEnd) {
@@ -104,6 +109,7 @@ public abstract class AbstractCamelLanguageServerTest {
 
 		@Override
 		public void telemetryEvent(Object object) {
+			AbstractCamelLanguageServerTest.this.telemetryEvents.add((TelemetryEvent) object);
 		}
 
 		@Override
@@ -154,6 +160,9 @@ public abstract class AbstractCamelLanguageServerTest {
 
 		assertThat(initialize).isCompleted();
 		assertThat(initialize.get().getCapabilities().getCompletionProvider().getResolveProvider()).isTrue();
+		
+		InitializedParams initialized = new InitializedParams();
+		camelLanguageServer.initialized(initialized);
 	}
 	
 	private InitializeParams getInitParams() throws URISyntaxException {

--- a/src/test/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryTest.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+
+class TelemetryTest extends AbstractCamelLanguageServerTest {
+
+	@Test
+	void testInitializationWithJvmInfoMetric() throws Exception {
+		initializeLanguageServer("");
+		assertThat(telemetryEvents).hasSize(1);
+		TelemetryEvent telemetryEvent = telemetryEvents.get(0);
+		assertThat(telemetryEvent.name).isEqualTo(TelemetryManager.STARTUP_EVENT_NAME);
+		Map<String, Object> properties = telemetryEvent.properties;
+		assertThat((String)properties.get("jvm.version")).isNotBlank();
+	}
+	
+}


### PR DESCRIPTION
Telemetry is part of the LSP specification: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#telemetry_event

the event is created on the [langauge server side](https://github.com/eclipse/lemminx/tree/master/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/telemetry) and the [client is sending the metric](https://github.com/redhat-developer/vscode-xml/commit/ee25f3abe24015dd11e01a8e9a6dfaa4f3875af1#diff-933541f88e08dbbc0a55ba6ccddf49d2e6a53b0f4f5a71a42a6ec691d1be24a3R41-R43) to Red Hat woopra if telemetry is enabled.

in combination with https://github.com/camel-tooling/camel-lsp-client-vscode/pull/690 , we can have this kind of report: https://app.woopra.com/project/test.vscode/analyze/report/trends/c0afwq5qlb