### PR TITLE
FUSETOOLS2-1677 - improve support for productized catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,13 @@ It is possible to specify a specific version of the Camel catalog. This can be p
 }
 ```
 
-To use Red Hat Integration productized version, the Red Hat Maven GA repository needs to be configured on the host running the Camel Language Server. To configure it, follow these steps:
+Please note that the first time a version is used, it can take several seconds/minutes to have it available depending on the time to download the dependencies in the background.
+
+When using a Red Hat productized version which contains `redhat` in the version, the Maven Red Hat repository is automatically added.
+
+To use other versions not available on Maven Central, additional repositories need to be configured on the host running the Camel Language Server. To configure it, follow these steps:
 * Copy the [default grape config file corresponding to the version used by Camel](https://github.com/apache/groovy/blob/GROOVY_2_5_8/src/resources/groovy/grape/defaultGrapeConfig.xml) into _~/.groovy_ folder and call it _grapeConfig.xml_
-* Add `<ibiblio name="fuse" m2compatible="true" root="https://maven.repository.redhat.com/ga/"/>` inside the chain node
+* Add `<ibiblio name="fuse" m2compatible="true" root="<https://<urlofYourMavenRepository>"/>` inside the chain node
 
 For more information, check the [Grape official documentation](http://docs.groovy-lang.org/latest/html/documentation/grape.html#Grape-CustomizeIvysettings).
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -142,7 +142,12 @@ public class CamelTextDocumentService implements TextDocumentService {
 
 	private void updateCatalogVersion(String camelVersion, DefaultCamelCatalog catalog) {
 		if (camelVersion != null && !camelVersion.isEmpty()) {
-			catalog.setVersionManager(new MavenVersionManager());
+			MavenVersionManager versionManager = new MavenVersionManager();
+			if (camelVersion.contains("redhat")) {
+				versionManager.addMavenRepository("central", "https://repo1.maven.org/maven2/");
+				versionManager.addMavenRepository("maven.redhat.ga", "https://maven.repository.redhat.com/ga/");
+			}
+			catalog.setVersionManager(versionManager);
 			if (!catalog.loadVersion(camelVersion)) {
 				LOGGER.warn("Cannot load Camel catalog with version {}", camelVersion);
 			}

--- a/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/AbstractCamelLanguageServerTest.java
@@ -103,6 +103,14 @@ public abstract class AbstractCamelLanguageServerTest {
 		return expectedAhcCompletioncompletionItem;
 	}
 	
+	protected CompletionItem createExpectedAhcCompletionItemForVersion3_11_5(int lineStart, int characterStart, int lineEnd, int characterEnd) {
+		CompletionItem expectedAhcCompletioncompletionItem = new CompletionItem("ahc:httpUri");
+		expectedAhcCompletioncompletionItem.setDocumentation(AHC_DOCUMENTATION);
+		expectedAhcCompletioncompletionItem.setDeprecated(false);
+		expectedAhcCompletioncompletionItem.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(lineStart, characterStart), new Position(lineEnd, characterEnd)), "ahc:httpUri")));
+		return expectedAhcCompletioncompletionItem;
+	}
+	
 	protected CompletionItem createExpectedAhcCompletionItemForVersionPriorTo33(int lineStart, int characterStart, int lineEnd, int characterEnd) {
 		CompletionItem expectedAhcCompletioncompletionItem = createExpectedAhcCompletionItem(lineStart, characterStart, lineEnd, characterEnd);
 		expectedAhcCompletioncompletionItem.setDocumentation(AHC_DOCUMENTATION_BEFORE_3_3);

--- a/src/test/java/com/github/cameltooling/lsp/internal/CamelCatalogVersionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/CamelCatalogVersionTest.java
@@ -84,6 +84,28 @@ class CamelCatalogVersionTest extends AbstractCamelLanguageServerTest {
 		basicCompletionCheck();
 	}
 	
+	@Test
+	void testProductizedCatalog2x() throws Exception {
+		camelCatalogVersion = "2.23.2.fuse-7_11_0-00037-redhat-00001";
+		
+		CamelLanguageServer camelLanguageServer = basicCompletionCheckBefore3_3();
+		
+		checkLoadedCamelCatalogVersion(camelLanguageServer, camelCatalogVersion);
+	}
+	
+	@Test
+	void testProductizedCatalog3x() throws Exception {
+		camelCatalogVersion = "3.11.5.fuse-800012-redhat-00004";
+		
+		CamelLanguageServer camelLanguageServer = basicCompletionCheckFor3_11_5();
+		
+		checkLoadedCamelCatalogVersion(camelLanguageServer, camelCatalogVersion);
+	}
+
+	private CamelLanguageServer basicCompletionCheckFor3_11_5() throws URISyntaxException, InterruptedException, ExecutionException {
+		return basicCompletionCheck(createExpectedAhcCompletionItemForVersion3_11_5(0, 11, 0, 11));
+	}
+
 	private CamelLanguageServer basicCompletionCheck() throws URISyntaxException, InterruptedException, ExecutionException {
 		return basicCompletionCheck(createExpectedAhcCompletionItem(0, 11, 0, 11));
 	}


### PR DESCRIPTION
Only the classic catalog is covered. It allows to cover the Camel
Quarkus use case. It will cover the SpringBoot based use case when it
will be productized.

