### PR TITLE
Upgrade log4j implementation for slf4j from 1.x to 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 		<jacoco.version>0.8.7</jacoco.version>
 		<lsp4j.version>0.12.0</lsp4j.version>
 		<slf4j.version>1.7.32</slf4j.version>
+		<log4j-slf4j.version>2.16.0</log4j-slf4j.version>
 		<junit.version>5.8.2</junit.version>
 		<assertj.version>3.21.0</assertj.version>
 		<jgit.version>6.0.0.202111291000-r</jgit.version>
@@ -240,9 +241,9 @@
 			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>${slf4j.version}</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j-slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.camel</groupId>

--- a/src/test/java/com/github/cameltooling/lsp/internal/parser/ParserXMLFileHelperTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/parser/ParserXMLFileHelperTest.java
@@ -18,23 +18,21 @@ package com.github.cameltooling.lsp.internal.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.log4j.Logger;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.junit.jupiter.api.Test;
 
 import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 import com.github.cameltooling.lsp.internal.DummyConstants;
-import com.github.cameltooling.lsp.internal.TestLogAppender;
+import com.github.cameltooling.lsp.internal.util.TestLogAppender;
+import com.github.cameltooling.lsp.internal.util.TestLoggerUtil;
 
 class ParserXMLFileHelperTest {
 
 	@Test
 	void testGetCamelComponentUri() throws Exception {
-		final TestLogAppender appender = new TestLogAppender();
-		final Logger logger = Logger.getRootLogger();
-		logger.addAppender(appender);
+		final TestLogAppender appender = new TestLoggerUtil().setupLogAppender(ParserXMLFileHelperTest.class.getName());
 		new ParserXMLFileHelper().getCamelComponentUri("uri=!!", 2);
-		assertThat(appender.getLog().get(0).getMessage()).isEqualTo("Encountered an unsupported URI closure char !");
+		assertThat(appender.getLog().get(0).getMessage().getFormattedMessage()).isEqualTo("Encountered an unsupported URI closure char !");
 	}
 	
 	void testGetRouteNodesWithNamespacePrefix() throws Exception {

--- a/src/test/java/com/github/cameltooling/lsp/internal/util/TestLogAppender.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/util/TestLogAppender.java
@@ -14,32 +14,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.cameltooling.lsp.internal;
+package com.github.cameltooling.lsp.internal.util;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.spi.LoggingEvent;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 
-public class TestLogAppender extends AppenderSkeleton {
-    private final List<LoggingEvent> log = new ArrayList<LoggingEvent>();
+public class TestLogAppender extends AbstractAppender {
 
-    @Override
-    public boolean requiresLayout() {
-        return false;
-    }
+	private final List<LogEvent> log = new ArrayList<LogEvent>();
+	
+	public TestLogAppender(String name) {
+		super(name, null, null, false, Property.EMPTY_ARRAY);
+	}
 
-    @Override
-    protected void append(final LoggingEvent loggingEvent) {
-        log.add(loggingEvent);
-    }
+	public List<LogEvent> getLog() {
+		return new ArrayList<LogEvent>(log);
+	}
 
-    @Override
-    public void close() {
-    }
-
-    public List<LoggingEvent> getLog() {
-        return new ArrayList<LoggingEvent>(log);
-    }
+	@Override
+	public void append(LogEvent event) {
+		log.add(event);
+	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/util/TestLoggerUtil.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/util/TestLoggerUtil.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.util;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+
+public class TestLoggerUtil {
+	
+	public TestLogAppender setupLogAppender(String name) {
+		final LoggerContext context = LoggerContext.getContext(false);
+		final Configuration config = context.getConfiguration();
+		config.getRootLogger().setLevel(Level.ALL);
+		final TestLogAppender appender = new TestLogAppender(name);
+		appender.start();
+		config.addAppender(appender);
+		updateLoggers(context, appender, config);
+		return appender;
+	}
+
+	private void updateLoggers(LoggerContext context, final Appender appender, final Configuration config) {
+		final Level level = Level.ALL;
+		for (final LoggerConfig loggerConfig : config.getLoggers().values()) {
+			loggerConfig.addAppender(appender, level, null);
+		}
+		config.getRootLogger().addAppender(appender, level, null);
+		context.updateLoggers(config);
+	}
+
+}


### PR DESCRIPTION
tricky part was to update the tests. the Appender is a bit trickier to
setup and also requires to set the log level

