### PR TITLE
FUSETOOLS2-2133 - use Camel 4

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -29,7 +29,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>

--- a/.github/workflows/jdks.yml
+++ b/.github/workflows/jdks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17, 20]
+        java: [17, 20]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v3.3.1

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
-org.eclipse.jdt.core.compiler.release=disabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>11</maven.compiler.release>
+		<maven.compiler.release>17</maven.compiler.release>
 		<jacoco.version>0.8.10</jacoco.version>
 		<lsp4j.version>0.21.0</lsp4j.version>
 		<slf4j.version>1.7.36</slf4j.version>
@@ -48,7 +48,7 @@
 		<junit.version>5.10.0</junit.version>
 		<assertj.version>3.24.2</assertj.version>
 		<jgit.version>6.6.0.202305301015-r</jgit.version>
-		<camel.version>3.21.0</camel.version>
+		<camel.version>4.0.0</camel.version>
 		<camel.kamelet.catalog.version>3.21.0</camel.kamelet.catalog.version>
 		<camel.quarkus.version>2.16.0</camel.quarkus.version>
 		<roaster.version>2.28.0.Final</roaster.version>
@@ -245,7 +245,7 @@
 		<dependency>
 			<groupId>org.apache.camel.karaf</groupId>
 			<artifactId>camel-catalog-provider-karaf</artifactId>
-			<version>${camel.version}</version>
+			<version>3.21.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.camel.springboot</groupId>

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionEnumerationValuesTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelComponentOptionEnumerationValuesTest.java
@@ -49,8 +49,7 @@ class CamelComponentOptionEnumerationValuesTest extends AbstractCamelLanguageSer
 
 		assertThat(completions.get().getLeft()).contains(
 				createExpectedCompletionItem("InOnly"),
-				createExpectedCompletionItem("InOut"),
-				createExpectedCompletionItem("InOptionalOut"));
+				createExpectedCompletionItem("InOut"));
 	}
 
 	private CompletionItem createExpectedCompletionItem(String enumOption) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/CompleteIdOnDirectEndpointsTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/CompleteIdOnDirectEndpointsTest.java
@@ -13,7 +13,9 @@ package com.github.cameltooling.lsp.internal.completion;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.FileInputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.CompletionItem;
@@ -21,6 +23,7 @@ import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
@@ -44,31 +47,6 @@ class CompleteIdOnDirectEndpointsTest extends AbstractCamelLanguageServerTest {
 		}
 	}
 
-	@Test
-	void testDirectVMEndpointCompletion() throws Exception {
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer(new FileInputStream("src/test/resources/workspace/direct-endpoint-test.xml"), ".xml");
-		Position positionInMiddleOfcomponentPart = new Position(17, 45);
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, positionInMiddleOfcomponentPart);
-		List<CompletionItem> items = completions.get().getLeft();
-		assertThat(items).hasSize(2);
-		for (CompletionItem completionItem : items) {
-			TextEdit textEdit = completionItem.getTextEdit().getLeft();
-			assertThat(textEdit.getNewText()).isIn("direct-vm:name", "direct-vm:processing");
-		}
-	}
-	
-	@Test
-	void testVMEndpointCompletion() throws Exception {
-		CamelLanguageServer camelLanguageServer = initializeLanguageServer(new FileInputStream("src/test/resources/workspace/direct-endpoint-test.xml"), ".xml");
-		Position positionInMiddleOfcomponentPart = new Position(25, 39);
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, positionInMiddleOfcomponentPart);
-		List<CompletionItem> items = completions.get().getLeft();
-		assertThat(items).hasSize(2);
-		for (CompletionItem completionItem : items) {
-			TextEdit textEdit = completionItem.getTextEdit().getLeft();
-			assertThat(textEdit.getNewText()).isIn("vm:name", "vm:processing");
-		}
-	}
 	
 	@Test
 	void testSEDAEndpointCompletion() throws Exception {
@@ -80,6 +58,52 @@ class CompleteIdOnDirectEndpointsTest extends AbstractCamelLanguageServerTest {
 		for (CompletionItem completionItem : items) {
 			TextEdit textEdit = completionItem.getTextEdit().getLeft();
 			assertThat(textEdit.getNewText()).isIn("seda:name", "seda:processing");
+		}
+	}
+	
+	/**
+	 * Direct VM and VM has been removed in 4.0
+	 */
+	@Nested
+	class VMCompletionPre4X extends AbstractCamelLanguageServerTest {
+		
+		@Test
+		void testDirectVMEndpointCompletion() throws Exception {
+			CamelLanguageServer camelLanguageServer = initializeLanguageServer(new FileInputStream("src/test/resources/workspace/direct-endpoint-test.xml"), ".xml");
+			Position positionInMiddleOfcomponentPart = new Position(17, 45);
+			CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, positionInMiddleOfcomponentPart);
+			List<CompletionItem> items = completions.get().getLeft();
+			assertThat(items).hasSize(2);
+			for (CompletionItem completionItem : items) {
+				TextEdit textEdit = completionItem.getTextEdit().getLeft();
+				assertThat(textEdit.getNewText()).isIn("direct-vm:name", "direct-vm:processing");
+			}
+		}
+		
+		@Test
+		void testVMEndpointCompletion() throws Exception {
+			CamelLanguageServer camelLanguageServer = initializeLanguageServer(new FileInputStream("src/test/resources/workspace/direct-endpoint-test.xml"), ".xml");
+			Position positionInMiddleOfcomponentPart = new Position(25, 39);
+			CompletableFuture<Either<List<CompletionItem>, CompletionList>> completions = getCompletionFor(camelLanguageServer, positionInMiddleOfcomponentPart);
+			List<CompletionItem> items = completions.get().getLeft();
+			assertThat(items).hasSize(2);
+			for (CompletionItem completionItem : items) {
+				TextEdit textEdit = completionItem.getTextEdit().getLeft();
+				assertThat(textEdit.getNewText()).isIn("vm:name", "vm:processing");
+			}
+		}
+		
+		@Override
+		protected Map<Object, Object> getInitializationOptions() {
+			return createMapSettingsWithVersion("3.21.0");
+		}
+		
+		private Map<Object, Object> createMapSettingsWithVersion(String camelCatalogVersion) {
+			Map<Object, Object> camelIntializationOptions = new HashMap<>();
+			camelIntializationOptions.put("Camel catalog version", camelCatalogVersion);
+			Map<Object, Object> initializationOptions = new HashMap<>();
+			initializationOptions.put("camel", camelIntializationOptions);
+			return initializationOptions;
 		}
 	}
 }


### PR DESCRIPTION
- Java 17 is required
- The `org.apache.camel.ExchangePattern` has removed `InOptionalOut`.
- Direct VM and VM component has been removed
- No Camel Kafka Connector catalog is provided, keep 3.21.0 for it but
not sure how long it would be possible