### PR TITLE
feature: Auto-completion for kubernetes mid-string

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelOptionValuesCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelOptionValuesCompletionsFuture.java
@@ -45,7 +45,7 @@ import com.github.cameltooling.lsp.internal.kubernetes.KubernetesConfigManager;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 public class CamelOptionValuesCompletionsFuture implements Function<CamelCatalog, List<CompletionItem>> {
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(CamelOptionValuesCompletionsFuture.class);
 
 	private static final String BOOLEAN_TYPE = "boolean";
@@ -60,19 +60,19 @@ public class CamelOptionValuesCompletionsFuture implements Function<CamelCatalog
 	@Override
 	public List<CompletionItem> apply(CamelCatalog camelCatalog) {
 		Optional<EndpointOptionModel> endpointModel = retrieveEndpointOptionModel(camelCatalog);
-		if(endpointModel.isPresent()) {
+		if (endpointModel.isPresent()) {
 			EndpointOptionModel endpointOptionModel = endpointModel.get();
 			List<String> enums = endpointOptionModel.getEnums();
 			if (enums != null && !enums.isEmpty()) {
 				return computeCompletionForEnums(enums);
-			} else if(BOOLEAN_TYPE.equals(endpointOptionModel.getType())) {
+			} else if (BOOLEAN_TYPE.equals(endpointOptionModel.getType())) {
 				CompletionItem trueItem = new CompletionItem(Boolean.TRUE.toString());
 				CompletionResolverUtils.applyTextEditToCompletionItem(optionParamValueURIInstance, trueItem);
-				CompletionItem falseItem =  new CompletionItem(Boolean.FALSE.toString());
+				CompletionItem falseItem = new CompletionItem(Boolean.FALSE.toString());
 				CompletionResolverUtils.applyTextEditToCompletionItem(optionParamValueURIInstance, falseItem);
 				Stream<CompletionItem> values = Stream.of(trueItem, falseItem);
 				return values.filter(FilterPredicateUtils.matchesCompletionFilter(filterString)).collect(Collectors.toList());
-			} else if(optionParamValueURIInstance.getComponentName().startsWith("kubernetes-")
+			} else if (optionParamValueURIInstance.getComponentName().startsWith("kubernetes-")
 					&& "namespace".equals(optionParamValueURIInstance.getOptionParamURIInstance().getKey().getKeyName())) {
 				try (KubernetesClient client = KubernetesConfigManager.getInstance().getClient()) {
 					return client.namespaces().list().getItems().stream().map(namespace -> {
@@ -83,11 +83,11 @@ public class CamelOptionValuesCompletionsFuture implements Function<CamelCatalog
 				} catch (ApiException e) {
 					LOGGER.error("Error while trying to provide completion for Kubernetes connected mode", e);
 				}
-			} else if("lang".equalsIgnoreCase(endpointOptionModel.getName())
+			} else if ("lang".equalsIgnoreCase(endpointOptionModel.getName())
 					&& optionParamValueURIInstance.getComponentName().startsWith("twitter-")) {
 				List<CompletionItem> items = new ArrayList<>();
 				//We will just rely on Java to be updated for this
-				for(String lang : Locale.getISOLanguages()) {
+				for (String lang : Locale.getISOLanguages()) {
 					CompletionItem langItem = new CompletionItem(lang);
 					CompletionResolverUtils.applyTextEditToCompletionItem(optionParamValueURIInstance, langItem);
 					items.add(langItem);
@@ -104,27 +104,58 @@ public class CamelOptionValuesCompletionsFuture implements Function<CamelCatalog
 	}
 
 	private List<CompletionItem> getCompletionForKubernetes() {
-
-		final var value = optionParamValueURIInstance.getOptionParamURIInstance().getValue().getValueName();
+		final var interestingPosition =
+				optionParamValueURIInstance.getValueName().length() > filterString.length() ?
+						filterString.length() + 1 : filterString.length();
+		final var value = optionParamValueURIInstance.getValueName().substring(0, interestingPosition);
 		var kubernetesPlaceholders = new ArrayList<CompletionItem>();
-		
-		if(StringUtils.startsWithIgnoreCase(value, "{{")) {
+
+		// Make sure we have the cursor after a {{
+		if (StringUtils.contains(value, "{{") &&
+				//Either it is not closed by }}
+				(!StringUtils.contains(value, "}}") ||
+						// or }} is after the cursor
+						(value.lastIndexOf("}}") < value.lastIndexOf("{{")))) {
+
+			//Get the string before the placeholder (starting with {{)
+			final var pre = value.substring(0, value.lastIndexOf("{{"));
+
+			// Now we get the string after the placeholder.
+			// This is tricky because we don't even know if the placeholder is already closed.
+			// interestingPosition is where the cursor is supposed to be
+			var lastPart = optionParamValueURIInstance.getValueName().substring(interestingPosition);
+
+			// The cursor is between {{ and }} because we found a }} after the cursor
+			if (lastPart.indexOf("}}") >= 0 &&
+					// This }} detected is closing the placeholder we are guessing
+					(lastPart.indexOf("}}") < lastPart.indexOf("{{")
+							//Or it is the only placeholder closing here, so it must be ours
+							|| lastPart.indexOf("{{") < 0)) {
+				//Let's get whatever is behind the detected }}
+				lastPart = lastPart.substring(lastPart.indexOf("}}") + 2);
+			}
+
+			final var post = lastPart;
 			try (KubernetesClient client = KubernetesConfigManager.getInstance().getClient()) {
 				if (client instanceof NamespacedKubernetesClient nsClient) {
 					kubernetesPlaceholders.addAll(nsClient.inAnyNamespace().secrets().list().getItems().stream().flatMap(element ->
-							element.getData().keySet().stream().map(k ->{
+							element.getData().keySet().stream().map(k -> {
 								CompletionItem item = new CompletionItem(
 										"{{secret:" + element.getMetadata().getName() + "/" + k + "}}");
+								item.setInsertText(pre + item.getLabel() + post);
+								item.setFilterText(pre + item.getLabel());
 								CompletionResolverUtils.applyTextEditToCompletionItem(optionParamValueURIInstance, item);
 								return item;
 							})).collect(Collectors.toList()));
 					kubernetesPlaceholders.addAll(nsClient.inAnyNamespace().configMaps().list().getItems().stream().flatMap(element ->
-								element.getData().keySet().stream().map(k ->{
-									CompletionItem item = new CompletionItem(
-											"{{configmap:" + element.getMetadata().getName() + "/" + k + "}}");
-									CompletionResolverUtils.applyTextEditToCompletionItem(optionParamValueURIInstance, item);
-									return item;
-								})).collect(Collectors.toList()));
+							element.getData().keySet().stream().map(k -> {
+								CompletionItem item = new CompletionItem(
+										"{{configmap:" + element.getMetadata().getName() + "/" + k + "}}");
+								item.setInsertText(pre + item.getLabel() + post);
+								item.setFilterText(pre + item.getLabel());
+								CompletionResolverUtils.applyTextEditToCompletionItem(optionParamValueURIInstance, item);
+								return item;
+							})).collect(Collectors.toList()));
 				}
 			} catch (Exception e) {
 				LOGGER.error("Error while trying to provide completion for Kubernetes connected mode", e);
@@ -136,7 +167,7 @@ public class CamelOptionValuesCompletionsFuture implements Function<CamelCatalog
 
 	private List<CompletionItem> computeCompletionForEnums(List<String> enums) {
 		List<CompletionItem> completionItems = new ArrayList<>();
-		for(String enumValue : enums) {
+		for (String enumValue : enums) {
 			CompletionItem item = new CompletionItem(enumValue);
 			CompletionResolverUtils.applyTextEditToCompletionItem(optionParamValueURIInstance, item);
 			completionItems.add(item);


### PR DESCRIPTION
Continue #990 and #995

Now instead of auto-completing the whole value of the parameter, the string can contain several placeholders and other pieces of string that won't get removed by the auto-completion.

[Screencast from 2023-10-13 13-49-40.webm](https://github.com/camel-tooling/camel-language-server/assets/726590/60b33a05-ee2d-4701-8fab-9d2e35ac7a2e)
