### PR TITLE
Bump camel.version from 3.15.0 to 3.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<junit.version>5.8.2</junit.version>
 		<assertj.version>3.22.0</assertj.version>
 		<jgit.version>6.1.0.202203080745-r</jgit.version>
-		<camel.version>3.15.0</camel.version>
+		<camel.version>3.16.0</camel.version>
 		<camel.kafka.connector.version>0.11.0</camel.kafka.connector.version>
 		<camel.kamelet.catalog.version>0.7.1</camel.kamelet.catalog.version>
 		<camel.quarkus.version>2.7.1</camel.quarkus.version>

--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemTag;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DefinitionParams;
@@ -96,7 +97,8 @@ public abstract class AbstractCamelLanguageServerTest {
 	protected CompletionItem createExpectedAhcCompletionItem(int lineStart, int characterStart, int lineEnd, int characterEnd) {
 		CompletionItem expectedAhcCompletioncompletionItem = new CompletionItem("ahc:httpUri");
 		expectedAhcCompletioncompletionItem.setDocumentation(AHC_DOCUMENTATION);
-		expectedAhcCompletioncompletionItem.setDeprecated(false);
+		expectedAhcCompletioncompletionItem.setDeprecated(true);
+		expectedAhcCompletioncompletionItem.setTags(Collections.singletonList(CompletionItemTag.Deprecated));
 		expectedAhcCompletioncompletionItem.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(lineStart, characterStart), new Position(lineEnd, characterEnd)), "ahc:httpUri")));
 		return expectedAhcCompletioncompletionItem;
 	}
@@ -104,6 +106,8 @@ public abstract class AbstractCamelLanguageServerTest {
 	protected CompletionItem createExpectedAhcCompletionItemForVersionPriorTo33(int lineStart, int characterStart, int lineEnd, int characterEnd) {
 		CompletionItem expectedAhcCompletioncompletionItem = createExpectedAhcCompletionItem(lineStart, characterStart, lineEnd, characterEnd);
 		expectedAhcCompletioncompletionItem.setDocumentation(AHC_DOCUMENTATION_BEFORE_3_3);
+		expectedAhcCompletioncompletionItem.setDeprecated(false);
+		expectedAhcCompletioncompletionItem.setTags(null);
 		return expectedAhcCompletioncompletionItem;
 	}
 	


### PR DESCRIPTION
Bumps `camel.version` from 3.15.0 to 3.16.0.

Updates `camel-catalog` from 3.15.0 to 3.16.0

Updates `camel-catalog-maven` from 3.15.0 to 3.16.0

Updates `camel-catalog-provider-karaf` from 3.15.0 to 3.16.0

Updates `camel-catalog-provider-springboot` from 3.15.0 to 3.16.0

Updates `camel-route-parser` from 3.15.0 to 3.16.0

---
updated-dependencies:
- dependency-name: org.apache.camel:camel-catalog
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.apache.camel:camel-catalog-maven
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.apache.camel.karaf:camel-catalog-provider-karaf
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name:
org.apache.camel.springboot:camel-catalog-provider-springboot
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.apache.camel:camel-route-parser
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Adapted test as now ahc:httpUri is deprecated. Will require to use
another component later on

