### PR TITLE
FUSETOOLS2-1251 - Revert "FUSETOOLS2-871 - provide specific label for

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CompletionOptions;
-import org.eclipse.lsp4j.DocumentSymbolOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
@@ -103,7 +102,7 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 		capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
 		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".","?","&", "\"", "=")));
 		capabilities.setHoverProvider(Boolean.TRUE);
-		capabilities.setDocumentSymbolProvider(new DocumentSymbolOptions("Camel"));
+		capabilities.setDocumentSymbolProvider(Boolean.TRUE);
 		capabilities.setReferencesProvider(Boolean.TRUE);
 		capabilities.setDefinitionProvider(Boolean.TRUE);
 		capabilities.setCodeActionProvider(new CodeActionOptions(Arrays.asList(CodeActionKind.QuickFix)));


### PR DESCRIPTION
outline titles"

This reverts commit f0018d9a021c7c9fea51c33fd774416d524eef49.

Eclipse LSP4E is breaking completely with this new feature. Reverting the time that LSP4E is fixing the issue.