### PR TITLE
Deprecate Camel Kafka Connector related classes

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/CamelKafkaConnectorCatalogManager.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/catalog/util/CamelKafkaConnectorCatalogManager.java
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.TextDocumentItem;
 
 import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
 
+@Deprecated
 public class CamelKafkaConnectorCatalogManager {
 	
 	private static final String CAMEL_KAFKA_CONNECTOR_TYPE_SOURCE = "source";

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelKafkaConnectorClassCompletionProcessor.java
@@ -27,6 +27,7 @@ import org.eclipse.lsp4j.CompletionItem;
 import com.github.cameltooling.lsp.internal.catalog.util.CamelKafkaConnectorCatalogManager;
 import com.github.cameltooling.lsp.internal.instancemodel.propertiesfile.CamelPropertyValueInstance;
 
+@Deprecated
 public class CamelKafkaConnectorClassCompletionProcessor {
 
 	private CamelPropertyValueInstance camelPropertyValueInstance;

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelSinkOrSourcePropertyKey.java
@@ -51,6 +51,7 @@ import com.github.cameltooling.lsp.internal.parser.CamelKafkaUtil;
  * it is used to represents "timer.delay"
  * 
  */
+@Deprecated
 public class CamelSinkOrSourcePropertyKey implements ILineRangeDefineable {
 
 	private String optionKey;

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/KafkaConnectTransformerTypePropertyKeyDetector.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/KafkaConnectTransformerTypePropertyKeyDetector.java
@@ -16,6 +16,7 @@
  */
 package com.github.cameltooling.lsp.internal.instancemodel.propertiesfile;
 
+@Deprecated
 public class KafkaConnectTransformerTypePropertyKeyDetector {
 	
 	private static final String TRANSFORMER_TYPE_KEY_PATTERN = "transforms\\.[^\\.]*\\.type";

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaConnectDSLParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelKafkaConnectDSLParser.java
@@ -32,6 +32,7 @@ import com.github.cameltooling.lsp.internal.instancemodel.PropertiesDSLModelHelp
  * @author Aurelien Pupier
  * Restriction on notation for properties file, it must be with '=' and without spaces
  */
+@Deprecated
 public class CamelKafkaConnectDSLParser extends ParserFileHelper {
 	
 	private static final Logger LOGGER = LoggerFactory.getLogger(CamelKafkaConnectDSLParser.class);


### PR DESCRIPTION
there was no reference in readme and there is no changelog so no other places to modify

