### PR TITLE
FUSETOOLS2-1816 - rename CamelKYaml related things which can now

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelYamlDSLParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelYamlDSLParser.java
@@ -31,7 +31,7 @@ import com.github.cameltooling.lsp.internal.instancemodel.YamlDSLModelHelper;
 /**
  * @author Lars Heinemann
  */
-public class CamelKYamlDSLParser extends ParserFileHelper {
+public class CamelYamlDSLParser extends ParserFileHelper {
 	
 	public static final String URI_KEY = "uri";
 	public static final String REST_KEY = "rest";

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperFactory.java
@@ -49,8 +49,8 @@ public class ParserFileHelperFactory {
 			if (camelKGroovyDSLParser.getCorrespondingMethodName(textDocumentItem, line) != null) {
 				return camelKGroovyDSLParser;
 			}
-		} else if(isCamelKYamlDSL(textDocumentItem, uri)) {
-			CamelKYamlDSLParser camelKYamlDSLParser = new CamelKYamlDSLParser();
+		} else if(isCamelYamlDSL(textDocumentItem, uri)) {
+			CamelYamlDSLParser camelKYamlDSLParser = new CamelYamlDSLParser();
 			if (camelKYamlDSLParser.getCorrespondingType(textDocumentItem, line) != null) {
 				return camelKYamlDSLParser;
 			}
@@ -82,7 +82,7 @@ public class ParserFileHelperFactory {
 		return isHighProbabilityCamelJavaDSL(textDocumentItem, uri)
 				|| isCamelXMLDSL(textDocumentItem, uri)
 				|| isCamelKJSDSL(textDocumentItem, uri)
-				|| isCamelKYamlDSL(textDocumentItem, uri)
+				|| isCamelYamlDSL(textDocumentItem, uri)
 				|| isCamelKKotlinDSL(textDocumentItem, uri)
 				|| isCamelKGroovyDSL(textDocumentItem, uri)
 				|| isCamelKafkaConnectDSL(textDocumentItem, uri);
@@ -143,7 +143,7 @@ public class ParserFileHelperFactory {
 		return uri.endsWith(".groovy") && textDocumentItem.getText().startsWith(SHEBANG_CAMEL_K);
 	}
 
-	private boolean isCamelKYamlDSL(TextDocumentItem textDocumentItem, String uri) {
+	private boolean isCamelYamlDSL(TextDocumentItem textDocumentItem, String uri) {
 		//improve this method to provide better heuristic to detect if it is a Camel file or not
 		return uri.endsWith(CAMELK_YAML_FILENAME_SUFFIX)
 				|| uri.endsWith(PLAIN_CAMEL_YAML_FILENAME_SUFFIX)

--- a/src/test/java/com/github/cameltooling/lsp/internal/parser/CamelKYamlDSLParserTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/parser/CamelKYamlDSLParserTest.java
@@ -25,27 +25,27 @@ class CamelKYamlDSLParserTest {
 
 	@Test
 	void testRepairEscapeCharacterWithNullLine() throws Exception {
-		assertThat(new CamelKYamlDSLParser().repairLostEscapeChars("\"", null)).isEmpty();
+		assertThat(new CamelYamlDSLParser().repairLostEscapeChars("\"", null)).isEmpty();
 	}
 	
 	@Test
 	void testRepairEscapeCharacterWithNoStringEncloser() throws Exception {
-		assertThat(new CamelKYamlDSLParser().repairLostEscapeChars(null, "myLine")).isEqualTo("myLine");
+		assertThat(new CamelYamlDSLParser().repairLostEscapeChars(null, "myLine")).isEqualTo("myLine");
 	}
 	
 	@Test
 	void testRepairEscapeCharacterWithQuote() throws Exception {
-		assertThat(new CamelKYamlDSLParser().repairLostEscapeChars("'", "a value with ' quote inside")).isEqualTo("a value with '' quote inside");
+		assertThat(new CamelYamlDSLParser().repairLostEscapeChars("'", "a value with ' quote inside")).isEqualTo("a value with '' quote inside");
 	}
 	
 	@Test
 	void testRepairEscapeCharacterWithDoubleQuote() throws Exception {
-		assertThat(new CamelKYamlDSLParser().repairLostEscapeChars("\"", "a value with double-quote \" inside")).isEqualTo("a value with double-quote \\\" inside");
+		assertThat(new CamelYamlDSLParser().repairLostEscapeChars("\"", "a value with double-quote \" inside")).isEqualTo("a value with double-quote \\\" inside");
 	}
 	
 	@Test
 	@Disabled("see https://github.com/camel-tooling/camel-language-server/issues/301")
 	void testRepairEscapeCharacterWithDoubleQuoteAndSlash() throws Exception {
-		assertThat(new CamelKYamlDSLParser().repairLostEscapeChars("\"", "a value with backslash \\ inside")).isEqualTo("a value with double-quote \\\\ inside");
+		assertThat(new CamelYamlDSLParser().repairLostEscapeChars("\"", "a value with backslash \\ inside")).isEqualTo("a value with double-quote \\\\ inside");
 	}
 }


### PR DESCRIPTION
supports plain Yaml

for other languages Kotlin, JS and groovy:
- created https://issues.redhat.com/browse/FUSETOOLS2-1825 for JS as it seems simple
- for the 2 others we cannot use the same trick of filename pattern and given that it is not part of languages priorities, I think we can live with it for now

