### PR TITLE
FUSETOOLS2-1377 - Provide hint for connected mode completion for

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/ConnectedModeDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/ConnectedModeDiagnosticService.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.diagnostic;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.camel.parser.model.CamelEndpointDetails;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import com.github.cameltooling.lsp.internal.instancemodel.ComponentNameConstants;
+
+public class ConnectedModeDiagnosticService extends DiagnosticService {
+
+	protected ConnectedModeDiagnosticService() {
+		super(null, null);
+	}
+
+	public Collection<? extends Diagnostic> compute(String camelText, TextDocumentItem documentItem) {
+		Set<Diagnostic> diagnostics = new HashSet<>();
+		List<CamelEndpointDetails> endpoints = retrieveEndpoints(documentItem.getUri(), camelText);
+		for (CamelEndpointDetails camelEndpointDetails : endpoints) {
+			String endpointUri = camelEndpointDetails.getEndpointUri();
+			if (endpointUri.startsWith(ComponentNameConstants.COMPONENT_NAME_KNATIVE)) {
+				diagnostics.add(new Diagnostic(
+						computeRange(camelText, documentItem, camelEndpointDetails),
+						"If a connection to Kubernetes with Knative installed is active, the completion will be dynamically augmented.",
+						DiagnosticSeverity.Hint,
+						APACHE_CAMEL_VALIDATION,
+						null));
+			} else if(endpointUri.startsWith("kubernetes-")) {
+				diagnostics.add(new Diagnostic(
+						computeRange(camelText, documentItem, camelEndpointDetails),
+						"If a connection to Kubernetes is active, the completion will be dynamically augmented.",
+						DiagnosticSeverity.Hint,
+						APACHE_CAMEL_VALIDATION,
+						null));
+			}
+		}
+		return diagnostics;
+	}	
+
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticRunner.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticRunner.java
@@ -38,6 +38,7 @@ public class DiagnosticRunner {
 	private ConfigurationPropertiesDiagnosticService configurationPropertiesDiagnosticService;
 	private CamelKModelineDiagnosticService camelKModelineDiagnosticService;
 	private CamelKafkaConnectorDiagnosticService camelKafkaConnectorDiagnosticService;
+	private ConnectedModeDiagnosticService connectedModeDiagnosticService;
 
 	public DiagnosticRunner(CompletableFuture<CamelCatalog> camelCatalog, CamelLanguageServer camelLanguageServer) {
 		this.camelLanguageServer = camelLanguageServer;
@@ -45,6 +46,7 @@ public class DiagnosticRunner {
 		configurationPropertiesDiagnosticService = new ConfigurationPropertiesDiagnosticService(camelCatalog);
 		camelKModelineDiagnosticService = new CamelKModelineDiagnosticService();
 		camelKafkaConnectorDiagnosticService = new CamelKafkaConnectorDiagnosticService(camelLanguageServer.getTextDocumentService().getCamelKafkaConnectorManager());
+		connectedModeDiagnosticService = new ConnectedModeDiagnosticService();
 	}
 
 	public void compute(DidSaveTextDocumentParams params) {
@@ -73,6 +75,7 @@ public class DiagnosticRunner {
 			diagnostics.addAll(configurationPropertiesDiagnosticService.converToLSPDiagnostics(configurationPropertiesErrors));
 			diagnostics.addAll(camelKModelineDiagnosticService.compute(camelText, documentItem));
 			diagnostics.addAll(camelKafkaConnectorDiagnosticService.compute(camelText, documentItem));
+			diagnostics.addAll(connectedModeDiagnosticService.compute(camelText, documentItem));
 			camelLanguageServer.getClient().publishDiagnostics(new PublishDiagnosticsParams(uri, diagnostics));
 		});
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/DiagnosticService.java
@@ -16,17 +16,34 @@
  */
 package com.github.cameltooling.lsp.internal.diagnostic;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.camel.catalog.CamelCatalog;
+import org.apache.camel.parser.RouteBuilderParser;
+import org.apache.camel.parser.XmlRouteParser;
+import org.apache.camel.parser.model.CamelEndpointDetails;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.JavaType;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.cameltooling.lsp.internal.catalog.diagnostic.CamelDiagnosticMessage;
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
+import com.github.cameltooling.lsp.internal.parser.ParserFileHelperUtil;
 
 public abstract class DiagnosticService {
 	
@@ -65,5 +82,72 @@ public abstract class DiagnosticService {
 		if(setOfErrors != null && !setOfErrors.isEmpty()) {
 			sb.append(errorMsgComputer.getErrorMessage(setOfErrors)).append("\n");
 		}
+	}
+
+	protected List<CamelEndpointDetails> retrieveEndpoints(String fileUri, String camelText) {
+		List<CamelEndpointDetails> endpoints = new ArrayList<>();
+		if (fileUri.endsWith(".xml")) {
+			try {
+				XmlRouteParser.parseXmlRouteEndpoints(new ByteArrayInputStream(camelText.getBytes(StandardCharsets.UTF_8)), "", "/"+fileUri, endpoints);
+			} catch (Exception e) {
+				logExceptionValidatingDocument(fileUri, e);
+			}
+		} else if(fileUri.endsWith(".java")) {
+			try {
+				JavaType<?> parsedJavaFile = Roaster.parse(camelText);
+				if (parsedJavaFile instanceof JavaClassSource) {
+					JavaClassSource clazz = (JavaClassSource) parsedJavaFile;
+					RouteBuilderParser.parseRouteBuilderEndpoints(clazz, "", "/"+fileUri, endpoints);
+				}
+			} catch(Exception e) {
+				logExceptionValidatingDocument(fileUri, e);
+			}
+		}
+		return endpoints;
+	}
+
+	protected Range computeRange(String fullCamelText, TextDocumentItem textDocumentItem, CamelEndpointDetails camelEndpointDetails) {
+		int endLine = camelEndpointDetails.getLineNumberEnd() != null ? Integer.valueOf(camelEndpointDetails.getLineNumberEnd()) - 1 : findLine(fullCamelText, camelEndpointDetails);
+		String lineContainingTheCamelURI = new ParserFileHelperUtil().getLine(textDocumentItem, endLine);
+		String endpointUri = camelEndpointDetails.getEndpointUri();
+		if(textDocumentItem.getUri().endsWith(".xml")) {
+			endpointUri = endpointUri.replace("&", "&amp;");
+		}
+		int startOfUri = lineContainingTheCamelURI.indexOf(endpointUri);
+		int startLinePosition;
+		int endLinePosition;
+		if (startOfUri != -1) {
+			startLinePosition = startOfUri;
+			endLinePosition = startOfUri + endpointUri.length();
+		} else {
+			startLinePosition = 0;
+			endLinePosition = lineContainingTheCamelURI.length();
+		}
+		int startLine = camelEndpointDetails.getLineNumber() != null ? Integer.valueOf(camelEndpointDetails.getLineNumber()) - 1 : findLine(fullCamelText, camelEndpointDetails);
+		return new Range(new Position(startLine, startLinePosition), new Position(endLine, endLinePosition));
+	}
+
+	/**
+	 * Computing by hand for Camel versions earlier than the version which will contain https://issues.apache.org/jira/browse/CAMEL-12639
+	 * 
+	 * @param fullCamelText
+	 * @param camelEndpointDetails
+	 * @return
+	 */
+	protected int findLine(String fullCamelText, CamelEndpointDetails camelEndpointDetails) {
+		int currentSearchedLine = 0;
+		String str;
+		BufferedReader reader = new BufferedReader(new StringReader(fullCamelText));
+		try {
+			while ((str = reader.readLine()) != null) {
+				if (str.contains(camelEndpointDetails.getEndpointUri())) {
+					return currentSearchedLine;
+				}
+				currentSearchedLine++;
+			}
+		} catch(IOException e) {
+			LOGGER.error("Error while computing range of error", e);
+		}
+		return 0;
 	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/ConnectedModeDiagnosticTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/diagnostic/ConnectedModeDiagnosticTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.diagnostic;
+
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+
+public class ConnectedModeDiagnosticTest extends AbstractDiagnosticTest {
+
+	@Test
+	void testKnativeHintOnXml() throws Exception {
+		testDiagnostic("camel-with-knative-endpoint", 1, ".xml");
+		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
+		checkRange(range, 8, 16, 8, 36);
+	}
+	
+	@Test
+	void testKnativeHintOnJava() throws Exception {
+		testDiagnostic("camel-with-knative-endpoint", 1, ".java");
+		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
+		checkRange(range, 12, 14, 12, 34);
+	}
+	
+	@Test
+	void testKubernetesHintOnXml() throws Exception {
+		testDiagnostic("camel-with-kubernetes-endpoint", 1, ".xml");
+		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
+		checkRange(range, 8, 16, 8, 60);
+	}
+	
+	@Test
+	void testKubernetesHintOnJava() throws Exception {
+		testDiagnostic("camel-with-kubernetes-endpoint", 1, ".java");
+		Range range = lastPublishedDiagnostics.getDiagnostics().get(0).getRange();
+		checkRange(range, 12, 14, 12, 58);
+	}
+	
+}

--- a/src/test/resources/workspace/diagnostic/camel-with-knative-endpoint.java
+++ b/src/test/resources/workspace/diagnostic/camel-with-knative-endpoint.java
@@ -1,0 +1,17 @@
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * A Camel Java DSL Router
+ */
+public class MyRouteBuilder extends RouteBuilder {
+
+    /**
+     * Let's configure the Camel routing rules using Java code...
+     */
+    public void configure() {
+
+        from("knative:channel/demo")
+            .to("direct:drink");
+    }
+
+}

--- a/src/test/resources/workspace/diagnostic/camel-with-knative-endpoint.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-knative-endpoint.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+	<endpoint uri="knative:channel/demo"></endpoint>
+    <route id="a route">
+      <from uri="timer:timerName?delay=1000"/>
+      <to uri="direct:drink"/>
+    </route>
+  </camelContext>
+</beans>

--- a/src/test/resources/workspace/diagnostic/camel-with-kubernetes-endpoint.java
+++ b/src/test/resources/workspace/diagnostic/camel-with-kubernetes-endpoint.java
@@ -1,0 +1,17 @@
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * A Camel Java DSL Router
+ */
+public class MyRouteBuilder extends RouteBuilder {
+
+    /**
+     * Let's configure the Camel routing rules using Java code...
+     */
+    public void configure() {
+
+        from("kubernetes-services:masterUrl?namespace=demo")
+            .to("direct:drink");
+    }
+
+}

--- a/src/test/resources/workspace/diagnostic/camel-with-kubernetes-endpoint.xml
+++ b/src/test/resources/workspace/diagnostic/camel-with-kubernetes-endpoint.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring https://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+	<endpoint uri="kubernetes-services:masterUrl?namespace=demo"></endpoint>
+    <route id="a route">
+      <from uri="timer:timerName?delay=1000"/>
+      <to uri="direct:drink"/>
+    </route>
+  </camelContext>
+</beans>


### PR DESCRIPTION
kubernetes and knative

choose to not check if there is a connection active or no for 2 reasons:
- avoids to potentially slow down validation
- still remains a bit interesting to have the hint when there is the connection to encourage users to use completion

limitation: available for XML and Java only

good visibility in Eclipse:
![hintConnectedMode](https://user-images.githubusercontent.com/1105127/148081419-6f839f97-9633-4752-b64b-b43a8983a8ee.gif)

Not good visibility in VS Code (but well that the client choice
![hintConnectedModeVSCode](https://user-images.githubusercontent.com/1105127/148081697-5be513cf-4f09-4335-b500-71be1b80c4ac.gif)
)