### PR TITLE
FUSETOOLS2-2196 - provide sbom with specific classifier as Maven

### DIFF
--- a/.github/workflows/jdks.yml
+++ b/.github/workflows/jdks.yml
@@ -32,5 +32,3 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
       run: mvn -B package
-    - name: Generate SBOM
-      run: mvn package -P sbom -DskipTests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,14 +48,4 @@ jobs:
         -Dsonar.projectKey="camel-lsp-server"
         -Dsonar.projectName="Camel LSP Server"
         -Dsonar.host.url=https://sonarcloud.io
-    - name: Generate SBOM
-      run: mvn package -P sbom -DskipTests
-    - name: Store SBOM
-      uses: actions/upload-artifact@v3
-      with:
-        name: sboms
-        path: |
-          target/bom.json
-          target/bom.xml
-     
         

--- a/pom.xml
+++ b/pom.xml
@@ -129,17 +129,7 @@
 		        			</execution>
 		      			</executions>
 		    		</plugin>
-				</plugins>
-			</build>
-		</profile>
-		
-		<profile>
-			<id>sbom</id>
-			<activation>
-				<activeByDefault>false</activeByDefault>
-			</activation>
-			<build>
-				<plugins>
+		    		
 					<plugin>
 						<groupId>org.cyclonedx</groupId>
 						<artifactId>cyclonedx-maven-plugin</artifactId>
@@ -156,7 +146,6 @@
 				</plugins>
 			</build>
 		</profile>
-		
 	</profiles>
 
 	<build>


### PR DESCRIPTION
artifact

- it will simplify consuming it after compared to having it as an artifact on GitHub Workflow
- CycloneDX Maven plugin is providing it automatically on package/deploy

