### PR TITLE
Configure log levels

### DIFF
--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -28,6 +28,12 @@ appender.rolling.strategy.delete.ifLastModified.type = IfLastModified
 # Delete all files older than 30 days
 appender.rolling.strategy.delete.ifLastModified.age = 30d
 
+# Configure Camel Tooling logger
+logger.cameltooling.name = com.github.cameltooling
+logger.cameltooling.level = debug
+logger.cameltooling.appenderRef.rolling.ref = fileLogger
+logger.cameltooling.additivity = false
+
 # Configure root logger
-rootLogger.level = debug
+rootLogger.level = info
 rootLogger.appenderRef.rolling.ref = fileLogger


### PR DESCRIPTION
- keep debug only for our code
- use info for others

Since changes in dependencies, the debug logging is now too much verbose to be useful on a day to day basis.

