### PR TITLE
FUSETOOLS2-2120 - Provide Camel Quarkus debug profile in completion

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -76,6 +76,7 @@ import com.github.cameltooling.lsp.internal.catalog.util.KameletsCatalogManager;
 import com.github.cameltooling.lsp.internal.codeactions.CodeActionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelEndpointCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.CamelPropertiesCompletionProcessor;
+import com.github.cameltooling.lsp.internal.completion.PomCompletionProcessor;
 import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineCompletionprocessor;
 import com.github.cameltooling.lsp.internal.definition.DefinitionProcessor;
 import com.github.cameltooling.lsp.internal.diagnostic.DiagnosticRunner;
@@ -167,6 +168,8 @@ public class CamelTextDocumentService implements TextDocumentService {
 				return new CamelKModelineInsertionProcessor(textDocumentItem).getCompletions().thenApply(Either::forLeft);
 			} else if (new CamelKModelineParser().isOnCamelKModeline(completionParams.getPosition().getLine(), textDocumentItem)){
 				return new CamelKModelineCompletionprocessor(textDocumentItem, getCamelCatalog()).getCompletions(completionParams.getPosition()).thenApply(Either::forLeft);
+			} else if(uri.endsWith("pom.xml")) {
+				return new PomCompletionProcessor().getCompletions().thenApply(Either::forLeft);
 			} else {
 				return new CamelEndpointCompletionProcessor(textDocumentItem, getCamelCatalog(), getKameletsCatalogManager()).getCompletions(completionParams.getPosition(), getSettingsManager()).thenApply(Either::forLeft);
 			}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/PomCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/PomCompletionProcessor.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.CompletionItem;
+
+public class PomCompletionProcessor {
+
+	public CompletableFuture<List<CompletionItem>> getCompletions() {
+		CompletionItem completionQuarkusDebugProfile = new CompletionItem("Camel debug profile for Quarkus");
+		completionQuarkusDebugProfile.setInsertText(
+				  "<profile>\n"
+				+ "    <id>camel.debug</id>\n"
+				+ "    <activation>\n"
+				+ "        <property>\n"
+				+ "            <name>camel.debug</name>\n"
+				+ "            <value>true</value>\n"
+				+ "        </property>\n"
+				+ "    </activation>\n"
+				+ "    <dependencies>\n"
+				+ "        <dependency>\n"
+				+ "            <groupId>org.apache.camel.quarkus</groupId>\n"
+				+ "            <artifactId>camel-quarkus-debug</artifactId>\n"
+				+ "        </dependency>\n"
+				+ "    </dependencies>\n"
+				+ "</profile>");
+		completionQuarkusDebugProfile.setDocumentation(
+				"Adding a profile to enable Camel Debug.\n"
+				+ "Combined with launch configuration and tasks, it allows single-click debug.\n"
+				+ "It requires Camel Quarkus 2.14+");
+		return CompletableFuture.completedFuture(Collections.singletonList(completionQuarkusDebugProfile));
+	}
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/PomCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/PomCompletionTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class PomCompletionTest extends AbstractCamelLanguageServerTest {
+
+	@Test
+	void testQuarkusDebugProfile() throws Exception {
+		CamelLanguageServer languageServer = initializeLanguageServerWithFileName("", "pom.xml");
+		List<CompletionItem> completionItems = getCompletionFor(languageServer, new Position(0, 0), "pom.xml").get().getLeft();
+		assertThat(completionItems).hasSize(1);
+		assertThat(completionItems.get(0).getLabel()).isEqualTo("Camel debug profile for Quarkus");
+		assertThat(completionItems.get(0).getInsertText()).isNotNull();
+	}
+	
+}


### PR DESCRIPTION
https://github.com/camel-tooling/camel-language-server/assets/1105127/e4b31b42-6c9c-4b60-a142-1c24cf0ac01f

ideas for other iterations:
- provide completion only inside a profiles block
- provide completion only when it is a Camel Quarkus project
- include profiles block when not available