### PR TITLE
FUSETOOLS2-1815 - Support CRD Yaml

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
@@ -25,6 +25,7 @@ import org.xml.sax.SAXException;
 
 public class ParserFileHelperFactory {
 	
+	private static final String KUBERNETES_CRD_API_VERSION_CAMEL = "apiVersion: camel.apache.org/";
 	private static final String CAMELK_XML_FILENAME_SUFFIX = "camelk.xml";
 	private static final String CAMELK_GROOVY_FILENAME_SUFFIX = ".camelk.groovy";
 	private static final String CAMELK_KOTLIN_FILENAME_SUFFIX = ".camelk.kts";
@@ -145,15 +146,25 @@ public class ParserFileHelperFactory {
 		//improve this method to provide better heuristic to detect if it is a Camel file or not
 		return uri.endsWith(CAMELK_YAML_FILENAME_SUFFIX)
 				|| isYamlFileWithCamelKShebang(textDocumentItem, uri)
-				|| isYamlFileWithCamelKModelineLike(textDocumentItem, uri);
+				|| isYamlFileWithCamelKModelineLike(textDocumentItem, uri)
+				|| isYamlFileOfCRDType(textDocumentItem, uri);
+	}
+
+	private boolean isYamlFileOfCRDType(TextDocumentItem textDocumentItem, String uri) {
+		return hasYamlExtension(uri)
+				&& textDocumentItem.getText().startsWith(KUBERNETES_CRD_API_VERSION_CAMEL);
+	}
+
+	private boolean hasYamlExtension(String uri) {
+		return uri.endsWith(".yaml") || uri.endsWith(".yml");
 	}
 
 	private boolean isYamlFileWithCamelKModelineLike(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".yaml") && textDocumentItem.getText().startsWith(CamelKModelineParser.MODELINE_LIKE_CAMEL_K_YAML);
+		return hasYamlExtension(uri) && textDocumentItem.getText().startsWith(CamelKModelineParser.MODELINE_LIKE_CAMEL_K_YAML);
 	}
 
 	protected boolean isYamlFileWithCamelKShebang(TextDocumentItem textDocumentItem, String uri) {
-		return uri.endsWith(".yaml") && textDocumentItem.getText().startsWith(SHEBANG_CAMEL_K);
+		return hasYamlExtension(uri) && textDocumentItem.getText().startsWith(SHEBANG_CAMEL_K);
 	}
 
 	private boolean isPotentiallyCamelJavaDSL(TextDocumentItem textDocumentItem, String uri) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
@@ -358,6 +358,17 @@ class CamelLanguageServerTest extends AbstractCamelLanguageServerTest {
 				assertThat(completions.get().getLeft()).contains(createExpectedAhcCompletionItem(9, 13, 9, 23));
 			}
 		}
+		
+		@Test
+		void testProvideCompletionForYamlCRD() throws Exception {
+			File f = new File("src/test/resources/workspace/crd-like.yaml");
+			assertThat(f).exists();
+			try (FileInputStream fis = new FileInputStream(f)) {
+				CamelLanguageServer cls = initializeLanguageServer(fis, ".yaml");
+				CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(cls, new Position(8, 15));
+				assertThat(completions.get().getLeft()).contains(createExpectedAhcCompletionItem(8, 15, 8, 25));
+			}
+		}
 	}
 
 	@Test

--- a/src/test/resources/workspace/crd-like.yaml
+++ b/src/test/resources/workspace/crd-like.yaml
@@ -1,0 +1,25 @@
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: testflow
+spec:
+  flows:
+    - route:
+        from:
+          uri: timer:tick
+          steps:
+            - setBody:
+                expression:
+                  constant:
+                    expression: Sample message
+            - log:
+                message: ${body}
+            - pollEnrich:
+                expression:
+                  simple:
+                    expression: file:file_src?noop=true
+            - log:
+                message: 'polled: ${body}'
+          parameters:
+            delay: '1000'
+            period: '3000'


### PR DESCRIPTION
Note: The naming of some classes are misleaded, it is no more only for Camel K, reported https://issues.redhat.com/browse/FUSETOOLS2-1816

![image](https://user-images.githubusercontent.com/1105127/191564545-3508d816-4c9d-4e0b-8a6c-e668e986dacd.png)


