### PR TITLE
FUSETOOLS2-1240 - improve robustness on completion for non-opened document

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -148,12 +148,17 @@ public class CamelTextDocumentService implements TextDocumentService {
 		String uri = completionParams.getTextDocument().getUri();
 		LOGGER.info("completion: {}", uri);
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
-		if (uri.endsWith(".properties")){
-			return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition(), getSettingsManager(), getKameletsCatalogManager()).thenApply(Either::forLeft);
-		} else if(new CamelKModelineParser().isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
-			return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+		if (textDocumentItem != null) {
+			if (uri.endsWith(".properties")){
+				return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition(), getSettingsManager(), getKameletsCatalogManager()).thenApply(Either::forLeft);
+			} else if(new CamelKModelineParser().isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
+				return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+			} else {
+				return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog(), getKameletsCatalogManager()).getCompletions(completionParams.getPosition(), getSettingsManager()).thenApply(Either::forLeft);
+			}
 		} else {
-			return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog(), getKameletsCatalogManager()).getCompletions(completionParams.getPosition(), getSettingsManager()).thenApply(Either::forLeft);
+			LOGGER.warn("The document with uri {} has not been found in opened documents. Cannot provide completion.", uri);
+			return CompletableFuture.completedFuture(Either.forLeft(Collections.emptyList()));
 		}
 	}
 

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelCompletionRobustnessTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelCompletionRobustnessTest.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelKafkaConnectorTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+import com.github.cameltooling.lsp.internal.util.RouteTextBuilder;
+
+class CamelCompletionRobustnessTest extends AbstractCamelKafkaConnectorTest {
+
+	@Test
+	void testCompletionOnNotOpenedDocument() throws Exception {
+		CamelLanguageServer server = initializeLanguageServer(RouteTextBuilder.createXMLBlueprintRoute(""));
+		
+		assertThat(getCompletionFor(server, new Position(0, 0), "wrongFileName.txt").get().getLeft()).isEmpty();
+	}
+	
+}


### PR DESCRIPTION

avoids NPE when the document for which the completion is requested is
not opened, or wasn't opened with same URI 2 times; or was already
closed.
In theory, it should not happened. The client should handle it. But
noticed the NPE in Eclipse LSP4E logs.

