### PR TITLE
FUSETOOLS2-1817 - Support Plain Camel yaml

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
@@ -30,6 +30,7 @@ public class ParserFileHelperFactory {
 	private static final String CAMELK_GROOVY_FILENAME_SUFFIX = ".camelk.groovy";
 	private static final String CAMELK_KOTLIN_FILENAME_SUFFIX = ".camelk.kts";
 	private static final String CAMELK_YAML_FILENAME_SUFFIX = ".camelk.yaml";
+	private static final String PLAIN_CAMEL_YAML_FILENAME_SUFFIX = ".camel.yaml";
 	private static final String CAMELK_JS_FILENAME_SUFFIX = ".camelk.js";
 	private static final String SHEBANG_CAMEL_K = "#!/usr/bin/env camel-k";
 
@@ -145,6 +146,7 @@ public class ParserFileHelperFactory {
 	private boolean isCamelKYamlDSL(TextDocumentItem textDocumentItem, String uri) {
 		//improve this method to provide better heuristic to detect if it is a Camel file or not
 		return uri.endsWith(CAMELK_YAML_FILENAME_SUFFIX)
+				|| uri.endsWith(PLAIN_CAMEL_YAML_FILENAME_SUFFIX)
 				|| isYamlFileWithCamelKShebang(textDocumentItem, uri)
 				|| isYamlFileWithCamelKModelineLike(textDocumentItem, uri)
 				|| isYamlFileOfCRDType(textDocumentItem, uri);

--- a/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/CamelLanguageServerTest.java
@@ -365,8 +365,21 @@ class CamelLanguageServerTest extends AbstractCamelLanguageServerTest {
 			assertThat(f).exists();
 			try (FileInputStream fis = new FileInputStream(f)) {
 				CamelLanguageServer cls = initializeLanguageServer(fis, ".yaml");
-				CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(cls, new Position(8, 15));
+				Position positionAtBeginningOfFromValue = new Position(8, 15);
+				CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(cls, positionAtBeginningOfFromValue);
 				assertThat(completions.get().getLeft()).contains(createExpectedAhcCompletionItem(8, 15, 8, 25));
+			}
+		}
+		
+		@Test
+		void testProvideCompletionForPlainYaml() throws Exception {
+			File f = new File("src/test/resources/workspace/plain.camel.yaml");
+			assertThat(f).exists();
+			try (FileInputStream fis = new FileInputStream(f)) {
+				CamelLanguageServer cls = initializeLanguageServer(fis, ".camel.yaml");
+				Position positionAtBeginningOfFromValue = new Position(1, 10);
+				CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(cls, positionAtBeginningOfFromValue);
+				assertThat(completions.get().getLeft()).contains(createExpectedAhcCompletionItem(1, 10, 1, 22));
 			}
 		}
 	}

--- a/src/test/resources/workspace/plain.camel.yaml
+++ b/src/test/resources/workspace/plain.camel.yaml
@@ -1,0 +1,11 @@
+- from:
+    uri: "direct:start"
+    steps:
+      - filter:
+          expression:
+            simple: "${in.header.continue} == true"
+          steps:
+            - to:
+                uri: "log:filtered"
+      - to:
+          uri: "log:original"


### PR DESCRIPTION
it requires the file to be named *.camel.yaml, it follows same pattern than for yaml schema association.

![image](https://user-images.githubusercontent.com/1105127/192743576-2592d570-1226-49a5-b2ee-015e3bf62726.png)
