### PR TITLE
FUSETOOLS2-871 - provide specific label for outline titles

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.DocumentSymbolOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
@@ -102,7 +103,7 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 		capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
 		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".","?","&", "\"", "=")));
 		capabilities.setHoverProvider(Boolean.TRUE);
-		capabilities.setDocumentSymbolProvider(Boolean.TRUE);
+		capabilities.setDocumentSymbolProvider(new DocumentSymbolOptions("Camel"));
 		capabilities.setReferencesProvider(Boolean.TRUE);
 		capabilities.setDefinitionProvider(Boolean.TRUE);
 		capabilities.setCodeActionProvider(new CodeActionOptions(Arrays.asList(CodeActionKind.QuickFix)));


### PR DESCRIPTION
it avoids to have a very long name based on the Client name.

before, name was often cropped and a lot of it doesn't provide a lot of values:
![outlienName-before](https://user-images.githubusercontent.com/1105127/127456796-3518e6af-6d4b-474b-80ea-62a079201f4e.png)

after:
![outlineName-after](https://user-images.githubusercontent.com/1105127/127456781-01b6576e-fd27-404a-82f4-43203e87b8ed.png)
