### PR TITLE
FUSETOOLS2-1870 - avoid flakiness by checking timeout more precisely

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/KafkaTopicCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/KafkaTopicCompletionTest.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
@@ -63,7 +65,7 @@ class KafkaTopicCompletionTest extends AbstractCamelLanguageServerTest {
 	}
 
 	@Test
-	@Timeout(3)
+	@Timeout(30)
 	void testInvalidConnectionUrl() throws Exception {
 		String connectionURL = "localhost:9091";
 		System.setProperty(KafkaTopicCompletionProvider.CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL, connectionURL);
@@ -139,9 +141,9 @@ class KafkaTopicCompletionTest extends AbstractCamelLanguageServerTest {
 		System.setProperty(KafkaTopicCompletionProvider.CAMEL_LANGUAGE_SERVER_KAFKA_CONNECTION_URL, connectionURL);
 	}
 
-	private List<CompletionItem> retrieveCompletionForKafkaTopicPosition() throws URISyntaxException, InterruptedException, ExecutionException {
+	private List<CompletionItem> retrieveCompletionForKafkaTopicPosition() throws URISyntaxException, InterruptedException, ExecutionException, TimeoutException {
 		CamelLanguageServer languageServer = initLanguageServer();
-		return getCompletionFor(languageServer, new Position(0, 17)).get().getLeft();
+		return getCompletionFor(languageServer, new Position(0, 17)).get(1, TimeUnit.SECONDS).getLeft();
 	}
 
 	private CamelLanguageServer initLanguageServer() throws URISyntaxException, InterruptedException, ExecutionException {


### PR DESCRIPTION
The goal of the test is to ensure that the end-user receive the completion feedback in less than a second. The timeout on the whole test before was impacted by the time to setup the environment for the test. Keeping a timeout at test level so that in case it hangs, it does not hangs for several minutes.

