### PR TITLE
FUSETOOLS2-1229 - Drop Java 8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,6 @@
 version: 2.1
 
 jobs:
-  jdk8:
-    docker:
-      - image: circleci/openjdk:8-stretch
-    steps:
-      - checkout
-      - run: mvn verify -V
-      - store_test_results:
-          path: target/surefire-reports
-
   jdk11:
     docker:
       - image: circleci/openjdk:11-stretch
@@ -47,7 +38,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/openjdk:8-stretch
+      - image: circleci/openjdk:11-stretch
     steps:
       - checkout
       - run: echo 'export GPG_DIR=`pwd`/cd' >> $BASH_ENV
@@ -60,12 +51,10 @@ workflows:
 
   build:
     jobs:
-      - jdk8
       - jdk11
       - jdk16
       - sonar:
           requires:
-            - jdk8
             - jdk11
             - jdk16
           filters:
@@ -75,7 +64,6 @@ workflows:
           context: sonarcloud
       - deploy:
           requires:
-             - jdk8
              - jdk11
              - jdk16
           filters:

--- a/.classpath
+++ b/.classpath
@@ -29,7 +29,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,6 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
 org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.source=11

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- compiler settings -->
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<jacoco.version>0.8.7</jacoco.version>
 		<lsp4j.version>0.12.0</lsp4j.version>
 		<slf4j.version>1.7.32</slf4j.version>
@@ -139,9 +139,6 @@
 		          				</goals>
 		        			</execution>
 		      			</executions>
-		      			<configuration>
-		      				<source>8</source>
-		      			</configuration>
 		    		</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
Java 11 is now required for the Camel language Server. It does not mean
that it requires Java 11 for your Camel runtime.
- Java 8 is EOL
- It will allow to upgrade Camel Quarkus catalog which requires java 11
