### PR TITLE
FUSETOOLS2-574 - CamelK Modeline insertion autocompletion

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineInsertionProcessor;
+import com.github.cameltooling.lsp.internal.parser.CamelKModelineInsertionParser;
 import org.apache.camel.catalog.CamelCatalog;
 import org.apache.camel.catalog.DefaultCamelCatalog;
 import org.apache.camel.catalog.RuntimeProvider;
@@ -152,13 +154,13 @@ public class CamelTextDocumentService implements TextDocumentService {
 		String uri = completionParams.getTextDocument().getUri();
 		LOGGER.info("completion: {}", uri);
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
-		CamelKModelineParser parser = new CamelKModelineParser();
+
 		if (textDocumentItem != null) {
 			if (uri.endsWith(".properties")){
 				return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition(), getSettingsManager(), getKameletsCatalogManager()).thenApply(Either::forLeft);
-			} else if (isCamelKFile(uri) && parser.canPutCamelKModeline(completionParams.getPosition(), textDocumentItem)){
-				return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getInsertion().thenApply(Either::forLeft);
-			} else if (parser.isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
+			} else if (new CamelKModelineInsertionParser().canPutCamelKModeline(completionParams.getPosition(), textDocumentItem)){
+				return new CamelKModelineInsertionProcessor(textDocumentItem).getInsertion().thenApply(Either::forLeft);
+			} else if (new CamelKModelineParser().isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
 				return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 			} else {
 				return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog(), getKameletsCatalogManager()).getCompletions(completionParams.getPosition(), getSettingsManager()).thenApply(Either::forLeft);
@@ -167,11 +169,6 @@ public class CamelTextDocumentService implements TextDocumentService {
 			LOGGER.warn("The document with uri {} has not been found in opened documents. Cannot provide completion.", uri);
 			return CompletableFuture.completedFuture(Either.forLeft(Collections.emptyList()));
 		}
-	}
-
-	private boolean isCamelKFile(String uri) {
-		//For now not checking that the file is a CamelK File
-		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -159,7 +159,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 			if (uri.endsWith(".properties")){
 				return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition(), getSettingsManager(), getKameletsCatalogManager()).thenApply(Either::forLeft);
 			} else if (new CamelKModelineInsertionParser(textDocumentItem).canPutCamelKModeline(completionParams.getPosition())){
-				return new CamelKModelineInsertionProcessor(textDocumentItem).getInsertion().thenApply(Either::forLeft);
+				return new CamelKModelineInsertionProcessor(textDocumentItem).getCompletions().thenApply(Either::forLeft);
 			} else if (new CamelKModelineParser().isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
 				return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
 			} else {

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -158,7 +158,7 @@ public class CamelTextDocumentService implements TextDocumentService {
 		if (textDocumentItem != null) {
 			if (uri.endsWith(".properties")){
 				return new CamelPropertiesCompletionProcessor(textDocumentItem, getCamelCatalog(), getCamelKafkaConnectorManager()).getCompletions(completionParams.getPosition(), getSettingsManager(), getKameletsCatalogManager()).thenApply(Either::forLeft);
-			} else if (new CamelKModelineInsertionParser().canPutCamelKModeline(completionParams.getPosition(), textDocumentItem)){
+			} else if (new CamelKModelineInsertionParser(textDocumentItem).canPutCamelKModeline(completionParams.getPosition())){
 				return new CamelKModelineInsertionProcessor(textDocumentItem).getInsertion().thenApply(Either::forLeft);
 			} else if (new CamelKModelineParser().isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
 				return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
@@ -43,10 +43,4 @@ public class CamelKModelineCompletionprocessor {
 		String modelineString = new ParserFileHelperUtil().getLine(textDocumentItem, position.getLine());
 		return new CamelKModeline(modelineString, textDocumentItem, position.getLine()).getCompletions(position.getCharacter(), camelCatalog);
 	}
-
-	public CompletableFuture<List<CompletionItem>> getInsertion() {
-		//Add documentation with link to camel-k instance
-		//Add switch for every file type
-		return CompletableFuture.completedFuture(Arrays.asList(new CompletionItem("// camel-k: ")));
-	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
@@ -16,8 +16,10 @@
  */
 package com.github.cameltooling.lsp.internal.completion.modeline;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;
@@ -42,4 +44,9 @@ public class CamelKModelineCompletionprocessor {
 		return new CamelKModeline(modelineString, textDocumentItem, position.getLine()).getCompletions(position.getCharacter(), camelCatalog);
 	}
 
+	public CompletableFuture<List<CompletionItem>> getInsertion() {
+		//Add documentation with link to camel-k instance
+		//Add switch for every file type
+		return CompletableFuture.completedFuture(Arrays.asList(new CompletionItem("// camel-k: ")));
+	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
@@ -16,10 +16,8 @@
  */
 package com.github.cameltooling.lsp.internal.completion.modeline;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 import org.apache.camel.catalog.CamelCatalog;
 import org.eclipse.lsp4j.CompletionItem;

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -36,7 +36,7 @@ public enum CamelKModelineFileType {
             CamelKModelineFileType::xmlCommentPattern,
             "<!-- camel-k: -->",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-    Java(
+    JAVA(
             List.of(".java"),
             "// camel-k:",
             CamelKModelineFileType::javaCommentPattern,

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -44,9 +44,9 @@ public enum CamelKModelineFileType {
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
     YAML(
             List.of(".camelk.yaml",".camelk.yml"),
-            "# camel-k",
+            "# camel-k:",
             CamelKModelineFileType::textIsFullyCommentedYAML,
-            "# camel-k",
+            "# camel-k:",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
     public final List<String> correspondingExtensions;

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -28,18 +28,18 @@ public enum CamelKModelineFileType {
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
     public final List<String> correspondingExtensions;
-    public final String modelineLabel;
+    public final String modeline;
     public final Function<String, Boolean> checkTextIsCommentsDelegate;
 
     public final CompletionItem completion;
 
     CamelKModelineFileType(List<String> correspondingExtensions,
-                           String modelineLabel,
+                           String modeline,
                            Function<String, Boolean> checkTextIsCommentsDelegate,
                            String completionLabel,
                            String completionDocumentation) {
         this.correspondingExtensions = correspondingExtensions;
-        this.modelineLabel = modelineLabel;
+        this.modeline = modeline;
         this.checkTextIsCommentsDelegate = checkTextIsCommentsDelegate;
         this.completion = getCompletionItem(completionLabel, completionDocumentation);
     }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -49,11 +49,10 @@ public enum CamelKModelineFileType {
             "# camel-k: ",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
-    public final List<String> correspondingExtensions;
-    public final String modeline;
-    public final Supplier<Pattern> commentRegexSupplier;
-
-    public final CompletionItem completion;
+    private final List<String> correspondingExtensions;
+    private final String modeline;
+    private final Supplier<Pattern> commentRegexSupplier;
+    private final CompletionItem completion;
 
     CamelKModelineFileType(List<String> correspondingExtensions,
                            String modeline,
@@ -66,6 +65,22 @@ public enum CamelKModelineFileType {
         this.completion = getCompletionItem(completionLabel, completionDocumentation);
     }
 
+    public List<String> getCorrespondingExtensions() {
+        return correspondingExtensions;
+    }
+
+    public String getModeline() {
+        return modeline;
+    }
+
+    public Supplier<Pattern> getCommentRegexSupplier() {
+        return commentRegexSupplier;
+    }
+
+    public CompletionItem getCompletion() {
+        return completion;
+    }
+
     public static CompletionItem getCompletionItem(String label, String documentation) {
         CompletionItem completion = new CompletionItem(label);
         completion.setDocumentation(documentation);
@@ -76,7 +91,7 @@ public enum CamelKModelineFileType {
     public static Optional<CamelKModelineFileType> getFileTypeCorrespondingToUri(String uri) {
         return List.of(CamelKModelineFileType.values()).stream()
                 .filter(type ->
-                        type.correspondingExtensions.stream().anyMatch(uri::endsWith)
+                        type.getCorrespondingExtensions().stream().anyMatch(uri::endsWith)
                 )
                 .findFirst();
     }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -1,0 +1,93 @@
+package com.github.cameltooling.lsp.internal.completion.modeline;
+
+import org.eclipse.lsp4j.CompletionItem;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+public enum CamelKModelineFileType {
+    XML(
+            List.of(".camelk.xml"),
+            "<!-- camel-k:",
+            CamelKModelineFileType::textIsFullyCommentedXML,
+            "<!-- camel-k: -->",
+            "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+    Java(
+            List.of(".java"),
+            "// camel-k:",
+            CamelKModelineFileType::textIsFullyCommentedJava,
+            "// camel-k:",
+            "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+    YAML(
+            List.of(".camelk.yaml",".camelk.yml"),
+            "# camel-k",
+            CamelKModelineFileType::textIsFullyCommentedYAML,
+            "# camel-k",
+            "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
+
+    public final List<String> correspondingExtensions;
+    public final String modelineLabel;
+    public final Function<String, Boolean> checkTextIsCommentsDelegate;
+
+    public final CompletionItem completion;
+
+    CamelKModelineFileType(List<String> correspondingExtensions,
+                           String modelineLabel,
+                           Function<String, Boolean> checkTextIsCommentsDelegate,
+                           String completionLabel,
+                           String completionDocumentation) {
+        this.correspondingExtensions = correspondingExtensions;
+        this.modelineLabel = modelineLabel;
+        this.checkTextIsCommentsDelegate = checkTextIsCommentsDelegate;
+        this.completion = getCompletionItem(completionLabel, completionDocumentation);
+    }
+
+    public static CompletionItem getCompletionItem(String label, String documentation) {
+        CompletionItem completion = new CompletionItem(label);
+        completion.setDocumentation(documentation);
+
+        return completion;
+    }
+
+    public static Optional<CamelKModelineFileType> getFileTypeCorrespondingToUri(String uri) {
+        return List.of(CamelKModelineFileType.values()).stream()
+                .filter(type ->
+                        type.correspondingExtensions.stream().anyMatch(uri::endsWith)
+                )
+                .findFirst();
+    }
+
+    private static boolean textIsFullyCommentedXML(String text){
+        //Remove all segments between <!-- and -->. Check if it's empty.
+        Pattern commentRegex = Pattern.compile("<!--.*-->");
+
+        return textIsFullOfRegex(text, commentRegex);
+    }
+
+    private static boolean textIsFullyCommentedYAML(String text){
+        //Remove all segments between # and \n
+        Pattern commentRegex = Pattern.compile("#.*\\n");
+
+        return textIsFullOfRegex(text, commentRegex);
+    }
+
+    private static boolean textIsFullyCommentedJava(String text){
+        //Line Comments: Remove from // to \n
+        //Block Comments: Remove from /* to */. Newlines have to be explicitly added
+        Pattern lineComment = Pattern.compile("\\/\\/.*\\n");
+        Pattern blockComment = Pattern.compile("\\/\\*(.|\\n)*\\*\\/");
+        Pattern commentRegex = Pattern.compile(String.format("(%s|%s)",lineComment.pattern(), blockComment.pattern()));
+
+        return textIsFullOfRegex(text, commentRegex);
+    }
+
+    private static boolean textIsFullOfRegex(String text, Pattern regex) {
+        //Add an extra carriage return at the end for correct matching with line comments
+        String textWithExtraCarriageReturn = text + "\n";
+        String textWithoutComments = textWithExtraCarriageReturn.replaceAll(regex.pattern(), "");
+
+        return textWithoutComments.isBlank();
+    }
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -40,13 +40,13 @@ public enum CamelKModelineFileType {
             List.of(".java"),
             "// camel-k:",
             CamelKModelineFileType::textIsFullyCommentedJava,
-            "// camel-k:",
+            "// camel-k: ",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
     YAML(
             List.of(".camelk.yaml",".camelk.yml"),
             "# camel-k:",
             CamelKModelineFileType::textIsFullyCommentedYAML,
-            "# camel-k:",
+            "# camel-k: ",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
     public final List<String> correspondingExtensions;

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
- * Provided configuration utils associated to File Types when handling modeline
+ * Provides configuration utils associated to File Types while handling camel-k modeline
  *
  * @author joshiraez
  */

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.cameltooling.lsp.internal.completion.modeline;
 
 import org.eclipse.lsp4j.CompletionItem;
@@ -7,6 +24,11 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+/**
+ * Provided configuration utils associated to File Types when handling modeline
+ *
+ * @author joshiraez
+ */
 public enum CamelKModelineFileType {
     XML(
             List.of(".camelk.xml"),

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -36,7 +36,7 @@ public enum CamelKModelineFileType {
             CamelKModelineFileType::xmlCommentPattern,
             "<!-- camel-k: -->",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-    JAVA(
+    Java(
             List.of(".java"),
             "// camel-k:",
             CamelKModelineFileType::javaCommentPattern,
@@ -95,7 +95,7 @@ public enum CamelKModelineFileType {
         //Line Comments: Remove from // to \n
         //Block Comments: Remove from /* to */. Newlines have to be explicitly added
         Pattern lineComment = Pattern.compile("\\/\\/.*\\n");
-        Pattern blockComment = Pattern.compile("\\/\\*(.|\\n)*\\*\\/");
+        Pattern blockComment = Pattern.compile("\\/\\*(?s).*\\*\\/");
         return Pattern.compile(String.format("(%s|%s)",lineComment.pattern(), blockComment.pattern()));
     }
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineFileType.java
@@ -21,7 +21,7 @@ import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 /**
@@ -33,36 +33,36 @@ public enum CamelKModelineFileType {
     XML(
             List.of(".camelk.xml"),
             "<!-- camel-k:",
-            CamelKModelineFileType::textIsFullyCommentedXML,
+            CamelKModelineFileType::xmlCommentPattern,
             "<!-- camel-k: -->",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
     Java(
             List.of(".java"),
             "// camel-k:",
-            CamelKModelineFileType::textIsFullyCommentedJava,
+            CamelKModelineFileType::javaCommentPattern,
             "// camel-k: ",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
     YAML(
             List.of(".camelk.yaml",".camelk.yml"),
             "# camel-k:",
-            CamelKModelineFileType::textIsFullyCommentedYAML,
+            CamelKModelineFileType::yamlCommentPattern,
             "# camel-k: ",
             "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
     public final List<String> correspondingExtensions;
     public final String modeline;
-    public final Function<String, Boolean> checkTextIsCommentsDelegate;
+    public final Supplier<Pattern> commentRegexSupplier;
 
     public final CompletionItem completion;
 
     CamelKModelineFileType(List<String> correspondingExtensions,
                            String modeline,
-                           Function<String, Boolean> checkTextIsCommentsDelegate,
+                           Supplier<Pattern> commentRegexSupplier,
                            String completionLabel,
                            String completionDocumentation) {
         this.correspondingExtensions = correspondingExtensions;
         this.modeline = modeline;
-        this.checkTextIsCommentsDelegate = checkTextIsCommentsDelegate;
+        this.commentRegexSupplier = commentRegexSupplier;
         this.completion = getCompletionItem(completionLabel, completionDocumentation);
     }
 
@@ -81,35 +81,21 @@ public enum CamelKModelineFileType {
                 .findFirst();
     }
 
-    private static boolean textIsFullyCommentedXML(String text){
+    private static Pattern xmlCommentPattern(){
         //Remove all segments between <!-- and -->. Check if it's empty.
-        Pattern commentRegex = Pattern.compile("<!--.*-->");
-
-        return textIsFullOfRegex(text, commentRegex);
+        return Pattern.compile("<!--.*-->");
     }
 
-    private static boolean textIsFullyCommentedYAML(String text){
+    private static Pattern yamlCommentPattern(){
         //Remove all segments between # and \n
-        Pattern commentRegex = Pattern.compile("#.*\\n");
-
-        return textIsFullOfRegex(text, commentRegex);
+        return Pattern.compile("#.*\\n");
     }
 
-    private static boolean textIsFullyCommentedJava(String text){
+    private static Pattern javaCommentPattern(){
         //Line Comments: Remove from // to \n
         //Block Comments: Remove from /* to */. Newlines have to be explicitly added
         Pattern lineComment = Pattern.compile("\\/\\/.*\\n");
         Pattern blockComment = Pattern.compile("\\/\\*(.|\\n)*\\*\\/");
-        Pattern commentRegex = Pattern.compile(String.format("(%s|%s)",lineComment.pattern(), blockComment.pattern()));
-
-        return textIsFullOfRegex(text, commentRegex);
-    }
-
-    private static boolean textIsFullOfRegex(String text, Pattern regex) {
-        //Add an extra carriage return at the end for correct matching with line comments
-        String textWithExtraCarriageReturn = text + "\n";
-        String textWithoutComments = textWithExtraCarriageReturn.replaceAll(regex.pattern(), "");
-
-        return textWithoutComments.isBlank();
+        return Pattern.compile(String.format("(%s|%s)",lineComment.pattern(), blockComment.pattern()));
     }
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.cameltooling.lsp.internal.completion.modeline;
 
 import org.eclipse.lsp4j.CompletionItem;
@@ -6,6 +22,11 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Provides with the available completions for inserting new camel-k modelines
+ *
+ * @author joshiraez
+ */
 public class CamelKModelineInsertionProcessor {
 
     private final TextDocumentItem textDocumentItem;

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -43,6 +43,6 @@ public class CamelKModelineInsertionProcessor {
     }
 
     private CompletionItem getCompletionCorrespondingToDocument() {
-        return CamelKModelineFileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().completion;
+        return CamelKModelineFileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().getCompletion();
     }
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -3,7 +3,6 @@ package com.github.cameltooling.lsp.internal.completion.modeline;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -17,7 +16,7 @@ public class CamelKModelineInsertionProcessor {
         this.textDocumentItem = textDocumentItem;
     }
 
-    public CompletableFuture<List<CompletionItem>> getInsertion() {
+    public CompletableFuture<List<CompletionItem>> getCompletions() {
         return CompletableFuture.completedFuture(
                 Arrays.asList(
                         getCompletionCorrespondingToDocument()
@@ -25,13 +24,10 @@ public class CamelKModelineInsertionProcessor {
     }
 
     private CompletionItem getCompletionCorrespondingToDocument() {
-        //What to throw here?
         return FileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().completion;
     }
 
-    //Unify all this file type information eventually
     private enum FileType {
-        //Documentation as
         XML(".camelk.xml", "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
         Java(".java","// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
         YAML(".camelk.yaml","# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -29,20 +29,20 @@ import java.util.concurrent.CompletableFuture;
  */
 public class CamelKModelineInsertionProcessor {
 
-    private final TextDocumentItem textDocumentItem;
+	private final TextDocumentItem textDocumentItem;
 
-    public CamelKModelineInsertionProcessor(TextDocumentItem textDocumentItem) {
-        this.textDocumentItem = textDocumentItem;
-    }
+	public CamelKModelineInsertionProcessor(TextDocumentItem textDocumentItem) {
+		this.textDocumentItem = textDocumentItem;
+	}
 
-    public CompletableFuture<List<CompletionItem>> getCompletions() {
-        return CompletableFuture.completedFuture(
-                List.of(
-                        getCompletionCorrespondingToDocument()
-                ));
-    }
+	public CompletableFuture<List<CompletionItem>> getCompletions() {
+		return CompletableFuture.completedFuture(
+				List.of(
+						getCompletionCorrespondingToDocument()
+				));
+	}
 
-    private CompletionItem getCompletionCorrespondingToDocument() {
-        return CamelKModelineFileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().getCompletion();
-    }
+	private CompletionItem getCompletionCorrespondingToDocument() {
+		return CamelKModelineFileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().getCompletion();
+	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -1,12 +1,9 @@
 package com.github.cameltooling.lsp.internal.completion.modeline;
 
-import com.github.cameltooling.lsp.internal.parser.CamelKModelineInsertionParser;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class CamelKModelineInsertionProcessor {
@@ -19,41 +16,12 @@ public class CamelKModelineInsertionProcessor {
 
     public CompletableFuture<List<CompletionItem>> getCompletions() {
         return CompletableFuture.completedFuture(
-                Arrays.asList(
+                List.of(
                         getCompletionCorrespondingToDocument()
                 ));
     }
 
     private CompletionItem getCompletionCorrespondingToDocument() {
-        return FileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().completion;
-    }
-
-    private enum FileType {
-        XML(List.of(".camelk.xml"), "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-        Java(List.of(".java"),"// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-        YAML(List.of(".camelk.yaml",".camelk.yml"),"# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
-
-        public final List<String> correspondingExtensions;
-        public final CompletionItem completion;
-
-        private FileType(List<String> correspondingExtensions, String completionLabel, String completionDocumentation) {
-            this.correspondingExtensions = correspondingExtensions;
-            this.completion = getCompletionItem(completionLabel, completionDocumentation);
-        }
-
-        private static CompletionItem getCompletionItem(String label, String documentation) {
-            CompletionItem completion = new CompletionItem(label);
-            completion.setDocumentation(documentation);
-
-            return completion;
-        }
-
-        private static Optional<FileType> getFileTypeCorrespondingToUri(String uri) {
-            return Arrays.asList(FileType.values()).stream()
-                    .filter(type ->
-                            type.correspondingExtensions.stream().anyMatch(uri::endsWith)
-                    )
-                    .findFirst();
-        }
+        return CamelKModelineFileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().completion;
     }
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -1,5 +1,6 @@
 package com.github.cameltooling.lsp.internal.completion.modeline;
 
+import com.github.cameltooling.lsp.internal.parser.CamelKModelineInsertionParser;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
@@ -28,15 +29,15 @@ public class CamelKModelineInsertionProcessor {
     }
 
     private enum FileType {
-        XML(".camelk.xml", "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-        Java(".java","// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-        YAML(".camelk.yaml","# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
+        XML(List.of(".camelk.xml"), "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+        Java(List.of(".java"),"// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+        YAML(List.of(".camelk.yaml",".camelk.yml"),"# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
-        public final String correspondingExtension;
+        public final List<String> correspondingExtensions;
         public final CompletionItem completion;
 
-        private FileType(String correspondingExtension, String completionLabel, String completionDocumentation) {
-            this.correspondingExtension = correspondingExtension;
+        private FileType(List<String> correspondingExtensions, String completionLabel, String completionDocumentation) {
+            this.correspondingExtensions = correspondingExtensions;
             this.completion = getCompletionItem(completionLabel, completionDocumentation);
         }
 
@@ -49,7 +50,9 @@ public class CamelKModelineInsertionProcessor {
 
         private static Optional<FileType> getFileTypeCorrespondingToUri(String uri) {
             return Arrays.asList(FileType.values()).stream()
-                    .filter(type -> uri.endsWith(type.correspondingExtension))
+                    .filter(type ->
+                            type.correspondingExtensions.stream().anyMatch(uri::endsWith)
+                    )
                     .findFirst();
         }
     }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -20,6 +20,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -37,12 +38,14 @@ public class CamelKModelineInsertionProcessor {
 
 	public CompletableFuture<List<CompletionItem>> getCompletions() {
 		return CompletableFuture.completedFuture(
-				List.of(
-						getCompletionCorrespondingToDocument()
-				));
+				getCompletionCorrespondingToDocument().map(
+						List::of
+				).orElse(List.of())
+		);
 	}
 
-	private CompletionItem getCompletionCorrespondingToDocument() {
-		return CamelKModelineFileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().getCompletion();
+	private Optional<CompletionItem> getCompletionCorrespondingToDocument() {
+		return CamelKModelineFileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri())
+				.map(CamelKModelineFileType::getCompletion);
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionProcessor.java
@@ -1,0 +1,60 @@
+package com.github.cameltooling.lsp.internal.completion.modeline;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class CamelKModelineInsertionProcessor {
+
+    private final TextDocumentItem textDocumentItem;
+
+    public CamelKModelineInsertionProcessor(TextDocumentItem textDocumentItem) {
+        this.textDocumentItem = textDocumentItem;
+    }
+
+    public CompletableFuture<List<CompletionItem>> getInsertion() {
+        return CompletableFuture.completedFuture(
+                Arrays.asList(
+                        getCompletionCorrespondingToDocument()
+                ));
+    }
+
+    private CompletionItem getCompletionCorrespondingToDocument() {
+        //What to throw here?
+        return FileType.getFileTypeCorrespondingToUri(textDocumentItem.getUri()).orElseThrow().completion;
+    }
+
+    //Unify all this file type information eventually
+    private enum FileType {
+        //Documentation as
+        XML(".camelk.xml", "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+        Java(".java","// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+        YAML(".camelk.yaml","# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
+
+        public final String correspondingExtension;
+        public final CompletionItem completion;
+
+        private FileType(String correspondingExtension, String completionLabel, String completionDocumentation) {
+            this.correspondingExtension = correspondingExtension;
+            this.completion = getCompletionItem(completionLabel, completionDocumentation);
+        }
+
+        private static CompletionItem getCompletionItem(String label, String documentation) {
+            CompletionItem completion = new CompletionItem(label);
+            completion.setDocumentation(documentation);
+
+            return completion;
+        }
+
+        private static Optional<FileType> getFileTypeCorrespondingToUri(String uri) {
+            return Arrays.asList(FileType.values()).stream()
+                    .filter(type -> uri.endsWith(type.correspondingExtension))
+                    .findFirst();
+        }
+    }
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -5,6 +5,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -50,23 +51,25 @@ public class CamelKModelineInsertionParser {
     }
 
     private enum FileType {
-        XML(".camelk.xml", "<!-- camel-k:", FileType::textIsFullyCommentedXML),
-        Java(".java", "// camel-k:", FileType::textIsFullyCommentedJava),
-        YAML(".camelk.yaml", "# camel-k", FileType::textIsFullyCommentedYAML);
+        XML(List.of(".camelk.xml"), "<!-- camel-k:", FileType::textIsFullyCommentedXML),
+        Java(List.of(".java"), "// camel-k:", FileType::textIsFullyCommentedJava),
+        YAML(List.of(".camelk.yaml", ".camelk.yml"), "# camel-k", FileType::textIsFullyCommentedYAML);
 
-        public final String extension;
+        public final List<String> extensions;
         public final String modelineLabel;
         public final Function<String, Boolean> checkTextIsCommentsDelegate;
 
-        private FileType(String extension, String modelineLabel, Function<String, Boolean> checkTextIsCommentsDelegate) {
-            this.extension = extension;
+        private FileType(List<String> extensions, String modelineLabel, Function<String, Boolean> checkTextIsCommentsDelegate) {
+            this.extensions = extensions;
             this.modelineLabel = modelineLabel;
             this.checkTextIsCommentsDelegate = checkTextIsCommentsDelegate;
         }
 
         private static Optional<FileType> getFileTypeCorrespondingToUri(String uri) {
             return Arrays.asList(FileType.values()).stream()
-                    .filter(type -> uri.endsWith(type.extension))
+                    .filter(type ->
+                        type.extensions.stream().anyMatch(uri::endsWith)
+                    )
                     .findFirst();
         }
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -1,62 +1,85 @@
 package com.github.cameltooling.lsp.internal.parser;
 
-import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineInsertionProcessor;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class CamelKModelineInsertionParser {
 
-    public boolean canPutCamelKModeline(Position position, TextDocumentItem textDocumentItem) {
+    private final TextDocumentItem document;
+
+    public CamelKModelineInsertionParser(TextDocumentItem document) {
+        this.document = document;
+    }
+
+    public boolean canPutCamelKModeline(Position position) {
         int currentLine = position.getLine();
 
         //Save the lines to not have to access multiple times to file?
-        return isCamelKFile(textDocumentItem)
-                && lineIsEmpty(currentLine, textDocumentItem)
-                && noModelineInsertedAlready(textDocumentItem)
-                && previousLinesAreCommentsOrEmpty(currentLine,textDocumentItem);
+        return isCamelKFile()
+                && lineIsEmpty(currentLine)
+                && noModelineInsertedAlready()
+                && previousLinesAreCommentsOrEmpty(currentLine);
     }
 
-    private boolean isCamelKFile(TextDocumentItem document) {
+    private boolean isCamelKFile() {
         return FileType.getFileTypeCorrespondingToUri(document.getUri()).isPresent();
     }
 
-    private boolean lineIsEmpty(int line, TextDocumentItem textDocumentItem) {
-        return new ParserFileHelperUtil().getLine(textDocumentItem, line).isEmpty();
+    private boolean lineIsEmpty(int line) {
+        return new ParserFileHelperUtil().getLine(document, line).isEmpty();
     }
 
-    private boolean noModelineInsertedAlready(TextDocumentItem textDocumentItem) {
-        //Will do later
+    private boolean noModelineInsertedAlready() {
+        // Edge case - Modeline inserted inside block comment in java
         return true;
     }
 
-    private boolean previousLinesAreCommentsOrEmpty(int line, TextDocumentItem textDocumentItem) {
-        //Harder than it looks. We have to take into account multi and single comment lines. Will be done when I get to that test
-        return true;
+    private boolean previousLinesAreCommentsOrEmpty(int line) {
+        String textBeforeLine = IntStream.range(0, line).boxed()
+                .map(currLine -> new ParserFileHelperUtil().getLine(document,currLine))
+                .collect(Collectors.joining());
+
+        return FileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
+                .checkTextIsCommentsDelegate.apply(textBeforeLine);
     }
 
     //Unify this somewhere for modeline parsing/completion?
     private enum FileType {
-        XML(".camelk.xml", "<!-- camel-k:"),
-        Java(".java", "// camel-k:"),
-        YAML(".camelk.yaml", "# camel-k");
+        XML(".camelk.xml", "<!-- camel-k:", FileType::textIsFullyCommentedXML),
+        Java(".java", "// camel-k:", text -> true),
+        YAML(".camelk.yaml", "# camel-k", text -> true);
         //YAML has the special condition `# yaml-language-server: $schema=<urlToCamelKyaml>`
 
         public final String extension;
         public final String modelineLabel;
+        public final Function<String, Boolean> checkTextIsCommentsDelegate;
 
-        private FileType(String extension, String modelineLabel) {
+        private FileType(String extension, String modelineLabel, Function<String, Boolean> checkTextIsCommentsDelegate) {
             this.extension = extension;
             this.modelineLabel = modelineLabel;
+            this.checkTextIsCommentsDelegate = checkTextIsCommentsDelegate;
         }
 
         private static Optional<FileType> getFileTypeCorrespondingToUri(String uri) {
             return Arrays.asList(FileType.values()).stream()
                     .filter(type -> uri.endsWith(type.extension))
                     .findFirst();
+        }
+
+        private static boolean textIsFullyCommentedXML(String text){
+            //Remove all segments between <!-- and -->. Check if it's empty.
+            Pattern commentRegex = Pattern.compile("<!--.*-->");
+            String textWithoutComments = text.replaceAll(commentRegex.pattern(), "");
+
+            return textWithoutComments.isEmpty();
         }
     }
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -4,6 +4,7 @@ import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineFi
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
+import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -33,7 +34,10 @@ public class CamelKModelineInsertionParser {
     }
 
     private boolean noModelineInsertedAlready() {
-        return true;
+        String modeline = CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
+                .modeline;
+
+        return !Arrays.stream(document.getText().split("\n")).anyMatch(line -> line.startsWith(modeline));
     }
 
     private boolean previousLinesAreCommentsOrEmpty(int line) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -59,7 +59,7 @@ public class CamelKModelineInsertionParser {
 		String modeline = CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
 				.getModeline();
 
-		return !Arrays.stream(document.getText().split("\n")).anyMatch(line -> line.startsWith(modeline));
+		return Arrays.stream(document.getText().split("\n")).noneMatch(line -> line.startsWith(modeline));
 	}
 
 	private boolean previousLinesAreCommentsOrEmpty(int line) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -21,6 +21,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -66,7 +67,15 @@ public class CamelKModelineInsertionParser {
                 .map(currLine -> new ParserFileHelperUtil().getLine(document,currLine))
                 .collect(Collectors.joining("\n"));
 
-        return CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
-                .checkTextIsCommentsDelegate.apply(textBeforeLine);
+        return textIsFullOfRegex(textBeforeLine,
+                CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
+                .commentRegexSupplier.get());
+    }
+    private boolean textIsFullOfRegex(String text, Pattern regex) {
+        //Add an extra carriage return at the end for correct matching with line comments
+        String textWithExtraCarriageReturn = text + "\n";
+        String textWithoutComments = textWithExtraCarriageReturn.replaceAll(regex.pattern(), "");
+
+        return textWithoutComments.isBlank();
     }
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -32,50 +32,50 @@ import java.util.stream.IntStream;
  */
 public class CamelKModelineInsertionParser {
 
-    private final TextDocumentItem document;
+	private final TextDocumentItem document;
 
-    public CamelKModelineInsertionParser(TextDocumentItem document) {
-        this.document = document;
-    }
+	public CamelKModelineInsertionParser(TextDocumentItem document) {
+		this.document = document;
+	}
 
-    public boolean canPutCamelKModeline(Position position) {
-        int currentLine = position.getLine();
+	public boolean canPutCamelKModeline(Position position) {
+		int currentLine = position.getLine();
 
-        return isCamelKFile()
-                && lineIsEmpty(currentLine)
-                && noModelineInsertedAlready()
-                && previousLinesAreCommentsOrEmpty(currentLine);
-    }
+		return isCamelKFile()
+				&& lineIsEmpty(currentLine)
+				&& noModelineInsertedAlready()
+				&& previousLinesAreCommentsOrEmpty(currentLine);
+	}
 
-    private boolean isCamelKFile() {
-        return CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).isPresent();
-    }
+	private boolean isCamelKFile() {
+		return CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).isPresent();
+	}
 
-    private boolean lineIsEmpty(int line) {
-        return new ParserFileHelperUtil().getLine(document, line).isBlank();
-    }
+	private boolean lineIsEmpty(int line) {
+		return new ParserFileHelperUtil().getLine(document, line).isBlank();
+	}
 
-    private boolean noModelineInsertedAlready() {
-        String modeline = CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
-                .getModeline();
+	private boolean noModelineInsertedAlready() {
+		String modeline = CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
+				.getModeline();
 
-        return !Arrays.stream(document.getText().split("\n")).anyMatch(line -> line.startsWith(modeline));
-    }
+		return !Arrays.stream(document.getText().split("\n")).anyMatch(line -> line.startsWith(modeline));
+	}
 
-    private boolean previousLinesAreCommentsOrEmpty(int line) {
-        String textBeforeLine = IntStream.range(0, line).boxed()
-                .map(currLine -> new ParserFileHelperUtil().getLine(document,currLine))
-                .collect(Collectors.joining("\n"));
+	private boolean previousLinesAreCommentsOrEmpty(int line) {
+		String textBeforeLine = IntStream.range(0, line).boxed()
+				.map(currLine -> new ParserFileHelperUtil().getLine(document,currLine))
+				.collect(Collectors.joining("\n"));
 
-        return textIsFullOfRegex(textBeforeLine,
-                CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
-                        .getCommentRegexSupplier().get());
-    }
-    private boolean textIsFullOfRegex(String text, Pattern regex) {
-        //Add an extra carriage return at the end for correct matching with line comments
-        String textWithExtraCarriageReturn = text + "\n";
-        String textWithoutComments = textWithExtraCarriageReturn.replaceAll(regex.pattern(), "");
+		return textIsFullOfRegex(textBeforeLine,
+				CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
+						.getCommentRegexSupplier().get());
+	}
+	private boolean textIsFullOfRegex(String text, Pattern regex) {
+		//Add an extra carriage return at the end for correct matching with line comments
+		String textWithExtraCarriageReturn = text + "\n";
+		String textWithoutComments = textWithExtraCarriageReturn.replaceAll(regex.pattern(), "");
 
-        return textWithoutComments.isBlank();
-    }
+		return textWithoutComments.isBlank();
+	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.cameltooling.lsp.internal.parser;
 
 import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineFileType;
@@ -8,6 +24,11 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+/**
+ * Parses and checks text document to see if camel-k modeline insertion completions are available.
+ *
+ * @author joshiraez
+ */
 public class CamelKModelineInsertionParser {
 
     private final TextDocumentItem document;

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -34,7 +34,7 @@ public class CamelKModelineInsertionParser {
     }
 
     private boolean lineIsEmpty(int line) {
-        return new ParserFileHelperUtil().getLine(document, line).isEmpty();
+        return new ParserFileHelperUtil().getLine(document, line).isBlank();
     }
 
     private boolean noModelineInsertedAlready() {
@@ -45,7 +45,7 @@ public class CamelKModelineInsertionParser {
     private boolean previousLinesAreCommentsOrEmpty(int line) {
         String textBeforeLine = IntStream.range(0, line).boxed()
                 .map(currLine -> new ParserFileHelperUtil().getLine(document,currLine))
-                .collect(Collectors.joining());
+                .collect(Collectors.joining("\n"));
 
         return FileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
                 .checkTextIsCommentsDelegate.apply(textBeforeLine);
@@ -55,7 +55,7 @@ public class CamelKModelineInsertionParser {
     private enum FileType {
         XML(".camelk.xml", "<!-- camel-k:", FileType::textIsFullyCommentedXML),
         Java(".java", "// camel-k:", text -> true),
-        YAML(".camelk.yaml", "# camel-k", text -> true);
+        YAML(".camelk.yaml", "# camel-k", FileType::textIsFullyCommentedYAML);
         //YAML has the special condition `# yaml-language-server: $schema=<urlToCamelKyaml>`
 
         public final String extension;
@@ -89,9 +89,10 @@ public class CamelKModelineInsertionParser {
         }
 
         private static boolean textIsFullOfRegex(String text, Pattern regex) {
-            String textWithoutComments = text.replaceAll(regex.pattern(), "");
+            String textWithExtraCarriageReturn = text + "\n";
+            String textWithoutComments = textWithExtraCarriageReturn.replaceAll(regex.pattern(), "");
 
-            return textWithoutComments.isEmpty();
+            return textWithoutComments.isBlank();
         }
     }
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -1,0 +1,62 @@
+package com.github.cameltooling.lsp.internal.parser;
+
+import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineInsertionProcessor;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentItem;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class CamelKModelineInsertionParser {
+
+    public boolean canPutCamelKModeline(Position position, TextDocumentItem textDocumentItem) {
+        int currentLine = position.getLine();
+
+        //Save the lines to not have to access multiple times to file?
+        return isCamelKFile(textDocumentItem)
+                && lineIsEmpty(currentLine, textDocumentItem)
+                && noModelineInsertedAlready(textDocumentItem)
+                && previousLinesAreCommentsOrEmpty(currentLine,textDocumentItem);
+    }
+
+    private boolean isCamelKFile(TextDocumentItem document) {
+        return FileType.getFileTypeCorrespondingToUri(document.getUri()).isPresent();
+    }
+
+    private boolean lineIsEmpty(int line, TextDocumentItem textDocumentItem) {
+        return new ParserFileHelperUtil().getLine(textDocumentItem, line).isEmpty();
+    }
+
+    private boolean noModelineInsertedAlready(TextDocumentItem textDocumentItem) {
+        //Will do later
+        return true;
+    }
+
+    private boolean previousLinesAreCommentsOrEmpty(int line, TextDocumentItem textDocumentItem) {
+        //Harder than it looks. We have to take into account multi and single comment lines. Will be done when I get to that test
+        return true;
+    }
+
+    //Unify this somewhere for modeline parsing/completion?
+    private enum FileType {
+        XML(".camelk.xml", "<!-- camel-k:"),
+        Java(".java", "// camel-k:"),
+        YAML(".camelk.yaml", "# camel-k");
+        //YAML has the special condition `# yaml-language-server: $schema=<urlToCamelKyaml>`
+
+        public final String extension;
+        public final String modelineLabel;
+
+        private FileType(String extension, String modelineLabel) {
+            this.extension = extension;
+            this.modelineLabel = modelineLabel;
+        }
+
+        private static Optional<FileType> getFileTypeCorrespondingToUri(String uri) {
+            return Arrays.asList(FileType.values()).stream()
+                    .filter(type -> uri.endsWith(type.extension))
+                    .findFirst();
+        }
+    }
+}

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -22,7 +22,6 @@ public class CamelKModelineInsertionParser {
     public boolean canPutCamelKModeline(Position position) {
         int currentLine = position.getLine();
 
-        //Save the lines to not have to access multiple times to file?
         return isCamelKFile()
                 && lineIsEmpty(currentLine)
                 && noModelineInsertedAlready()
@@ -38,7 +37,6 @@ public class CamelKModelineInsertionParser {
     }
 
     private boolean noModelineInsertedAlready() {
-        // Edge case - Modeline inserted inside block comment in java
         return true;
     }
 
@@ -51,12 +49,10 @@ public class CamelKModelineInsertionParser {
                 .checkTextIsCommentsDelegate.apply(textBeforeLine);
     }
 
-    //Unify this somewhere for modeline parsing/completion?
     private enum FileType {
         XML(".camelk.xml", "<!-- camel-k:", FileType::textIsFullyCommentedXML),
         Java(".java", "// camel-k:", text -> true),
         YAML(".camelk.yaml", "# camel-k", FileType::textIsFullyCommentedYAML);
-        //YAML has the special condition `# yaml-language-server: $schema=<urlToCamelKyaml>`
 
         public final String extension;
         public final String modelineLabel;
@@ -89,6 +85,7 @@ public class CamelKModelineInsertionParser {
         }
 
         private static boolean textIsFullOfRegex(String text, Pattern regex) {
+            //Add an extra carriage return at the end for correct matching with line comments
             String textWithExtraCarriageReturn = text + "\n";
             String textWithoutComments = textWithExtraCarriageReturn.replaceAll(regex.pattern(), "");
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -51,7 +51,7 @@ public class CamelKModelineInsertionParser {
 
     private enum FileType {
         XML(".camelk.xml", "<!-- camel-k:", FileType::textIsFullyCommentedXML),
-        Java(".java", "// camel-k:", text -> true),
+        Java(".java", "// camel-k:", FileType::textIsFullyCommentedJava),
         YAML(".camelk.yaml", "# camel-k", FileType::textIsFullyCommentedYAML);
 
         public final String extension;
@@ -80,6 +80,16 @@ public class CamelKModelineInsertionParser {
         private static boolean textIsFullyCommentedYAML(String text){
             //Remove all segments between # and \n
             Pattern commentRegex = Pattern.compile("#.*\\n");
+
+            return textIsFullOfRegex(text, commentRegex);
+        }
+
+        private static boolean textIsFullyCommentedJava(String text){
+            //Line Comments: Remove from // to \n
+            //Block Comments: Remove from /* to */. Newlines have to be explicitly added
+            Pattern lineComment = Pattern.compile("\\/\\/.*\\n");
+            Pattern blockComment = Pattern.compile("\\/\\*(.|\\n)*\\*\\/");
+            Pattern commentRegex = Pattern.compile(String.format("(%s|%s)",lineComment.pattern(), blockComment.pattern()));
 
             return textIsFullOfRegex(text, commentRegex);
         }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -77,7 +77,19 @@ public class CamelKModelineInsertionParser {
         private static boolean textIsFullyCommentedXML(String text){
             //Remove all segments between <!-- and -->. Check if it's empty.
             Pattern commentRegex = Pattern.compile("<!--.*-->");
-            String textWithoutComments = text.replaceAll(commentRegex.pattern(), "");
+
+            return textIsFullOfRegex(text, commentRegex);
+        }
+
+        private static boolean textIsFullyCommentedYAML(String text){
+            //Remove all segments between # and \n
+            Pattern commentRegex = Pattern.compile("#.*\\n");
+
+            return textIsFullOfRegex(text, commentRegex);
+        }
+
+        private static boolean textIsFullOfRegex(String text, Pattern regex) {
+            String textWithoutComments = text.replaceAll(regex.pattern(), "");
 
             return textWithoutComments.isEmpty();
         }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -21,6 +21,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -40,36 +41,34 @@ public class CamelKModelineInsertionParser {
 
 	public boolean canPutCamelKModeline(Position position) {
 		int currentLine = position.getLine();
-
-		return isCamelKFile()
-				&& lineIsEmpty(currentLine)
-				&& noModelineInsertedAlready()
-				&& previousLinesAreCommentsOrEmpty(currentLine);
+		return retrieveFileType().map(
+				fileType ->
+					lineIsEmpty(currentLine)
+							&& noModelineInsertedAlready(fileType)
+							&& previousLinesAreCommentsOrEmpty(currentLine, fileType)
+				).orElse(false);
 	}
 
-	private boolean isCamelKFile() {
-		return CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).isPresent();
+	private Optional<CamelKModelineFileType> retrieveFileType() {
+		return CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri());
 	}
 
 	private boolean lineIsEmpty(int line) {
 		return new ParserFileHelperUtil().getLine(document, line).isBlank();
 	}
 
-	private boolean noModelineInsertedAlready() {
-		String modeline = CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
-				.getModeline();
+	private boolean noModelineInsertedAlready(CamelKModelineFileType forFileType) {
+		String modeline = forFileType.getModeline();
 
 		return Arrays.stream(document.getText().split("\n")).noneMatch(line -> line.startsWith(modeline));
 	}
 
-	private boolean previousLinesAreCommentsOrEmpty(int line) {
+	private boolean previousLinesAreCommentsOrEmpty(int line, CamelKModelineFileType forFileType) {
 		String textBeforeLine = IntStream.range(0, line).boxed()
 				.map(currLine -> new ParserFileHelperUtil().getLine(document,currLine))
 				.collect(Collectors.joining("\n"));
 
-		return textIsFullOfRegex(textBeforeLine,
-				CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
-						.getCommentRegexSupplier().get());
+		return textIsFullOfRegex(textBeforeLine, forFileType.getCommentRegexSupplier().get());
 	}
 	private boolean textIsFullOfRegex(String text, Pattern regex) {
 		//Add an extra carriage return at the end for correct matching with line comments

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineInsertionParser.java
@@ -57,7 +57,7 @@ public class CamelKModelineInsertionParser {
 
     private boolean noModelineInsertedAlready() {
         String modeline = CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
-                .modeline;
+                .getModeline();
 
         return !Arrays.stream(document.getText().split("\n")).anyMatch(line -> line.startsWith(modeline));
     }
@@ -69,7 +69,7 @@ public class CamelKModelineInsertionParser {
 
         return textIsFullOfRegex(textBeforeLine,
                 CamelKModelineFileType.getFileTypeCorrespondingToUri(document.getUri()).orElseThrow()
-                .commentRegexSupplier.get());
+                        .getCommentRegexSupplier().get());
     }
     private boolean textIsFullOfRegex(String text, Pattern regex) {
         //Add an extra carriage return at the end for correct matching with line comments

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
@@ -39,5 +39,4 @@ public class CamelKModelineParser {
 		return retrieveModelineCamelKStart(new ParserFileHelperUtil().getLine(textDocumentItem, line)) != null;
 	}
 
-
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
@@ -16,12 +16,10 @@
  */
 package com.github.cameltooling.lsp.internal.parser;
 
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 public class CamelKModelineParser {
 
-	//Unify this and Insertion definitions?
 	public static final String MODELINE_LIKE_CAMEL_K = "// camel-k:";
 	public static final String MODELINE_LIKE_CAMEL_K_YAML = "# camel-k:";
 	public static final String MODELINE_LIKE_CAMEL_K_XML = "<!-- camel-k:";

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
@@ -21,6 +21,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 
 public class CamelKModelineParser {
 
+	//Unify this and Insertion definitions?
 	public static final String MODELINE_LIKE_CAMEL_K = "// camel-k:";
 	public static final String MODELINE_LIKE_CAMEL_K_YAML = "# camel-k:";
 	public static final String MODELINE_LIKE_CAMEL_K_XML = "<!-- camel-k:";
@@ -40,19 +41,5 @@ public class CamelKModelineParser {
 		return retrieveModelineCamelKStart(new ParserFileHelperUtil().getLine(textDocumentItem, line)) != null;
 	}
 
-	public boolean canPutCamelKModeline(Position position, TextDocumentItem textDocumentItem) {
-		int currentLine = position.getLine();
 
-		//Save the lines to not have to access multiple times to file?
-		return lineIsEmpty(currentLine, textDocumentItem) && previousLinesAreCommentsOrEmpty(currentLine,textDocumentItem);
-	}
-
-	private boolean previousLinesAreCommentsOrEmpty(int line, TextDocumentItem textDocumentItem) {
-		//Harder than it looks. We have to take into account multi and single comment lines. Will be done when I get to that test
-		return true;
-	}
-
-	private boolean lineIsEmpty(int line, TextDocumentItem textDocumentItem) {
-		return new ParserFileHelperUtil().getLine(textDocumentItem, line).isEmpty();
-	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKModelineParser.java
@@ -16,6 +16,7 @@
  */
 package com.github.cameltooling.lsp.internal.parser;
 
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentItem;
 
 public class CamelKModelineParser {
@@ -38,5 +39,20 @@ public class CamelKModelineParser {
 	public boolean isOnCamelKModeline(int line, TextDocumentItem textDocumentItem) {
 		return retrieveModelineCamelKStart(new ParserFileHelperUtil().getLine(textDocumentItem, line)) != null;
 	}
-	
+
+	public boolean canPutCamelKModeline(Position position, TextDocumentItem textDocumentItem) {
+		int currentLine = position.getLine();
+
+		//Save the lines to not have to access multiple times to file?
+		return lineIsEmpty(currentLine, textDocumentItem) && previousLinesAreCommentsOrEmpty(currentLine,textDocumentItem);
+	}
+
+	private boolean previousLinesAreCommentsOrEmpty(int line, TextDocumentItem textDocumentItem) {
+		//Harder than it looks. We have to take into account multi and single comment lines. Will be done when I get to that test
+		return true;
+	}
+
+	private boolean lineIsEmpty(int line, TextDocumentItem textDocumentItem) {
+		return new ParserFileHelperUtil().getLine(textDocumentItem, line).isEmpty();
+	}
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
 
-    //Use parameterized tests on future
     /* EMPTY FILE TESTS */
     @Test
     void testProvideInsertionOnEmptyXMLFile() throws Exception {
@@ -115,8 +114,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testDontProvideInsertionIfExtraTextXML() throws Exception {
         FileType type = FileType.XML;
         String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>\n";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertNoCompletionsAvailable(completionItems);
     }
@@ -133,16 +133,16 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
 
-    @Test
-    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "# Example\n \n #Example2 ####\n ";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
+//    @Test
+//    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
+//        FileType type = FileType.XML;
+//        String contents = "# Example\n \n #Example2 ####\n ";
+//        Position position = beginningOfLastLine(contents);
+//
+//        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+//
+//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+//    }
 
     @Test
     void testDontProvideInsertionIfExtraTextYAML() throws Exception {

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -64,8 +64,9 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
             CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);
             List<CompletionItem> completionItems =  completions.get().getLeft();
 
-            assertThat(completionItems).hasSize(1);
-            assertThat(completionItems).contains(FileType.YAML.completion);
+            assertThat(completionItems)
+                    .hasSize(1)
+                    .contains(FileType.YAML.completion);
         }
 
         @Test
@@ -342,8 +343,9 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
     }
 
     private void assertCompletionItemsHasExpectedCompletionForType(FileType type, List<CompletionItem> completionItems) {
-        assertThat(completionItems).hasSize(1);
-        checkInsertionCompletionAvailableForType(completionItems, type);
+        assertThat(completionItems)
+                .hasSize(1)
+                .contains(type.completion);
     }
 
     private List<CompletionItem>  getCompletionsFor(FileType type, String contents, Position position) throws Exception {
@@ -352,10 +354,6 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);
 
         return completions.get().getLeft();
-    }
-
-    private void checkInsertionCompletionAvailableForType(List<CompletionItem> completionItems, FileType toAssert) {
-        assertThat(completionItems).contains(toAssert.completion);
     }
 
     private enum FileType {

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -155,6 +155,39 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertNoCompletionsAvailable(completionItems);
     }
 
+    /* JAVA */
+    @Test
+    void testProvideInsertionOnLineCommentedJavaFile() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "// Example\n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
+
+//    @Test
+//    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
+//        FileType type = FileType.YAML;
+//        String contents = "# Example\n \n #Example2 ####\n ";
+//        Position position = beginningOfLastLine(contents);
+//
+//        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+//
+//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+//    }
+//
+//    @Test
+//    void testDontProvideInsertionIfExtraTextYAML() throws Exception {
+//        FileType type = FileType.YAML;
+//        String contents = "# Example\nexample:\n";
+//        Position position = beginningOfLastLine(contents);
+//
+//        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+//
+//        assertNoCompletionsAvailable(completionItems);
+//    }
 
     /** UTILS **/
 

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -167,17 +167,50 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
 
-//    @Test
-//    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
-//        FileType type = FileType.YAML;
-//        String contents = "# Example\n \n #Example2 ####\n ";
-//        Position position = beginningOfLastLine(contents);
-//
-//        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-//
-//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-//    }
-//
+    @Test
+    void testProvideInsertionOnMultipleLineCommentedJavaFile() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "// Example\n \n //Example //Example \n //EEExample \n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
+
+    @Test
+    void testProvideInsertionOnBlockCommentedJavaFile() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "/* Example */\n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
+
+    @Test
+    void testProvideInsertionOnMultipleBlockCommentedJavaFile() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "/* Example\n \n Example */ /*Example \n EEExample */ \n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
+
+    @Test
+    void testProvideInsertionOnMixCommentedJavaFile() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "/* Example\n \n Example */ /*Example \n //EEExample */ \n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
+
 //    @Test
 //    void testDontProvideInsertionIfExtraTextYAML() throws Exception {
 //        FileType type = FileType.YAML;

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -232,6 +232,40 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
         assertNoCompletionsAvailable(completionItems);
     }
 
+    /** FILE WITH MODELINE ALREADY INSERTED **/
+    @Test
+    void testDontProvideInsertionOnXMLFileWithModeline() throws Exception {
+        FileType type = FileType.XML;
+        String contents = "<!-- camel-k: -->\n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
+
+    @Test
+    void testDontProvideInsertionOnYAMLFileWithModeline() throws Exception {
+        FileType type = FileType.YAML;
+        String contents = "# camel-k:\n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
+
+    @Test
+    void testDontProvideInsertionOnJavaFileWithModeline() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "// camel-k:\n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
+
     /** MID FILE **/
     @Test
     void testProvideInsertionIfCursorBetweenCommentsAndStartOfCode() throws Exception {
@@ -261,7 +295,7 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
         checkInsertionCompletionAvailableForType(completionItems, type);
     }
 
-    List<CompletionItem>  getCompletionsFor(FileType type, String contents, Position position) throws Exception {
+    private List<CompletionItem>  getCompletionsFor(FileType type, String contents, Position position) throws Exception {
         CamelLanguageServer camelLanguageServer = initializeLanguageServer(contents, type.extension);
 
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -189,7 +189,6 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         XML(".camelk.xml", "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
         Java(".java", "// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
         YAML(".camelk.yaml", "# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
-        //YAML has the special condition `# yaml-language-server: $schema=<urlToCamelKyaml>`
 
         public final String extension;
         public final CompletionItem completion;

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
 
-    /* EMPTY FILE TESTS */
+    /** EMPTY FILE TESTS **/
     @Test
     void testProvideInsertionOnEmptyXMLFile() throws Exception {
         FileType type = FileType.XML;
@@ -75,8 +75,8 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertNoCompletionsAvailable(completionItems);
     }
 
-    /* FILE WITH COMMENTS ABOVE LINE TEST */
-    /* XML */
+    /** FILE WITH COMMENTS ABOVE LINE TESTS **/
+    /** XML **/
     @Test
     void testProvideInsertionOnCommentedXMLFile() throws Exception {
         FileType type = FileType.XML;
@@ -121,7 +121,7 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertNoCompletionsAvailable(completionItems);
     }
 
-    /* YAML */
+    /** YAML **/
     @Test
     void testProvideInsertionOnCommentedYAMLFile() throws Exception {
         FileType type = FileType.YAML;
@@ -155,7 +155,7 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertNoCompletionsAvailable(completionItems);
     }
 
-    /* JAVA */
+    /** JAVA **/
     @Test
     void testProvideInsertionOnLineCommentedJavaFile() throws Exception {
         FileType type = FileType.Java;
@@ -220,6 +220,18 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertNoCompletionsAvailable(completionItems);
+    }
+
+    /** MID FILE **/
+    @Test
+    void testProvideInsertionIfCursorBetweenCommentsAndStartOfCode() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "// Example\n\npublic class CamelExample {\n";
+        Position position = new Position(1,0);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
 
     /** UTILS **/

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -339,7 +339,7 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
     }
 
     private void assertNoCompletionsAvailable(List<CompletionItem> completionItems) {
-        assertThat(completionItems).hasSize(0);
+        assertThat(completionItems).isEmpty();
     }
 
     private void assertCompletionItemsHasExpectedCompletionForType(FileType type, List<CompletionItem> completionItems) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -345,8 +345,8 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
 
     private enum FileType {
         XML(".camelk.xml", "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-        Java(".java", "// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
-        YAML(".camelk.yaml", "# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
+        Java(".java", "// camel-k: ", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+        YAML(".camelk.yaml", "# camel-k: ", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
         public final String extension;
         public final CompletionItem completion;

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -54,6 +54,20 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     }
 
     @Test
+    void testProvideInsertionOnEmptyYMLFile() throws Exception {
+        String extension = ".camelk.yml";
+        String contents = "";
+        Position position = beginningOfLastLine(contents);
+
+        CamelLanguageServer camelLanguageServer = initializeLanguageServer(contents, extension);
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);
+        List<CompletionItem> completionItems =  completions.get().getLeft();
+
+        assertThat(completionItems).hasSize(1);
+        assertThat(completionItems).contains(FileType.YAML.completion);
+    }
+
+    @Test
     void testInsertionOnLineWithSpacesOrTabs() throws Exception {
         FileType type = FileType.Java;
         String contents = "\t   \t \t";

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -7,6 +7,8 @@ import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -14,21 +16,45 @@ import java.util.concurrent.CompletableFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
+
+    //Use parameterized tests on future
     @Test
     void testProvideInsertionOnEmptyXMLFile() throws Exception {
-        CamelLanguageServer camelLanguageServer = initializeLanguageServer("");
+        FileType type = FileType.XML;
+        CamelLanguageServer camelLanguageServer = initializeLanguageServer("", type.extension);
 
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 0));
 
         List<CompletionItem> completionItems = completions.get().getLeft();
         assertThat(completionItems).hasSize(1);
-//        checkInsertionCompletionAvailable(completionItems);
+        checkInsertionCompletionAvailableForType(completionItems, type);
     }
 
-//    private void checkInsertionCompletionAvailable(List<CompletionItem> completionItems) {
-//        CompletionItem traitCompletionItem = new CompletionItem("insertion");
-//        traitCompletionItem.setDocumentation("Configure a trait. E.g. \"trait=service.enabled=false\"");
-//        assertThat(completionItems).contains(traitCompletionItem);
-//    }
+    private void checkInsertionCompletionAvailableForType(List<CompletionItem> completionItems, FileType toAssert) {
+        assertThat(completionItems).contains(toAssert.completion);
+    }
 
+    private enum FileType {
+        XML(".camelk.xml", "<!-- camel-k: -->", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+        Java(".java", "// camel-k:", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
+        YAML(".camelk.yaml", "# camel-k", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
+        //YAML has the special condition `# yaml-language-server: $schema=<urlToCamelKyaml>`
+
+        public final String extension;
+        public final CompletionItem completion;
+
+
+        private FileType(String fileExtension, String expectedLabel, String expectedDocumentation) {
+            this.extension = fileExtension;
+            this.completion = getCompletion(expectedLabel, expectedDocumentation);
+        }
+
+        private static CompletionItem getCompletion(String label, String documentation) {
+            CompletionItem completion = new CompletionItem(label);
+            completion.setDocumentation(documentation);
+
+            return completion;
+        }
+
+    }
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -248,6 +248,17 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
     }
 
     @Test
+    void testDontProvideInsertionOnXMLFileWithModelineAfterCursorPosition() throws Exception {
+        FileType type = FileType.XML;
+        String contents = "\n<!-- camel-k: -->\n";
+        Position position = new Position(0,0);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
+
+    @Test
     void testDontProvideInsertionOnYAMLFileWithModeline() throws Exception {
         FileType type = FileType.YAML;
         String contents = "# camel-k:\n";
@@ -259,10 +270,32 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
     }
 
     @Test
+    void testDontProvideInsertionOnYAMLFileWithModelineAfterCursorPosition() throws Exception {
+        FileType type = FileType.YAML;
+        String contents = "\n# camel-k:\n";
+        Position position = new Position(0,0);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
+
+    @Test
     void testDontProvideInsertionOnJavaFileWithModeline() throws Exception {
         FileType type = FileType.Java;
         String contents = "// camel-k:\n";
         Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
+
+    @Test
+    void testDontProvideInsertionOnJavaFileWithModelineAfterCursorPosition() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "\n// camel-k:\n";
+        Position position = new Position(0,0);
 
         List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -30,6 +30,28 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         checkInsertionCompletionAvailableForType(completionItems, type);
     }
 
+    @Test
+    void testProvideInsertionOnEmptyJavaFile() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "";
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+
+        assertThat(completionItems).hasSize(1);
+        checkInsertionCompletionAvailableForType(completionItems, type);
+    }
+
+    @Test
+    void testProvideInsertionOnEmptyYAMLFile() throws Exception {
+        FileType type = FileType.YAML;
+        String contents = "";
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+
+        assertThat(completionItems).hasSize(1);
+        checkInsertionCompletionAvailableForType(completionItems, type);
+    }
+
     //Why no default args
     List<CompletionItem> getCompletionsFor(FileType type, String contents) throws Exception{
         return getCompletionsFor(type, contents, new Position(0, 0));

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -7,17 +7,13 @@ import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import javax.annotation.processing.Completion;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
+class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
 
     /** EMPTY FILE TESTS **/
     @Test

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -13,6 +13,9 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ @author joshiraez
+ */
 class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
 
     /** EMPTY FILE TESTS **/

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -61,7 +61,7 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
 
         List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
-        assertNoCompletionsAvailable(completionItems);
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
     
     @Test
@@ -133,20 +133,20 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
 
-//    @Test
-//    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
-//        FileType type = FileType.XML;
-//        String contents = "# Example\n \n #Example2 ####\n ";
-//        Position position = beginningOfLastLine(contents);
-//
-//        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-//
-//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-//    }
+    @Test
+    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
+        FileType type = FileType.YAML;
+        String contents = "# Example\n \n #Example2 ####\n ";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
 
     @Test
     void testDontProvideInsertionIfExtraTextYAML() throws Exception {
-        FileType type = FileType.XML;
+        FileType type = FileType.YAML;
         String contents = "# Example\nexample:\n";
         Position position = beginningOfLastLine(contents);
 

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -211,16 +211,16 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
 
-//    @Test
-//    void testDontProvideInsertionIfExtraTextYAML() throws Exception {
-//        FileType type = FileType.YAML;
-//        String contents = "# Example\nexample:\n";
-//        Position position = beginningOfLastLine(contents);
-//
-//        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-//
-//        assertNoCompletionsAvailable(completionItems);
-//    }
+    @Test
+    void testDontProvideInsertionIfExtraTextJava() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "// Example\npublic class CamelExample {\n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
 
     /** UTILS **/
 

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -1,0 +1,34 @@
+package com.github.cameltooling.lsp.internal.completion.modeline;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
+    @Test
+    void testProvideInsertionOnEmptyXMLFile() throws Exception {
+        CamelLanguageServer camelLanguageServer = initializeLanguageServer("");
+
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 0));
+
+        List<CompletionItem> completionItems = completions.get().getLeft();
+        assertThat(completionItems).hasSize(1);
+//        checkInsertionCompletionAvailable(completionItems);
+    }
+
+//    private void checkInsertionCompletionAvailable(List<CompletionItem> completionItems) {
+//        CompletionItem traitCompletionItem = new CompletionItem("insertion");
+//        traitCompletionItem.setDocumentation("Configure a trait. E.g. \"trait=service.enabled=false\"");
+//        assertThat(completionItems).contains(traitCompletionItem);
+//    }
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -349,7 +349,7 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
     }
 
     private List<CompletionItem>  getCompletionsFor(FileType type, String contents, Position position) throws Exception {
-        CamelLanguageServer camelLanguageServer = initializeLanguageServer(contents, type.extension);
+        CamelLanguageServer camelLanguageServer = initializeLanguageServer(contents, type.getExtension());
 
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);
 
@@ -361,11 +361,11 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
         Java(".java", "// camel-k: ", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html"),
         YAML(".camelk.yaml", "# camel-k: ", "Read more: https://camel.apache.org/camel-k/1.9.x/cli/modeline.html");
 
-        public final String extension;
-        public final CompletionItem completion;
+        private final String extension;
+        private final CompletionItem completion;
 
 
-        private FileType(String fileExtension, String expectedLabel, String expectedDocumentation) {
+        FileType(String fileExtension, String expectedLabel, String expectedDocumentation) {
             this.extension = fileExtension;
             this.completion = getCompletion(expectedLabel, expectedDocumentation);
         }
@@ -377,5 +377,12 @@ class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
             return completion;
         }
 
+        public String getExtension() {
+            return extension;
+        }
+
+        public CompletionItem getCompletion() {
+            return completion;
+        }
     }
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -25,8 +25,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testProvideInsertionOnEmptyXMLFile() throws Exception {
         FileType type = FileType.XML;
         String contents = "";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
@@ -35,8 +36,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testProvideInsertionOnEmptyJavaFile() throws Exception {
         FileType type = FileType.Java;
         String contents = "";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
@@ -45,8 +47,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testProvideInsertionOnEmptyYAMLFile() throws Exception {
         FileType type = FileType.YAML;
         String contents = "";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
@@ -55,8 +58,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testInsertionOnLineWithSpacesOrTabs() throws Exception {
         FileType type = FileType.Java;
         String contents = "\t   \t \t";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertNoCompletionsAvailable(completionItems);
     }
@@ -65,8 +69,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testNoInsertionOnLineWithContents() throws Exception {
         FileType type = FileType.Java;
         String contents = "//example";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertNoCompletionsAvailable(completionItems);
     }
@@ -77,8 +82,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testProvideInsertionOnCommentedXMLFile() throws Exception {
         FileType type = FileType.XML;
         String contents = "<!-- One comment -->\n";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
@@ -87,8 +93,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testProvideInsertionOnMultipleCommentsXMLFile() throws Exception {
         FileType type = FileType.XML;
         String contents = "<!-- One comment --><!-- Moar comments -->\n";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
@@ -97,8 +104,9 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testProvideInsertionOnMultipleCommentsOnMultipleLinesXMLFile() throws Exception {
         FileType type = FileType.XML;
         String contents = "<!-- One comment -->\n \n <!-- Moar comments -->\n";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
@@ -106,7 +114,7 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     @Test
     void testDontProvideInsertionIfExtraTextXML() throws Exception {
         FileType type = FileType.XML;
-        String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>";
+        String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>\n";
 
         List<CompletionItem> completionItems = getCompletionsFor(type, contents);
 
@@ -118,45 +126,43 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     void testProvideInsertionOnCommentedYAMLFile() throws Exception {
         FileType type = FileType.YAML;
         String contents = "# Example\n";
+        Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
 
-//    @Test
-//    void testProvideInsertionOnMultipleCommentsXMLFile() throws Exception {
-//        FileType type = FileType.XML;
-//        String contents = "<!-- One comment --><!-- Moar comments -->\n";
-//
-//        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
-//
-//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-//    }
-//
-//    @Test
-//    void testProvideInsertionOnMultipleCommentsOnMultipleLinesXMLFile() throws Exception {
-//        FileType type = FileType.XML;
-//        String contents = "<!-- One comment -->\n \n <!-- Moar comments -->\n";
-//
-//        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
-//
-//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-//    }
-//
-//    @Test
-//    void testDontProvideInsertionIfExtraTextYAML() throws Exception {
-//        FileType type = FileType.XML;
-//        String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>";
-//
-//        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
-//
-//        assertNoCompletionsAvailable(completionItems);
-//    }
+    @Test
+    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
+        FileType type = FileType.XML;
+        String contents = "# Example\n \n #Example2 ####\n ";
+        Position position = beginningOfLastLine(contents);
 
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
+
+    @Test
+    void testDontProvideInsertionIfExtraTextYAML() throws Exception {
+        FileType type = FileType.XML;
+        String contents = "# Example\nexample:\n";
+        Position position = beginningOfLastLine(contents);
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
 
 
     /** UTILS **/
+
+    private Position beginningOfLastLine(String text) {
+        int lastLine = (int)text.chars().filter(ch -> ch == '\n').count();
+
+        return new Position(lastLine, 0);
+    }
 
     private void assertNoCompletionsAvailable(List<CompletionItem> completionItems) {
         assertThat(completionItems).hasSize(0);
@@ -165,15 +171,6 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     private void assertCompletionItemsHasExpectedCompletionForType(FileType type, List<CompletionItem> completionItems) {
         assertThat(completionItems).hasSize(1);
         checkInsertionCompletionAvailableForType(completionItems, type);
-    }
-
-    //Why no default args
-    List<CompletionItem> getCompletionsFor(FileType type, String contents) throws Exception{
-
-        final Function<String,Integer> getLastLine = text -> (int)text.chars().filter(ch -> ch == '\n').count();
-
-        // By default it will put cursor at last position
-        return getCompletionsFor(type, contents, new Position(getLastLine.apply(contents), 0));
     }
 
     List<CompletionItem>  getCompletionsFor(FileType type, String contents, Position position) throws Exception {

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -6,6 +6,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -18,303 +19,317 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest {
 
-    /** EMPTY FILE TESTS **/
-    @Test
-    void testProvideInsertionOnEmptyXMLFile() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "";
-        Position position = beginningOfLastLine(contents);
+    @Nested
+    class EmptyFileTest {
+        @Test
+        void testProvideInsertionOnEmptyXMLFile() throws Exception {
+            FileType type = FileType.XML;
+            String contents = "";
+            Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+        }
+
+        @Test
+        void testProvideInsertionOnEmptyJavaFile() throws Exception {
+            FileType type = FileType.Java;
+            String contents = "";
+            Position position = beginningOfLastLine(contents);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+        }
+
+        @Test
+        void testProvideInsertionOnEmptyYAMLFile() throws Exception {
+            FileType type = FileType.YAML;
+            String contents = "";
+            Position position = beginningOfLastLine(contents);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+        }
+
+        @Test
+        void testProvideInsertionOnEmptyYMLFile() throws Exception {
+            String extension = ".camelk.yml";
+            String contents = "";
+            Position position = beginningOfLastLine(contents);
+
+            CamelLanguageServer camelLanguageServer = initializeLanguageServer(contents, extension);
+            CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);
+            List<CompletionItem> completionItems =  completions.get().getLeft();
+
+            assertThat(completionItems).hasSize(1);
+            assertThat(completionItems).contains(FileType.YAML.completion);
+        }
+
+        @Test
+        void testInsertionOnLineWithSpacesOrTabs() throws Exception {
+            FileType type = FileType.Java;
+            String contents = "\t   \t \t";
+            Position position = beginningOfLastLine(contents);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+        }
+
+        @Test
+        void testNoInsertionOnLineWithContents() throws Exception {
+            FileType type = FileType.Java;
+            String contents = "//example";
+            Position position = beginningOfLastLine(contents);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertNoCompletionsAvailable(completionItems);
+        }
     }
 
-    @Test
-    void testProvideInsertionOnEmptyJavaFile() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "";
-        Position position = beginningOfLastLine(contents);
+    @Nested
+    class FileWithCommentsTest {
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+        @Nested
+        class XMLTest {
+            @Test
+            void testProvideInsertionOnCommentedXMLFile() throws Exception {
+                FileType type = FileType.XML;
+                String contents = "<!-- One comment -->\n";
+                Position position = beginningOfLastLine(contents);
 
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testProvideInsertionOnMultipleCommentsXMLFile() throws Exception {
+                FileType type = FileType.XML;
+                String contents = "<!-- One comment --><!-- Moar comments -->\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testProvideInsertionOnMultipleCommentsOnMultipleLinesXMLFile() throws Exception {
+                FileType type = FileType.XML;
+                String contents = "<!-- One comment -->\n \n <!-- Moar comments -->\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testDontProvideInsertionIfExtraTextXML() throws Exception {
+                FileType type = FileType.XML;
+                String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertNoCompletionsAvailable(completionItems);
+            }
+        }
+
+        @Nested
+        class YAMLTest {
+            @Test
+            void testProvideInsertionOnCommentedYAMLFile() throws Exception {
+                FileType type = FileType.YAML;
+                String contents = "# Example\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
+                FileType type = FileType.YAML;
+                String contents = "# Example\n \n #Example2 ####\n ";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testDontProvideInsertionIfExtraTextYAML() throws Exception {
+                FileType type = FileType.YAML;
+                String contents = "# Example\nexample:\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertNoCompletionsAvailable(completionItems);
+            }
+        }
+
+        @Nested
+        class JavaTest {
+            @Test
+            void testProvideInsertionOnLineCommentedJavaFile() throws Exception {
+                FileType type = FileType.Java;
+                String contents = "// Example\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testProvideInsertionOnMultipleLineCommentedJavaFile() throws Exception {
+                FileType type = FileType.Java;
+                String contents = "// Example\n \n //Example //Example \n //EEExample \n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testProvideInsertionOnBlockCommentedJavaFile() throws Exception {
+                FileType type = FileType.Java;
+                String contents = "/* Example */\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testProvideInsertionOnMultipleBlockCommentedJavaFile() throws Exception {
+                FileType type = FileType.Java;
+                String contents = "/* Example\n \n Example */ /*Example \n EEExample */ \n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testProvideInsertionOnMixCommentedJavaFile() throws Exception {
+                FileType type = FileType.Java;
+                String contents = "/* Example\n \n Example */ /*Example \n //EEExample */ \n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            }
+
+            @Test
+            void testDontProvideInsertionIfExtraTextJava() throws Exception {
+                FileType type = FileType.Java;
+                String contents = "// Example\npublic class CamelExample {\n";
+                Position position = beginningOfLastLine(contents);
+
+                List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+                assertNoCompletionsAvailable(completionItems);
+            }
+        }
     }
 
-    @Test
-    void testProvideInsertionOnEmptyYAMLFile() throws Exception {
-        FileType type = FileType.YAML;
-        String contents = "";
-        Position position = beginningOfLastLine(contents);
+    @Nested
+    class ModelineAlreadyPresentTest {
+        @Test
+        void testDontProvideInsertionOnXMLFileWithModeline() throws Exception {
+            FileType type = FileType.XML;
+            String contents = "<!-- camel-k: -->\n";
+            Position position = beginningOfLastLine(contents);
 
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
 
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+            assertNoCompletionsAvailable(completionItems);
+        }
+
+        @Test
+        void testDontProvideInsertionOnXMLFileWithModelineAfterCursorPosition() throws Exception {
+            FileType type = FileType.XML;
+            String contents = "\n<!-- camel-k: -->\n";
+            Position position = new Position(0,0);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertNoCompletionsAvailable(completionItems);
+        }
+
+        @Test
+        void testDontProvideInsertionOnYAMLFileWithModeline() throws Exception {
+            FileType type = FileType.YAML;
+            String contents = "# camel-k:\n";
+            Position position = beginningOfLastLine(contents);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertNoCompletionsAvailable(completionItems);
+        }
+
+        @Test
+        void testDontProvideInsertionOnYAMLFileWithModelineAfterCursorPosition() throws Exception {
+            FileType type = FileType.YAML;
+            String contents = "\n# camel-k:\n";
+            Position position = new Position(0,0);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertNoCompletionsAvailable(completionItems);
+        }
+
+        @Test
+        void testDontProvideInsertionOnJavaFileWithModeline() throws Exception {
+            FileType type = FileType.Java;
+            String contents = "// camel-k:\n";
+            Position position = beginningOfLastLine(contents);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertNoCompletionsAvailable(completionItems);
+        }
+
+        @Test
+        void testDontProvideInsertionOnJavaFileWithModelineAfterCursorPosition() throws Exception {
+            FileType type = FileType.Java;
+            String contents = "\n// camel-k:\n";
+            Position position = new Position(0,0);
+
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertNoCompletionsAvailable(completionItems);
+        }
     }
 
-    @Test
-    void testProvideInsertionOnEmptyYMLFile() throws Exception {
-        String extension = ".camelk.yml";
-        String contents = "";
-        Position position = beginningOfLastLine(contents);
 
-        CamelLanguageServer camelLanguageServer = initializeLanguageServer(contents, extension);
-        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);
-        List<CompletionItem> completionItems =  completions.get().getLeft();
+    @Nested
+    class MidFilePositionTest{
+        @Test
+        void testProvideInsertionIfCursorBetweenCommentsAndStartOfCode() throws Exception {
+            FileType type = FileType.Java;
+            String contents = "// Example\n\npublic class CamelExample {\n";
+            Position position = new Position(1,0);
 
-        assertThat(completionItems).hasSize(1);
-        assertThat(completionItems).contains(FileType.YAML.completion);
+            List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
+
+            assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+        }
     }
-
-    @Test
-    void testInsertionOnLineWithSpacesOrTabs() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "\t   \t \t";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-    
-    @Test
-    void testNoInsertionOnLineWithContents() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "//example";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    /** FILE WITH COMMENTS ABOVE LINE TESTS **/
-    /** XML **/
-    @Test
-    void testProvideInsertionOnCommentedXMLFile() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "<!-- One comment -->\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testProvideInsertionOnMultipleCommentsXMLFile() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "<!-- One comment --><!-- Moar comments -->\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testProvideInsertionOnMultipleCommentsOnMultipleLinesXMLFile() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "<!-- One comment -->\n \n <!-- Moar comments -->\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionIfExtraTextXML() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    /** YAML **/
-    @Test
-    void testProvideInsertionOnCommentedYAMLFile() throws Exception {
-        FileType type = FileType.YAML;
-        String contents = "# Example\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testProvideInsertionOnMultipleCommentsOnMultipleLinesYAMLFile() throws Exception {
-        FileType type = FileType.YAML;
-        String contents = "# Example\n \n #Example2 ####\n ";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionIfExtraTextYAML() throws Exception {
-        FileType type = FileType.YAML;
-        String contents = "# Example\nexample:\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    /** JAVA **/
-    @Test
-    void testProvideInsertionOnLineCommentedJavaFile() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "// Example\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testProvideInsertionOnMultipleLineCommentedJavaFile() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "// Example\n \n //Example //Example \n //EEExample \n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testProvideInsertionOnBlockCommentedJavaFile() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "/* Example */\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testProvideInsertionOnMultipleBlockCommentedJavaFile() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "/* Example\n \n Example */ /*Example \n EEExample */ \n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testProvideInsertionOnMixCommentedJavaFile() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "/* Example\n \n Example */ /*Example \n //EEExample */ \n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionIfExtraTextJava() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "// Example\npublic class CamelExample {\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    /** FILE WITH MODELINE ALREADY INSERTED **/
-    @Test
-    void testDontProvideInsertionOnXMLFileWithModeline() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "<!-- camel-k: -->\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionOnXMLFileWithModelineAfterCursorPosition() throws Exception {
-        FileType type = FileType.XML;
-        String contents = "\n<!-- camel-k: -->\n";
-        Position position = new Position(0,0);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionOnYAMLFileWithModeline() throws Exception {
-        FileType type = FileType.YAML;
-        String contents = "# camel-k:\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionOnYAMLFileWithModelineAfterCursorPosition() throws Exception {
-        FileType type = FileType.YAML;
-        String contents = "\n# camel-k:\n";
-        Position position = new Position(0,0);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionOnJavaFileWithModeline() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "// camel-k:\n";
-        Position position = beginningOfLastLine(contents);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    @Test
-    void testDontProvideInsertionOnJavaFileWithModelineAfterCursorPosition() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "\n// camel-k:\n";
-        Position position = new Position(0,0);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertNoCompletionsAvailable(completionItems);
-    }
-
-    /** MID FILE **/
-    @Test
-    void testProvideInsertionIfCursorBetweenCommentsAndStartOfCode() throws Exception {
-        FileType type = FileType.Java;
-        String contents = "// Example\n\npublic class CamelExample {\n";
-        Position position = new Position(1,0);
-
-        List<CompletionItem> completionItems = getCompletionsFor(type, contents, position);
-
-        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
-    }
-
-    /** UTILS **/
 
     private Position beginningOfLastLine(String text) {
         int lastLine = (int)text.chars().filter(ch -> ch == '\n').count();

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -104,7 +104,7 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     }
 
     @Test
-    void testDontProvideInsertionIfExtraText() throws Exception {
+    void testDontProvideInsertionIfExtraTextXML() throws Exception {
         FileType type = FileType.XML;
         String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>";
 
@@ -113,7 +113,46 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
         assertNoCompletionsAvailable(completionItems);
     }
 
+    /* YAML */
+    @Test
+    void testProvideInsertionOnCommentedYAMLFile() throws Exception {
+        FileType type = FileType.YAML;
+        String contents = "# Example\n";
 
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+
+        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+    }
+
+//    @Test
+//    void testProvideInsertionOnMultipleCommentsXMLFile() throws Exception {
+//        FileType type = FileType.XML;
+//        String contents = "<!-- One comment --><!-- Moar comments -->\n";
+//
+//        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+//
+//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+//    }
+//
+//    @Test
+//    void testProvideInsertionOnMultipleCommentsOnMultipleLinesXMLFile() throws Exception {
+//        FileType type = FileType.XML;
+//        String contents = "<!-- One comment -->\n \n <!-- Moar comments -->\n";
+//
+//        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+//
+//        assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
+//    }
+//
+//    @Test
+//    void testDontProvideInsertionIfExtraTextYAML() throws Exception {
+//        FileType type = FileType.XML;
+//        String contents = "<!-- One comment --><!-- Moar comments -->\n<tag></tag>";
+//
+//        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+//
+//        assertNoCompletionsAvailable(completionItems);
+//    }
 
 
 

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -50,6 +50,17 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
 
         assertCompletionItemsHasExpectedCompletionForType(type, completionItems);
     }
+
+    @Test
+    void testInsertionOnLineWithSpacesOrTabs() throws Exception {
+        FileType type = FileType.Java;
+        String contents = "\t   \t \t";
+
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
+
+        assertNoCompletionsAvailable(completionItems);
+    }
+    
     @Test
     void testNoInsertionOnLineWithContents() throws Exception {
         FileType type = FileType.Java;

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineInsertionTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.annotation.processing.Completion;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -21,13 +22,24 @@ public class CamelKModelineInsertionTest extends AbstractCamelLanguageServerTest
     @Test
     void testProvideInsertionOnEmptyXMLFile() throws Exception {
         FileType type = FileType.XML;
-        CamelLanguageServer camelLanguageServer = initializeLanguageServer("", type.extension);
+        String contents = "";
 
-        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, new Position(0, 0));
+        List<CompletionItem> completionItems = getCompletionsFor(type, contents);
 
-        List<CompletionItem> completionItems = completions.get().getLeft();
         assertThat(completionItems).hasSize(1);
         checkInsertionCompletionAvailableForType(completionItems, type);
+    }
+
+    //Why no default args
+    List<CompletionItem> getCompletionsFor(FileType type, String contents) throws Exception{
+        return getCompletionsFor(type, contents, new Position(0, 0));
+    }
+    List<CompletionItem>  getCompletionsFor(FileType type, String contents, Position position) throws Exception {
+        CamelLanguageServer camelLanguageServer = initializeLanguageServer(contents, type.extension);
+
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, position);
+
+        return completions.get().getLeft();
     }
 
     private void checkInsertionCompletionAvailableForType(List<CompletionItem> completionItems, FileType toAssert) {


### PR DESCRIPTION
# Pull Request informations

## Rebase & Merge default requirements

1. Green build for main branch
2. Wait 24 hours after PR creation
3. Green job for PR
4. Approved PR

## PR labels default process

- READY_FOR_REVIEW  &rightarrow;  REVIEW_DONE  &rightarrow;  READY_FOR_MERGE

## Tests

- [x] Are there **Unit tests**?

## PR workflow progress

1. [x] Tagged with relevant **PR labels**
2. [x] Green **job for PR**
3. [x] PR was created more than **24 hours ago** or **All committers approved** it
4. [x] Green **main** branch build

-----

Adds support to include camelk modeline comment when available.

It works for any
* Java file
* Any XML file ending in `.camelk.xml`
* Any YAML file ending in `camelk.yaml` or `camelk.yml`

Completion is proposed in any empty line that is preceded by blank (spaces, new lines, tabs) or the specific file type comments. 

Completion proposed depends on file-type.

As improvement points in the future, 
* Allow it if the yaml file jas has the # yaml-language-server: $schema=<urlToCamelKyaml> 
* Autocomplete from start of modeline label. For example, autocomplete on `// cam` on java files and have it fill the rest correctly.

Gifs showing the behaviour in every file type

*JAVA*

![ModelineInsertionJava](https://user-images.githubusercontent.com/17336236/176556381-0321a9ca-cdc3-4795-9522-4146cc099d30.gif)

*XML*
![ModelineInsertionXML](https://user-images.githubusercontent.com/17336236/176556448-de7ae3d2-9933-4f71-9615-6b9776b7f2e6.gif)

*YAML*
The gif is slightly outdated. It now correctly has the colon at the end of the completion
![ModelineInsertionYAML](https://user-images.githubusercontent.com/17336236/176556482-bbc83246-9e2f-4491-bf77-87aba4d250bb.gif)



 