### PR TITLE
fix FUSETOOLS2-2178: Provide completion for secrets coming from Kubernetes Context

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelKubernetesServicesCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/CamelKubernetesServicesCompletionTest.java
@@ -19,9 +19,12 @@ package com.github.cameltooling.lsp.internal.completion;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import io.fabric8.kubernetes.api.model.SecretBuilder;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -40,12 +43,12 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 class CamelKubernetesServicesCompletionTest extends AbstractCamelLanguageServerTest {
 
 	private KubernetesClient client;
-	
+
 	@Test
 	void testCompletionForNamespace() throws Exception {
 		KubernetesConfigManager.getInstance().setClient(client);
 		createNamespace("first_namespace");
-		
+
 		List<CompletionItem> completions = getCompletionForNamespace();
 		assertThat(completions).hasSize(1);
 		CompletionItem completion = completions.get(0);
@@ -56,33 +59,88 @@ class CamelKubernetesServicesCompletionTest extends AbstractCamelLanguageServerT
 	@Test
 	void testCompletionWithNoNamespace() throws Exception {
 		KubernetesConfigManager.getInstance().setClient(client);
-		
+
 		List<CompletionItem> completions = getCompletionForNamespace();
 		assertThat(completions).isEmpty();
 	}
-	
+
 	@Test
 	void testCompletionWithSeveralNamespace() throws Exception {
 		KubernetesConfigManager.getInstance().setClient(client);
 		createNamespace("first_namespace");
 		createNamespace("second_namespace");
-		
+
 		List<CompletionItem> completions = getCompletionForNamespace();
 		assertThat(completions).hasSize(2);
 	}
 
-	private void createNamespace(String name) {
-		client.namespaces().resource(new NamespaceBuilder().withNewMetadata().withName(name).endMetadata().build()).create();
-	}
-	
-	private List<CompletionItem> getCompletionForNamespace()
-			throws URISyntaxException, InterruptedException, ExecutionException {
-		String camelUri = "kubernetes-services:masterUrl?namespace=";
-		String text = RouteTextBuilder.createXMLSpringRoute(camelUri);
-		CamelLanguageServer languageServer = initializeLanguageServer(text, ".xml");
-		Position position = new Position(0, RouteTextBuilder.XML_PREFIX_FROM.length() + camelUri.length());
-		List<CompletionItem> completions = getCompletionFor(languageServer, position).get().getLeft();
-		return completions;
-	}
-	
+    @Test
+    void testCompletionForSecret() throws Exception {
+        KubernetesConfigManager.getInstance().setClient(client);
+        createNamespace("my-secrets-namespace");
+        createSecret("mySecrets", List.of("password"));
+        List<CompletionItem> completions = getCompletionForSecrets();
+        assertThat(completions).hasSize(1);
+        CompletionItem completion = completions.get(0);
+        assertThat(completion.getLabel()).isEqualTo("{{secret:mySecrets/password}}");
+    }
+
+    @Test
+    void testSecretCompletionWithNoSecrets() throws Exception {
+        KubernetesConfigManager.getInstance().setClient(client);
+        createNamespace("my-secrets-namespace");
+        List<CompletionItem> completions = getCompletionForSecrets();
+        assertThat(completions).isEmpty();
+    }
+
+    @Test
+    void testSecretCompletionWithSeveralSecrets() throws Exception {
+        KubernetesConfigManager.getInstance().setClient(client);
+        createNamespace("my-secrets-namespace");
+        createSecret("mySecrets", List.of("key","second"));
+        createSecret("myRealSecrets", List.of("another"));
+
+        List<CompletionItem> completions = getCompletionForSecrets();
+        assertThat(completions).hasSize(3);
+    }
+
+    private void createNamespace(String name) {
+        client.namespaces().resource(new NamespaceBuilder().withNewMetadata().withName(name).endMetadata().build()).create();
+    }
+
+    private List<CompletionItem> getCompletionForNamespace()
+            throws URISyntaxException, InterruptedException, ExecutionException {
+        String camelUri = "kubernetes-services:masterUrl?namespace=";
+        String text = RouteTextBuilder.createXMLSpringRoute(camelUri);
+        CamelLanguageServer languageServer = initializeLanguageServer(text, ".xml");
+        Position position = new Position(0, RouteTextBuilder.XML_PREFIX_FROM.length() + camelUri.length());
+        List<CompletionItem> completions = getCompletionFor(languageServer, position).get().getLeft();
+        return completions;
+    }
+
+    private void createSecret(String secretName, List<String> keys) {
+        Map<String, String> data = new HashMap<>();
+        keys.forEach(k -> data.put(k, k + "encrypted"));
+        client.secrets().resource(
+                new SecretBuilder()
+                        .withNewMetadata()
+                        .withName(secretName)
+                        .withNamespace("my-secrets-namespace")
+                        .withLabels(Map.of())
+                        .endMetadata()
+                        .withData(data)
+                        .build())
+                .create();
+    }
+
+    private List<CompletionItem> getCompletionForSecrets()
+            throws URISyntaxException, InterruptedException, ExecutionException {
+        String camelUri = "pgevent:host:999/database/channel?user={{secret:";
+        String text = RouteTextBuilder.createXMLSpringRoute(camelUri);
+        CamelLanguageServer languageServer = initializeLanguageServer(text, ".xml");
+        Position position = new Position(0, RouteTextBuilder.XML_PREFIX_FROM.length() + camelUri.length());
+        List<CompletionItem> completions = getCompletionFor(languageServer, position).get().getLeft();
+        return completions;
+    }
+
 }


### PR DESCRIPTION
It searches in all namespaces if there is a kubernetes connection configured.
It doesn't discriminate by name of the property, but detects when a {{secret: is being written as value.

Maybe we could improve this, so when the value of a property starts with `{{'' it shows suggestions for different placeholder types, and once you select the type of placeholder (`secret`, `configmap`,...), it expands the auto-completions to specific values.

## Tests

- [ ] Are there **Unit tests**?
- [ ] Are there **Integration tests**?
- [ ] Do we need a new **UI test**?

## PR workflow progress

1. [ ] Tagged with relevant **PR labels**
2. [ ] Green **job for PR**
3. [ ] PR was created more than **24 hours ago** or **All committers approved** it
4. [ ] Green **main** branch build