### PR TITLE
1911 sonar analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,23 +10,6 @@ jobs:
       - store_test_results:
           path: target/surefire-reports
 
-  sonar:
-    docker:
-      - image: cimg/openjdk:11.0
-    steps:
-      - checkout
-      - run: > 
-          mvn verify
-          -P !build-extras
-          -Dtest="*,!RunnerStandardIOTest,!RunnerWebSocketTest"
-          -B
-          sonar:sonar
-          -Dsonar.login=${SONAR_TOKEN}
-          -Dsonar.organization="camel-tooling"
-          -Dsonar.projectKey="camel-lsp-server"
-          -Dsonar.projectName="Camel LSP Server"
-          -Dsonar.host.url=https://sonarcloud.io
-
   deploy:
     docker:
       - image: cimg/openjdk:11.0
@@ -43,14 +26,6 @@ workflows:
   build:
     jobs:
       - jdk11
-      - sonar:
-          requires:
-            - jdk11
-          filters:
-            branches:
-              only:
-                main
-          context: sonarcloud
       - deploy:
           requires:
              - jdk11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: Main branch - Sonar analysis
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: 'temurin'
+        cache: 'maven'
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v3.0.11
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+    - name: Sonar analysis
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: >
+        mvn -B verify
+        -P !build-extras
+        -Dtest="*,!RunnerStandardIOTest,!RunnerWebSocketTest"
+        sonar:sonar
+        -Dsonar.login=${SONAR_TOKEN}
+        -Dsonar.organization="camel-tooling"
+        -Dsonar.projectKey="camel-lsp-server"
+        -Dsonar.projectName="Camel LSP Server"
+        -Dsonar.host.url=https://sonarcloud.io
+        


### PR DESCRIPTION
based on https://github.com/camel-tooling/camel-language-server/pull/876

configure Sonar analysis for Main branch

created a specific workflow instead of reusing Matrixes despite
replaying one configuration of test (ubuntu/JDK11) for the following
reasons:
- not the exact same maven parameters as 2 tests must be deactivated due to a bug in Jacoco coverage (or the way we configure it, or the interaction between JUnit and Jacoco)
- it will allow to gather also the sign and deploy in this config and keep it a bit more readable
- Keep it consistent with camel-debug-adapter for which the choice was made this way


Note:
SONAR_TOKEN added, see https://github.com/camel-tooling/camel-language-server/settings/secrets/actions