### PR TITLE
FUSETOOLS2-1222 - provide language of Camel files opened

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -4,6 +4,7 @@ Telemetry events can be collected by the LSP client program.
 
 The following information is emitted when the language server starts:
 
+ * Extension of the Camel file used
  * JVM information:
     * Whether it is being run with Java or as a GraalVM native image (binary)
     * The name of the vm (`java.vm.name`)

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
@@ -141,5 +141,9 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 	public SettingsManager getSettingsManager() {
 		return settingsManager;
 	}
+
+	public TelemetryManager getTelemetryManager() {
+		return telemetryManager;
+	}
 	
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -86,6 +86,7 @@ import com.github.cameltooling.lsp.internal.parser.CamelKModelineParser;
 import com.github.cameltooling.lsp.internal.references.ReferencesProcessor;
 import com.github.cameltooling.lsp.internal.settings.JSONUtility;
 import com.github.cameltooling.lsp.internal.settings.SettingsManager;
+import com.github.cameltooling.lsp.internal.telemetry.TelemetryLanguage;
 import com.google.gson.Gson;
 
 /**
@@ -274,6 +275,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 		LOGGER.info("didOpen: {}", textDocument);
 		openedDocuments.put(textDocument.getUri(), textDocument);
 		new DiagnosticRunner(getCamelCatalog(), camelLanguageServer).compute(params);
+		new TelemetryLanguage(camelLanguageServer.getTelemetryManager()).compute(textDocument);
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserXMLFileHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserXMLFileHelper.java
@@ -99,7 +99,7 @@ public class ParserXMLFileHelper extends ParserFileHelper {
 		}
 	}
 
-	private boolean hasElementFromCamelNamespace(TextDocumentItem textDocumentItem) throws SAXException, IOException, ParserConfigurationException {
+	public boolean hasElementFromCamelNamespace(TextDocumentItem textDocumentItem) throws SAXException, IOException, ParserConfigurationException {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryLanguage.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryLanguage.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.telemetry;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelperFactory;
+
+public class TelemetryLanguage {
+
+	private TelemetryManager telemetryManager;
+
+	public TelemetryLanguage(TelemetryManager telemetryManager) {
+		this.telemetryManager = telemetryManager;
+	}
+
+	public void compute(TextDocumentItem textDocument) {
+		CompletableFuture.runAsync(() -> {
+			if(new ParserFileHelperFactory().isProbablyCamelFile(textDocument)) {
+				telemetryManager.sendOpenedCamelFile(textDocument.getUri());
+			}
+		});
+		
+	}
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryManager.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryManager.java
@@ -9,6 +9,7 @@
 *******************************************************************************/
 package com.github.cameltooling.lsp.internal.telemetry;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -26,6 +27,7 @@ public class TelemetryManager {
 	 * "startup" telemetry event name
 	 */
 	public static final String STARTUP_EVENT_NAME = "camel.lsp.server.initialized";
+	public static final String OPENED_DOCUMENT = "camel.lsp.open.document";
 
 	private final LanguageClient languageClient;
 
@@ -34,7 +36,7 @@ public class TelemetryManager {
 	}
 
 	/**
-	 * Send a telemetry event on start of the XML server
+	 * Send a telemetry event on start of the Camel Language server
 	 *
 	 */
 	public void onInitialized() {
@@ -47,6 +49,12 @@ public class TelemetryManager {
 	 */
 	private void telemetryEvent(String eventName, Map<String, Object> object) {
 		languageClient.telemetryEvent(new TelemetryEvent(eventName, object));
+	}
+
+	public void sendOpenedCamelFile(String uri) {
+		int lastIndexOfDot = uri.lastIndexOf('.');
+		String extension = lastIndexOfDot != -1 ? uri.substring(lastIndexOfDot + 1) : uri;
+		telemetryEvent(OPENED_DOCUMENT, Collections.singletonMap("language", extension));
 	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/telemetry/TelemetryTest.java
@@ -17,12 +17,22 @@
 package com.github.cameltooling.lsp.internal.telemetry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.util.RouteTextBuilder;
 
 class TelemetryTest extends AbstractCamelLanguageServerTest {
 
@@ -34,6 +44,38 @@ class TelemetryTest extends AbstractCamelLanguageServerTest {
 		assertThat(telemetryEvent.name).isEqualTo(TelemetryManager.STARTUP_EVENT_NAME);
 		Map<String, Object> properties = telemetryEvent.properties;
 		assertThat((String)properties.get("jvm.version")).isNotBlank();
+	}
+	
+	@ParameterizedTest(name= "Telemetry sent for language {1}")
+	@MethodSource
+	void testOpenedDocumentMetric(String content, String extension) throws Exception {
+		initializeLanguageServer(content, "."+extension);
+		await("Await that telemetry event is sent as it is done async to not slow down the server")
+			.untilAsserted(() -> assertThat(telemetryEvents).hasSize(2));
+		TelemetryEvent telemetryEvent = telemetryEvents.get(1);
+		assertThat(telemetryEvent.name).isEqualTo(TelemetryManager.OPENED_DOCUMENT);
+		Map<String, Object> properties = telemetryEvent.properties;
+		assertThat((String)properties.get("language")).isEqualTo(extension);
+	}
+	
+	@Test
+	void noTelemetrySentForJavaFileWithOnlyCamelTextInIt() throws Exception {
+		initializeLanguageServer("camel", ".java");
+		assertThat(telemetryEvents).hasSize(1);
+	}
+	
+	private static Stream<Arguments> testOpenedDocumentMetric() {
+		InputStream inputStreamOfJavaFile = TelemetryTest.class.getResourceAsStream("/workspace/My3RoutesBuilder.java");
+		String javaContent = new BufferedReader(new InputStreamReader(inputStreamOfJavaFile))
+				   				.lines()
+				   				.collect(Collectors.joining("\n"));
+		return Stream.of(
+				Arguments.of(RouteTextBuilder.createXMLSpringRoute(""), "xml"),
+				Arguments.of(javaContent, "java"),
+				Arguments.of("# camel-k:", "yaml"),
+				Arguments.of("// camel-k:", "kts"),
+				Arguments.of("// camel-k:", "js")
+				);
 	}
 	
 }


### PR DESCRIPTION
heuristic to detect if it s a Camel file or not is not perfect but it
the best that we were using so far.

it will allow to have this kind of report https://app.woopra.com/project/test.vscode/analyze/report/trends/j6rpgiwdyn when used in combination with https://github.com/camel-tooling/camel-lsp-client-vscode/pull/693