### PR TITLE
Prepare for 1.2.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.camel-tooling</groupId>
 	<artifactId>camel-lsp-server</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.0</version>
 	
 	<name>Camel Language Server Protocol :: Server Implementation</name>
 	<description>Server Implementation of the Language Server Protocol for Apache Camel</description>


### PR DESCRIPTION
I checked that is no more snapshots version in dependencies
This PR modifies the version to a non-snapshot version

see https://github.com/camel-tooling/camel-language-server/blob/master/Contributing.md#how-to-release