### PR TITLE
feature: Support multiline in YAML camel uri autocompletion

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/codeactions/ConvertCamelKPropertyFileModelineRefactorAction.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/codeactions/ConvertCamelKPropertyFileModelineRefactorAction.java
@@ -56,7 +56,7 @@ public class ConvertCamelKPropertyFileModelineRefactorAction {
 		int startLine = params.getRange().getStart().getLine();
 		int endLine = params.getRange().getEnd().getLine();
 		if(startLine == endLine && new CamelKModelineParser().isOnCamelKModeline(startLine, openedDocument)) {
-			CamelKModeline camelKModeline = new CamelKModeline(new ParserFileHelperUtil().getLine(openedDocument, startLine), openedDocument, startLine);
+			CamelKModeline camelKModeline = new CamelKModeline(new ParserFileHelperUtil().getLine(openedDocument, startLine), openedDocument, startLine, endLine);
 			List<Either<Command, CodeAction>> codeActions = new ArrayList<>();
 			Map<String, List<TextEdit>> changes = new HashMap<>();
 			List<TextEdit> textEdits = new ArrayList<>();

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelPropertiesCompletionProcessor.java
@@ -43,7 +43,9 @@ public class CamelPropertiesCompletionProcessor {
 	public CompletableFuture<List<CompletionItem>> getCompletions(Position position, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager) {
 		if (textDocumentItem != null) {
 			String line = new ParserFileHelperUtil().getLine(textDocumentItem, position);
-			return new CamelPropertyEntryInstance(line, new Position(position.getLine(), 0), textDocumentItem).getCompletions(position, camelCatalog, settingsManager, kameletsCatalogManager);
+			return new CamelPropertyEntryInstance(line, new Position(position.getLine(), 0),
+					position, textDocumentItem).getCompletions(position, camelCatalog, settingsManager,
+					kameletsCatalogManager);
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CompletionResolverUtils.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CompletionResolverUtils.java
@@ -46,9 +46,8 @@ public class CompletionResolverUtils {
 	
 	public static void applyTextEditToCompletionItem(ILineRangeDefineable lineRangeDefineable, CompletionItem item) {
 		if (lineRangeDefineable != null) {
-			int line = lineRangeDefineable.getLine();
-			Position pStart = new Position(line, lineRangeDefineable.getStartPositionInLine());
-			Position pEnd = new Position(line, lineRangeDefineable.getEndPositionInLine());
+			Position pStart = new Position(lineRangeDefineable.getStartLine(), lineRangeDefineable.getStartPositionInLine());
+			Position pEnd = new Position(lineRangeDefineable.getEndLine(), lineRangeDefineable.getEndPositionInLine());
 			
 			Range range = new Range(pStart, pEnd);
 			

--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/modeline/CamelKModelineCompletionprocessor.java
@@ -39,6 +39,6 @@ public class CamelKModelineCompletionprocessor {
 
 	public CompletableFuture<List<CompletionItem>>  getCompletions(Position position) {
 		String modelineString = new ParserFileHelperUtil().getLine(textDocumentItem, position.getLine());
-		return new CamelKModeline(modelineString, textDocumentItem, position.getLine()).getCompletions(position.getCharacter(), camelCatalog);
+		return new CamelKModeline(modelineString, textDocumentItem, position.getLine(), position.getLine()).getCompletions(position.getCharacter(), camelCatalog);
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKModelineDiagnosticService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/diagnostic/CamelKModelineDiagnosticService.java
@@ -49,7 +49,7 @@ public class CamelKModelineDiagnosticService extends DiagnosticService {
 		try {
 			while((line=bufReader.readLine()) != null){
 				if(camelKModelineParser.retrieveModelineCamelKStart(line) != null) {
-					diagnostics.addAll(computeDiagnosticForLine(documentItem, line, lineNumber));
+					diagnostics.addAll(computeDiagnosticForLine(documentItem, line, lineNumber, lineNumber));
 				}
 				lineNumber++;
 			}
@@ -59,9 +59,9 @@ public class CamelKModelineDiagnosticService extends DiagnosticService {
 		return diagnostics;
 	}
 
-	private Collection<Diagnostic> computeDiagnosticForLine(TextDocumentItem documentItem, String line, int lineNumber) {
+	private Collection<Diagnostic> computeDiagnosticForLine(TextDocumentItem documentItem, String line, int startLine, int endLine) {
 		Collection<Diagnostic> diagnostics = new HashSet<>();
-		CamelKModeline camelKModeline = new CamelKModeline(line, documentItem, lineNumber);
+		CamelKModeline camelKModeline = new CamelKModeline(line, documentItem, startLine, endLine);
 		List<CamelKModelineTraitOption> traitOptions = camelKModeline.getOptions().stream()
 				.map(CamelKModelineOption::getOptionValue)
 				.filter(CamelKModelineTraitOption.class::isInstance)
@@ -76,8 +76,11 @@ public class CamelKModelineDiagnosticService extends DiagnosticService {
 					&& propertyName != null
 					&& definitionName.equals(traitOption2.getTraitDefinition().getValueAsString())
 					&& propertyName.equals(traitOption2.getTraitProperty().getValueAsString())) {
-						Range range = new Range(new Position(traitOption2.getLine(), traitOption2.getStartPositionInLine()), new Position(traitOption2.getLine(), traitOption2.getEndPositionInLine()));
-						diagnostics.add(new Diagnostic(range, "More than one trait defines the same property: " + definitionName + "." + propertyName));
+						Range range = new Range(new Position(traitOption2.getStartLine(),
+								traitOption2.getStartPositionInLine()), new Position(traitOption2.getEndLine(),
+								traitOption2.getEndPositionInLine()));
+						diagnostics.add(new Diagnostic(range,
+								"More than one trait defines the same property: " + definitionName + "." + propertyName));
 					}
 				}
 			}

--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineHoverProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineHoverProcessor.java
@@ -36,7 +36,8 @@ public class CamelKModelineHoverProcessor {
 
 	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
 		int lineNumber = position.getLine();
-		CamelKModeline camelKModeline = new CamelKModeline(new ParserFileHelperUtil().getLine(textDocumentItem, lineNumber), textDocumentItem, lineNumber);
+		CamelKModeline camelKModeline = new CamelKModeline(new ParserFileHelperUtil().getLines(textDocumentItem,
+				lineNumber, lineNumber + 1), textDocumentItem, lineNumber, lineNumber);
 		return camelKModeline.getHover(position, camelCatalog);
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineHoverProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelKModelineHoverProcessor.java
@@ -37,7 +37,7 @@ public class CamelKModelineHoverProcessor {
 	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog) {
 		int lineNumber = position.getLine();
 		CamelKModeline camelKModeline = new CamelKModeline(new ParserFileHelperUtil().getLines(textDocumentItem,
-				lineNumber, lineNumber + 1), textDocumentItem, lineNumber, lineNumber);
+				lineNumber, lineNumber), textDocumentItem, lineNumber, lineNumber);
 		return camelKModeline.getHover(position, camelCatalog);
 	}
 

--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverProcessor.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelPropertiesFileHoverProcessor.java
@@ -38,7 +38,8 @@ public class CamelPropertiesFileHoverProcessor {
 	public CompletableFuture<Hover> getHover(Position position, CompletableFuture<CamelCatalog> camelCatalog, KameletsCatalogManager kameletCatalogManager) {
 		int line = position.getLine();
 		String propertyEntryTextLine = new ParserFileHelperUtil().getLine(textDocumentItem, line);
-		return new CamelPropertyEntryInstance(propertyEntryTextLine, new Position(line, 0), textDocumentItem).getHover(position, camelCatalog, kameletCatalogManager);
+		return new CamelPropertyEntryInstance(propertyEntryTextLine, new Position(line, 0),
+				position, textDocumentItem).getHover(position, camelCatalog, kameletCatalogManager);
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/hover/CamelURIHoverFuture.java
@@ -47,8 +47,8 @@ public class CamelURIHoverFuture implements Function<CamelCatalog, Hover> {
 			Hover hover = new Hover();
 			ComponentModel componentModel = ModelHelper.generateComponentModel(componentJSonSchema, true);
 			hover.setContents(Collections.singletonList((Either.forLeft(uriElement.getDescription(componentModel, kameletCatalogManager)))));
-			Position start = new Position(uriElement.getLine(), uriElement.getStartPositionInLine());
-			hover.setRange(new Range(start, new Position(uriElement.getLine(), uriElement.getEndPositionInLine())));
+			Position start = new Position(uriElement.getStartLine(), uriElement.getStartPositionInLine());
+			hover.setRange(new Range(start, new Position(uriElement.getEndLine(), uriElement.getEndPositionInLine())));
 			return hover;
 		}
 		return null;

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelUriElementInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelUriElementInstance.java
@@ -73,9 +73,15 @@ public abstract class CamelUriElementInstance implements ILineRangeDefineable{
 	public int getEndPositionInLine() {
 		return getCamelUriInstance().getStartPositionInDocument().getCharacter() + getEndPositionInUri();
 	}
-	
-	public int getLine() {
+
+	@Override
+	public int getStartLine() {
 		return getCamelUriInstance().getAbsoluteBounds().getStart().getLine();
+	}
+
+	@Override
+	public int getEndLine() {
+		return getCamelUriInstance().getAbsoluteBounds().getEnd().getLine();
 	}
 	
 	public abstract CompletableFuture<List<CompletionItem>> getCompletions(CompletableFuture<CamelCatalog> camelCatalog, int positionInCamelUri, TextDocumentItem docItem, SettingsManager settingsManager, KameletsCatalogManager kameletsCatalogManager);

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ILineRangeDefineable.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ILineRangeDefineable.java
@@ -25,20 +25,22 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public interface ILineRangeDefineable {
 	
-	public int getLine();
+	public int getStartLine();
+	public int getEndLine();
 	public int getStartPositionInLine();
 	public int getEndPositionInLine();
 	
 	public default Hover createHover(String description) {
 		Hover hover = new Hover();
 		hover.setContents(Collections.singletonList((Either.forLeft(description))));
-		hover.setRange(new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getEndPositionInLine())));
+		hover.setRange(new Range(new Position(getStartLine(), getStartPositionInLine()), new Position(getEndLine(),
+				getEndPositionInLine())));
 		return hover;
 	}
 	
 	public default Range getRange() {
 		return new Range(
-				new Position(getLine(), getStartPositionInLine()),
-				new Position(getLine(), getEndPositionInLine())); 
+				new Position(getStartLine(), getStartPositionInLine()),
+				new Position(getEndLine(), getEndPositionInLine()));
 	}
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentNamePropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentNamePropertyInstance.java
@@ -46,8 +46,12 @@ public class CamelComponentNamePropertyInstance implements ILineRangeDefineable 
 	}
 
 	@Override
-	public int getLine() {
-		return camelComponentPropertyKey.getLine();
+	public int getStartLine() {
+		return camelComponentPropertyKey.getStartLine();
+	}
+	@Override
+	public int getEndLine() {
+		return camelComponentPropertyKey.getEndLine();
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentParameterPropertyInstance.java
@@ -50,8 +50,12 @@ public class CamelComponentParameterPropertyInstance implements ILineRangeDefine
 	}
 
 	@Override
-	public int getLine() {
-		return camelComponentPropertykey.getLine();
+	public int getStartLine() {
+		return camelComponentPropertykey.getStartLine();
+	}
+	@Override
+	public int getEndLine() {
+		return camelComponentPropertykey.getEndLine();
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelComponentPropertyKey.java
@@ -88,8 +88,13 @@ public class CamelComponentPropertyKey implements ILineRangeDefineable {
 	}
 
 	@Override
-	public int getLine() {
-		return getCamelPropertyKeyInstance().getLine();
+	public int getEndLine() {
+		return getCamelPropertyKeyInstance().getEndLine();
+	}
+
+	@Override
+	public int getStartLine() {
+		return getCamelPropertyKeyInstance().getStartLine();
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelGroupPropertyKey.java
@@ -59,8 +59,13 @@ public class CamelGroupPropertyKey implements ILineRangeDefineable {
 	}
 
 	@Override
-	public int getLine() {
-		return camelPropertyKeyInstance.getLine();
+	public int getStartLine() {
+		return camelPropertyKeyInstance.getStartLine();
+	}
+
+	@Override
+	public int getEndLine() {
+		return camelPropertyKeyInstance.getEndLine();
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstance.java
@@ -43,11 +43,14 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 	private CamelPropertyValueInstance camelPropertyValueInstance;
 	private String line;
 	private Position startPosition;
+	private Position endPosition;
 	private TextDocumentItem textDocumentItem;
 
-	public CamelPropertyEntryInstance(String line, Position startPosition, TextDocumentItem textDocumentItem) {
+	public CamelPropertyEntryInstance(String line, Position startPosition, Position endPosition,
+									  TextDocumentItem textDocumentItem) {
 		this.line = line;
 		this.startPosition = startPosition;
+		this.endPosition = endPosition;
 		this.textDocumentItem = textDocumentItem;
 		int indexOf = line.indexOf('=');
 		String camelPropertyFileKeyInstanceString;
@@ -83,8 +86,13 @@ public class CamelPropertyEntryInstance implements ILineRangeDefineable {
 		return camelPropertyValueInstance;
 	}
 
-	public int getLine() {
+	@Override
+	public int getStartLine() {
 		return startPosition.getLine();
+	}
+	@Override
+	public int getEndLine() {
+		return endPosition.getLine();
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyKeyInstance.java
@@ -82,7 +82,9 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 			CompletionItem completionItem = new CompletionItem("camel");
 			String insertText = indexOfFirstDot != -1 ? "camel" : CAMEL_KEY_PREFIX;
 			completionItem.setInsertText(insertText);
-			completionItem.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), indexOfFirstDot != -1 ? getStartPositionInLine() + indexOfFirstDot : getEndPositionInLine())), insertText)));
+			completionItem.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(getStartLine(),
+					getStartPositionInLine()), new Position(getEndLine(), indexOfFirstDot != -1 ?
+					getStartPositionInLine() + indexOfFirstDot : getEndPositionInLine())), insertText)));
 			return CompletableFuture.completedFuture(Collections.singletonList(completionItem));
 		} else if (isBetweenFirstAndSecondDotOfCamelPropertyKey(position, indexOfSecondDot)) {
 			return getTopLevelCamelCompletion(camelCatalog, indexOfSecondDot, position.getCharacter());
@@ -119,8 +121,9 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 		CompletionItem completionItem = new CompletionItem("component");
 		String insertText = indexOfSecondDot != -1 ? "component" : "component.";
 		completionItem.setInsertText(insertText);
-		Position start = new Position(getLine(), getStartPositionInLine() + CAMEL_KEY_PREFIX.length());
-		Position end = new Position(getLine(), indexOfSecondDot != -1 ? getStartPositionInLine() + indexOfSecondDot : getEndPositionInLine());
+		Position start = new Position(getStartLine(), getStartPositionInLine() + CAMEL_KEY_PREFIX.length());
+		Position end = new Position(getEndLine(), indexOfSecondDot != -1 ? getStartPositionInLine() + indexOfSecondDot :
+				getEndPositionInLine());
 		Range range = new Range(start, end);
 		TextEdit textEdit = new TextEdit(range, insertText);
 		completionItem.setTextEdit(Either.forLeft(textEdit));
@@ -134,8 +137,9 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 			completionItem.setDocumentation(group.getDescription());
 			String insertText = indexOfSecondDot != -1 ? realGroupName : realGroupName + ".";
 			completionItem.setInsertText(insertText);
-			Position start = new Position(getLine(), getStartPositionInLine() + CAMEL_KEY_PREFIX.length());
-			Position end = new Position(getLine(), indexOfSecondDot != -1 ? getStartPositionInLine() + indexOfSecondDot : getEndPositionInLine());
+			Position start = new Position(getStartLine(), getStartPositionInLine() + CAMEL_KEY_PREFIX.length());
+			Position end = new Position(getEndLine(), indexOfSecondDot != -1 ? getStartPositionInLine() + indexOfSecondDot :
+					getEndPositionInLine());
 			Range range = new Range(start, end);
 			completionItem.setTextEdit(Either.forLeft(new TextEdit(range, insertText)));
 			return completionItem;
@@ -154,8 +158,13 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 		return camelPropertyEntryInstance;
 	}
 
-	public int getLine() {
-		return camelPropertyEntryInstance.getLine();
+	@Override
+	public int getStartLine() {
+		return camelPropertyEntryInstance.getStartLine();
+	}
+	@Override
+	public int getEndLine() {
+		return camelPropertyEntryInstance.getEndLine();
 	}
 
 	@Override
@@ -195,7 +204,8 @@ public class CamelPropertyKeyInstance implements ILineRangeDefineable {
 				.findAny();
 			if(duplicateByDashCamelNotationDifference.isPresent()) {
 				diagnostics.add(new Diagnostic(
-						new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getEndPositionInLine())),
+						new Range(new Position(getStartLine(), getStartPositionInLine()), new Position(getEndLine(),
+								getEndPositionInLine())),
 						"Duplicated properties using different Dash/camel case notation: " + duplicateByDashCamelNotationDifference.get(),
 						DiagnosticSeverity.Error,
 						DiagnosticService.APACHE_CAMEL_VALIDATION));

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyValueInstance.java
@@ -62,8 +62,12 @@ public class CamelPropertyValueInstance implements ILineRangeDefineable {
 	}
 
 	@Override
-	public int getLine() {
-		return key.getLine();
+	public int getStartLine() {
+		return key.getStartLine();
+	}
+	@Override
+	public int getEndLine() {
+		return key.getEndLine();
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModeline.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModeline.java
@@ -36,11 +36,13 @@ public class CamelKModeline implements ILineRangeDefineable {
 	private String fullModeline;
 	private List<CamelKModelineOption> options = new ArrayList<>();
 	private int endOfPrefixPositionInline;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public CamelKModeline(String fullModeline, TextDocumentItem documentItem, int line) {
+	public CamelKModeline(String fullModeline, TextDocumentItem documentItem, int startLine, int endLine) {
 		this.fullModeline = fullModeline;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 		String modelineCamelkStart = new CamelKModelineParser().retrieveModelineCamelKStart(fullModeline);
 		if(modelineCamelkStart != null) {
 			endOfPrefixPositionInline = modelineCamelkStart.length();
@@ -56,12 +58,12 @@ public class CamelKModeline implements ILineRangeDefineable {
 		while(!remainingModeline.isEmpty()) {
 			int nextSpaceLikeCharacter = getNextSpaceLikeCharacter(remainingModeline);
 			if(nextSpaceLikeCharacter != -1) {
-				options.add(new CamelKModelineOption(remainingModeline.substring(1, nextSpaceLikeCharacter), currentPosition + 1, documentItem, line));
+				options.add(new CamelKModelineOption(remainingModeline.substring(1, nextSpaceLikeCharacter), currentPosition + 1, documentItem, startLine, endLine));
 				remainingModeline = remainingModeline.substring(nextSpaceLikeCharacter);
 				currentPosition += nextSpaceLikeCharacter; 
 			} else {
 				if(!remainingModeline.trim().isEmpty() && !isEnfOfXmlModeline(remainingModeline.trim())) {
-					options.add(new CamelKModelineOption(remainingModeline.substring(1), currentPosition + 1, documentItem, line));
+					options.add(new CamelKModelineOption(remainingModeline.substring(1), currentPosition + 1, documentItem, startLine, endLine));
 				}
 				remainingModeline = "";
 			}
@@ -85,8 +87,13 @@ public class CamelKModeline implements ILineRangeDefineable {
 	}
 
 	@Override
-	public int getLine() {
-		return line;
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineConfigFileOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineConfigFileOption.java
@@ -27,8 +27,8 @@ import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineOp
  */
 public class CamelKModelineConfigFileOption extends CamelKModelineLocalResourceRelatedOption {
 
-	protected CamelKModelineConfigFileOption(String value, int startPosition, String documentItemUri, int line) {
-		super(value, startPosition, documentItemUri, line);
+	protected CamelKModelineConfigFileOption(String value, int startPosition, String documentItemUri, int startLine, int endLine) {
+		super(value, startPosition, documentItemUri, startLine, endLine);
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineConfigOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineConfigOption.java
@@ -28,21 +28,28 @@ public class CamelKModelineConfigOption implements ICamelKModelineOptionValue {
 	private static final String PREFIX_FILE = "file:";
 	private String value;
 	private int startPosition;
-	private int line;
+	private int startLine;
+	private int endLine;
 	private CamelKModelineConfigFileOption configFileValue;
 
-	public CamelKModelineConfigOption(String value, int startPosition, String documentItemUri, int line) {
+	public CamelKModelineConfigOption(String value, int startPosition, String documentItemUri, int startLine, int endLine) {
 		this.value = value;
 		this.startPosition = startPosition;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 		if(value.startsWith(PREFIX_FILE)) {
-			this.configFileValue = new CamelKModelineConfigFileOption(value.substring(PREFIX_FILE.length()), startPosition + PREFIX_FILE.length(), documentItemUri, line);
+			this.configFileValue = new CamelKModelineConfigFileOption(value.substring(PREFIX_FILE.length()), startPosition + PREFIX_FILE.length(), documentItemUri, startLine, endLine);
 		}
 	}
 
 	@Override
-	public int getLine() {
-		return line;
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineDependencyOption.java
@@ -36,12 +36,14 @@ public class CamelKModelineDependencyOption implements ICamelKModelineOptionValu
 
 	private String value;
 	private int startPosition;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public CamelKModelineDependencyOption(String value, int startPosition, int line) {
+	public CamelKModelineDependencyOption(String value, int startPosition, int startLine, int endLine) {
 		this.value = value;
 		this.startPosition = startPosition;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 	}
 
 	@Override
@@ -141,8 +143,13 @@ public class CamelKModelineDependencyOption implements ICamelKModelineOptionValu
 	}
 
 	@Override
-	public int getLine() {
-		return line;
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineLocalResourceRelatedOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineLocalResourceRelatedOption.java
@@ -46,17 +46,26 @@ public abstract class CamelKModelineLocalResourceRelatedOption implements ICamel
 	private String value;
 	private int startPosition;
 	private String documentItemUri;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	protected CamelKModelineLocalResourceRelatedOption(String value, int startPosition, String documentItemUri, int line) {
+	protected CamelKModelineLocalResourceRelatedOption(String value, int startPosition, String documentItemUri,
+													   int startLine, int endLine) {
 		this.value = value;
 		this.startPosition = startPosition;
 		this.documentItemUri = documentItemUri;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 	}
-	
-	public int getLine() {
-		return line;
+
+	@Override
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOpenAPIOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOpenAPIOption.java
@@ -23,8 +23,8 @@ import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineOp
 
 public class CamelKModelineOpenAPIOption extends CamelKModelineLocalResourceRelatedOption {
 	
-	public CamelKModelineOpenAPIOption(String value, int startPosition, String documentItemUri, int line) {
-		super(value, startPosition, documentItemUri, line);
+	public CamelKModelineOpenAPIOption(String value, int startPosition, String documentItemUri, int startLine, int endLine) {
+		super(value, startPosition, documentItemUri, startLine, endLine);
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOption.java
@@ -38,10 +38,13 @@ public class CamelKModelineOption implements ILineRangeDefineable {
 	private String optionName;
 	private ICamelKModelineOptionValue optionValue;
 	private int startCharacter;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public CamelKModelineOption(String option, int startCharacter, TextDocumentItem documentItem, int line) {
-		this.line = line;
+	public CamelKModelineOption(String option, int startCharacter, TextDocumentItem documentItem, int startLine,
+								int endLine) {
+		this.startLine = startLine;
+		this.endLine = endLine;
 		int nameValueIndexSeparator = option.indexOf('=');
 		this.startCharacter = startCharacter;
 		this.optionName = option.substring(0, nameValueIndexSeparator != -1 ? nameValueIndexSeparator : option.length());
@@ -56,21 +59,21 @@ public class CamelKModelineOption implements ILineRangeDefineable {
 			}
 			int startPosition = getStartPositionInLine() + optionName.length() + 1;
 			if(CamelKModelineOptionNames.OPTION_NAME_TRAIT.equals(optionName)) {
-				return new CamelKModelineTraitOption(value, startPosition, line);
+				return new CamelKModelineTraitOption(value, startPosition, startLine, endLine);
 			} else if(CamelKModelineOptionNames.OPTION_NAME_DEPENDENCY.equals(optionName)) {
-				return new CamelKModelineDependencyOption(value, startPosition, line);
+				return new CamelKModelineDependencyOption(value, startPosition, startLine, endLine);
 			} else if(CamelKModelineOptionNames.OPTION_NAME_PROPERTY.equals(optionName)) {
-				return new CamelKModelinePropertyOption(value, startPosition, documentItem, line);
+				return new CamelKModelinePropertyOption(value, startPosition, documentItem, startLine, endLine);
 			} else if(CamelKModelineOptionNames.OPTION_NAME_PROPERTY_FILE.equals(optionName)) {
-				return new CamelKModelinePropertyDashFileOption(value, startPosition, documentItem.getUri(), line);
+				return new CamelKModelinePropertyDashFileOption(value, startPosition, documentItem.getUri(), startLine, endLine);
 			} else if(CamelKModelineOptionNames.OPTION_NAME_RESOURCE.equals(optionName)) {
-				return new CamelKModelineResourceOption(value, startPosition, documentItem.getUri(), line);
+				return new CamelKModelineResourceOption(value, startPosition, documentItem.getUri(), startLine, endLine);
 			} else if(CamelKModelineOptionNames.OPTION_NAME_OPEN_API.equals(optionName)) {
-				return new CamelKModelineOpenAPIOption(value, startPosition, documentItem.getUri(), line);
+				return new CamelKModelineOpenAPIOption(value, startPosition, documentItem.getUri(), startLine, endLine);
 			} else if(CamelKModelineOptionNames.OPTION_NAME_CONFIG.equals(optionName)) {
-				return new CamelKModelineConfigOption(value, startPosition, documentItem.getUri(), line);
+				return new CamelKModelineConfigOption(value, startPosition, documentItem.getUri(), startLine, endLine);
 			} else {
-				return new GenericCamelKModelineOptionValue(value, startPosition, line);
+				return new GenericCamelKModelineOptionValue(value, startPosition, startLine, endLine);
 			}
 		} else {
 			return null;
@@ -80,12 +83,18 @@ public class CamelKModelineOption implements ILineRangeDefineable {
 	private boolean isEndOfCommentStuckToEndLine(String option, TextDocumentItem documentItem, String value) {
 		return value.endsWith(END_OF_XML_COMMENT)
 				&& documentItem.getUri().endsWith(".xml")
-				&& startCharacter + option.length() == new ParserFileHelperUtil().getLine(documentItem, getLine()).length();
+				&& startCharacter + option.length() == new ParserFileHelperUtil().getLines(documentItem,
+				getStartLine(), getEndLine()).length();
 	}
 	
 	@Override
-	public int getLine() {
-		return line;
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override
@@ -129,7 +138,8 @@ public class CamelKModelineOption implements ILineRangeDefineable {
 			if(description != null) {
 				Hover hover = new Hover();
 				hover.setContents(Collections.singletonList((Either.forLeft(description))));
-				hover.setRange(new Range(new Position(getLine(), getStartPositionInLine()), new Position(getLine(), getStartPositionInLine() + optionName.length())));
+				hover.setRange(new Range(new Position(getStartLine(), getStartPositionInLine()), new Position(getEndLine(),
+						getStartPositionInLine() + optionName.length())));
 				return CompletableFuture.completedFuture(hover);
 			}
 		}

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyDashFileOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyDashFileOption.java
@@ -27,8 +27,8 @@ import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineOp
  */
 public class CamelKModelinePropertyDashFileOption extends CamelKModelineLocalResourceRelatedOption {
 	
-	public CamelKModelinePropertyDashFileOption(String value, int startPosition, String documentItemUri, int line) {
-		super(value, startPosition, documentItemUri, line);
+	public CamelKModelinePropertyDashFileOption(String value, int startPosition, String documentItemUri, int startLine, int endLine) {
+		super(value, startPosition, documentItemUri, startLine, endLine);
 	}
 	
 	protected Predicate<Path> getFilter() {

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyFileOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyFileOption.java
@@ -27,8 +27,9 @@ import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineOp
  */
 public class CamelKModelinePropertyFileOption extends CamelKModelineLocalResourceRelatedOption {
 	
-	public CamelKModelinePropertyFileOption(String value, int startPosition, String documentItemUri, int line) {
-		super(value, startPosition, documentItemUri, line);
+	public CamelKModelinePropertyFileOption(String value, int startPosition, String documentItemUri, int startLine,
+											int endLine) {
+		super(value, startPosition, documentItemUri, startLine, endLine);
 	}
 	
 	protected Predicate<Path> getFilter() {

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelinePropertyOption.java
@@ -45,14 +45,17 @@ public class CamelKModelinePropertyOption implements ICamelKModelineOptionValue 
 	private CamelKModelinePropertyFileOption fileValue;
 	private int startPosition;
 	private String fullStringValue;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public CamelKModelinePropertyOption(String value, int startPosition, TextDocumentItem documentItem, int line) {
-		this.line = line;
+	public CamelKModelinePropertyOption(String value, int startPosition, TextDocumentItem documentItem, int startLine, int endLine) {
+		this.startLine = startLine;
+		this.endLine = endLine;
 		if(value.startsWith(FILE_PREFIX)) {
-			this.fileValue = new CamelKModelinePropertyFileOption(value.substring(FILE_PREFIX.length()), startPosition + FILE_PREFIX.length(), documentItem.getUri(), line);
+			this.fileValue = new CamelKModelinePropertyFileOption(value.substring(FILE_PREFIX.length()), startPosition + FILE_PREFIX.length(), documentItem.getUri(), startLine, endLine);
 		} else {
-			this.singlePropertyValue = new CamelPropertyEntryInstance(value, new Position(0, startPosition), documentItem);
+			this.singlePropertyValue = new CamelPropertyEntryInstance(value, new Position(0, startPosition),
+					new Position(endLine, startPosition), documentItem);
 		}
 		this.fullStringValue = value;
 		this.startPosition = startPosition;
@@ -110,9 +113,15 @@ public class CamelKModelinePropertyOption implements ICamelKModelineOptionValue 
 			return CompletableFuture.completedFuture(null);
 		}
 	}
-	
-	public int getLine() {
-		return line;
+
+	@Override
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineResourceFileOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineResourceFileOption.java
@@ -23,8 +23,8 @@ import com.github.cameltooling.lsp.internal.completion.modeline.CamelKModelineOp
 
 public class CamelKModelineResourceFileOption extends CamelKModelineLocalResourceRelatedOption {
 	
-	public CamelKModelineResourceFileOption(String value, int startPosition, String documentItemUri, int line) {
-		super(value, startPosition, documentItemUri, line);
+	public CamelKModelineResourceFileOption(String value, int startPosition, String documentItemUri, int startLine, int endLine) {
+		super(value, startPosition, documentItemUri, startLine, endLine);
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineResourceOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineResourceOption.java
@@ -29,26 +29,33 @@ public class CamelKModelineResourceOption implements ICamelKModelineOptionValue 
 
 	private String value;
 	private int startPosition;
-	private int line;
+	private int startLine;
+	private int endLine;
 	private CamelKModelineResourceFileOption resourceFileValue;
 
-	public CamelKModelineResourceOption(String value, int startPosition, String uri, int line) {
+	public CamelKModelineResourceOption(String value, int startPosition, String uri, int startLine, int endLine) {
 		this.value = value;
 		this.startPosition = startPosition;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 		if(value.startsWith(PREFIX_FILE)) {
 			int endPosition = value.indexOf('@');
 			if(endPosition != -1) {
-				this.resourceFileValue = new CamelKModelineResourceFileOption(value.substring(PREFIX_FILE.length(), endPosition), startPosition + PREFIX_FILE.length(), uri, line);
+				this.resourceFileValue = new CamelKModelineResourceFileOption(value.substring(PREFIX_FILE.length(), endPosition), startPosition + PREFIX_FILE.length(), uri, startLine, endLine);
 			} else {
-				this.resourceFileValue = new CamelKModelineResourceFileOption(value.substring(PREFIX_FILE.length()), startPosition + PREFIX_FILE.length(), uri, line);
+				this.resourceFileValue = new CamelKModelineResourceFileOption(value.substring(PREFIX_FILE.length()), startPosition + PREFIX_FILE.length(), uri, startLine, endLine);
 			}
 		}
 	}
 
 	@Override
-	public int getLine() {
-		return line;
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinition.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinition.java
@@ -30,17 +30,26 @@ public class CamelKModelineTraitDefinition implements ICamelKModelineOptionValue
 	private String traitDefinitionName;
 	private int startPosition;
 	private CamelKModelineTraitOption traitOption;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public CamelKModelineTraitDefinition(CamelKModelineTraitOption traitOption, String traitDefinitionName, int startPosition, int line) {
+	public CamelKModelineTraitDefinition(CamelKModelineTraitOption traitOption, String traitDefinitionName,
+										 int startPosition, int startLine, int endLine) {
 		this.traitOption = traitOption;
 		this.traitDefinitionName = traitDefinitionName;
 		this.startPosition = startPosition;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 	}
-	
-	public int getLine() {
-		return line;
+
+	@Override
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinitionProperty.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitDefinitionProperty.java
@@ -30,17 +30,27 @@ public class CamelKModelineTraitDefinitionProperty implements ICamelKModelineOpt
 	private String traitDefinitionProperty;
 	private int startPosition;
 	private CamelKModelineTraitOption traitOption;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public CamelKModelineTraitDefinitionProperty(CamelKModelineTraitOption camelKModelineTraitOption, String traitDefinitionProperty, int startPosition, int line) {
+	public CamelKModelineTraitDefinitionProperty(CamelKModelineTraitOption camelKModelineTraitOption,
+												 String traitDefinitionProperty, int startPosition, int startLine,
+												 int endLine) {
 		this.traitOption = camelKModelineTraitOption;
 		this.traitDefinitionProperty = traitDefinitionProperty;
 		this.startPosition = startPosition;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 	}
-	
-	public int getLine() {
-		return line;
+
+	@Override
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOption.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOption.java
@@ -35,12 +35,14 @@ public class CamelKModelineTraitOption implements ICamelKModelineOptionValue {
 	private String optionValue;
 	private CamelKModelineTraitDefinition traitDefinition;
 	private CamelKModelineTraitDefinitionProperty traitProperty;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public CamelKModelineTraitOption(String optionValue, int startPosition, int line) {
+	public CamelKModelineTraitOption(String optionValue, int startPosition, int startLine, int endLine) {
 		this.optionValue = optionValue;
 		this.startPosition = startPosition;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 		this.endPosition = startPosition + optionValue.length();
 		this.traitDefinition = createTraitDefinition(optionValue, startPosition);
 		this.traitProperty = createTraitProperty(optionValue);
@@ -52,9 +54,9 @@ public class CamelKModelineTraitOption implements ICamelKModelineOptionValue {
 			int indexOfEqualSeparator = optionValue.indexOf('=', indexOfDotSeparator);
 			int startPositionOfTraitDefintionProperty = getStartPositionInLine() + indexOfDotSeparator + 1;
 			if(indexOfEqualSeparator != -1) {
-				return new CamelKModelineTraitDefinitionProperty(this, optionValue.substring(indexOfDotSeparator + 1, indexOfEqualSeparator), startPositionOfTraitDefintionProperty, line);
+				return new CamelKModelineTraitDefinitionProperty(this, optionValue.substring(indexOfDotSeparator + 1, indexOfEqualSeparator), startPositionOfTraitDefintionProperty, startLine, endLine);
 			} else {
-				return new CamelKModelineTraitDefinitionProperty(this, optionValue.substring(indexOfDotSeparator + 1), startPositionOfTraitDefintionProperty, line);
+				return new CamelKModelineTraitDefinitionProperty(this, optionValue.substring(indexOfDotSeparator + 1), startPositionOfTraitDefintionProperty, startLine, endLine);
 			}
 		}
 		return null;
@@ -63,14 +65,20 @@ public class CamelKModelineTraitOption implements ICamelKModelineOptionValue {
 	private CamelKModelineTraitDefinition createTraitDefinition(String optionValue, int startPosition) {
 		int indexOfDotSeparator = optionValue.indexOf('.');
 		if(indexOfDotSeparator != -1) {
-			return new CamelKModelineTraitDefinition(this, optionValue.substring(0, indexOfDotSeparator), startPosition, line);
+			return new CamelKModelineTraitDefinition(this, optionValue.substring(0, indexOfDotSeparator), startPosition, startLine, endLine);
 		} else {
-			return new CamelKModelineTraitDefinition(this, optionValue, startPosition, line);
+			return new CamelKModelineTraitDefinition(this, optionValue, startPosition, startLine, endLine);
 		}
 	}
-	
-	public int getLine() {
-		return line;
+
+	@Override
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 	@Override

--- a/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/GenericCamelKModelineOptionValue.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/modelinemodel/GenericCamelKModelineOptionValue.java
@@ -20,12 +20,14 @@ public class GenericCamelKModelineOptionValue implements ICamelKModelineOptionVa
 
 	private String value;
 	private int startPosition;
-	private int line;
+	private int startLine;
+	private int endLine;
 
-	public GenericCamelKModelineOptionValue(String value, int startPosition, int line) {
+	public GenericCamelKModelineOptionValue(String value, int startPosition, int startLine, int endLine) {
 		this.value = value;
 		this.startPosition = startPosition;
-		this.line = line;
+		this.startLine = startLine;
+		this.endLine = endLine;
 	}
 
 	@Override
@@ -41,10 +43,15 @@ public class GenericCamelKModelineOptionValue implements ICamelKModelineOptionVa
 	public String getValueAsString() {
 		return value;
 	}
-	
+
 	@Override
-	public int getLine() {
-		return line;
+	public int getStartLine() {
+		return startLine;
+	}
+
+	@Override
+	public int getEndLine() {
+		return endLine;
 	}
 
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelYamlDSLParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelYamlDSLParser.java
@@ -264,7 +264,7 @@ public class CamelYamlDSLParser extends ParserFileHelper {
 							 StringBuilder lines, int pos, boolean cleanNewLine) {
 		// If it is a multi-line, cleanNewLine decides if we convert it to one very long single line
 		for (Integer lineNo = position.getLine(); lineNo >=0; lineNo--) {
-			String tempLine = parserFileHelperUtil.getLine(textDocumentItem, lineNo);
+			String tempLine = parserFileHelperUtil.getLines(textDocumentItem, lineNo, lineNo);
 
 			for (String whenToStop : whenToStopArray) {
 				if (tempLine.stripLeading().startsWith(whenToStop)) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelYamlDSLParser.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/CamelYamlDSLParser.java
@@ -268,9 +268,14 @@ public class CamelYamlDSLParser extends ParserFileHelper {
 
 			for (String whenToStop : whenToStopArray) {
 				if (tempLine.stripLeading().startsWith(whenToStop)) {
-					// Remove the potential '>' character of multiline
-					if (tempLine.stripLeading().substring(whenToStop.length() + 1).stripLeading().startsWith(">")) {
-						tempLine = tempLine.substring(0, tempLine.indexOf(">"));
+					// Remove the potential initial character of multiline
+					String[] multiLineIndicator = new String[] {">+", ">-", ">", "|+", "|-", "|"};
+					//This character should indicate if we want to keep new lines or not. Too late for that...
+					for (String indicator : multiLineIndicator) {
+						if (tempLine.stripLeading().substring(whenToStop.length() + 1)
+								.stripLeading().startsWith(indicator)) {
+							tempLine = tempLine.substring(0, tempLine.indexOf(indicator));
+						}
 					}
 					lineNo = -1; // Stop after this iteration, do not continue the loop
 					break;

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelper.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelper.java
@@ -28,7 +28,7 @@ public abstract class ParserFileHelper {
 	public abstract String getCamelComponentUri(String line, int characterPosition);
 	
 	public String getCamelComponentUri(TextDocumentItem textDocumentItem, Position position) {
-		return getCamelComponentUri(parserFileHelperUtil.getLine(textDocumentItem, position), position.getCharacter());
+		return getCamelComponentUri(parserFileHelperUtil.getLines(textDocumentItem, position), position.getCharacter());
 	}
 	
 	protected boolean isBetween(int position, int start, int end) {

--- a/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperUtil.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/parser/ParserFileHelperUtil.java
@@ -21,20 +21,40 @@ import org.eclipse.lsp4j.TextDocumentItem;
 
 public class ParserFileHelperUtil {
 
+	@Deprecated
 	public String getLine(TextDocumentItem textDocumentItem, Position position) {
-		return getLine(textDocumentItem, position.getLine());
-	}
-	
-	public String getLine(TextDocumentItem textDocumentItem, int line) {
-		return getLine(textDocumentItem.getText(), line);
+		return getLines(textDocumentItem, position.getLine(), position.getLine());
 	}
 
+	@Deprecated
+	public String getLine(TextDocumentItem textDocumentItem, int line) {
+		return getLines(textDocumentItem.getText(), line, line);
+	}
+
+	@Deprecated
 	public String getLine(String text, int line) {
 		String[] lines = text.split("\\r?\\n", line + 2);
 		if (lines.length >= line + 1) {
 			return lines[line];
 		}
 		return null;
+	}
+
+	public String getLines(TextDocumentItem textDocumentItem, Position position) {
+		return getLines(textDocumentItem, position.getLine(), position.getLine());
+	}
+
+	public String getLines(TextDocumentItem textDocumentItem, int startLine, int endLine) {
+		return getLines(textDocumentItem.getText(), startLine, endLine);
+	}
+
+	public String getLines(String text, int startLine, int endLine) {
+		String[] lines = text.split("\\r?\\n", endLine + 2);
+		StringBuilder sb = new StringBuilder();
+		for (int i = startLine; i <= endLine && i < lines.length; i++) {
+			sb.append(lines[i]);
+		}
+		return sb.toString();
 	}
 	
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/MultilineCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/MultilineCompletionTest.java
@@ -96,5 +96,92 @@ spec:
 		assertThat(completions).isNotEmpty();
 	}
 
+	@Test
+	void testMultilineYamlEscalarEscape() throws Exception {
+		String text = """
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: integration
+spec:
+  dependencies:
+  - mvn:something.something
+  flows:
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: 5000
+      steps:
+      - to:
+          uri: activemq:queue:myQueue
+      - to:
+          uri: |+
+            aws2-athena:blabla?label=something
+                """;
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".yaml");
+		List<CompletionItem> completions =
+				getCompletionFor(languageServer, new Position(19, 32))
+						.get(1, TimeUnit.SECONDS).getLeft();
+		assertThat(completions).isNotEmpty();
+
+
+		text = """
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: integration
+spec:
+  dependencies:
+  - mvn:something.something
+  flows:
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: 5000
+      steps:
+      - to:
+          uri: activemq:queue:myQueue
+      - to:
+          uri: |-
+            aws2-athena:blabla?label=something
+                """;
+		languageServer = initializeLanguageServer(text, ".yaml");
+		completions =
+				getCompletionFor(languageServer, new Position(19, 32))
+						.get(1, TimeUnit.SECONDS).getLeft();
+		assertThat(completions).isNotEmpty();
+
+		text = """
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: integration
+spec:
+  dependencies:
+  - mvn:something.something
+  flows:
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: 5000
+      steps:
+      - to:
+          uri: activemq:queue:myQueue
+      - to:
+          uri: |
+            aws2-athena:blabla?label=something
+                """;
+		languageServer = initializeLanguageServer(text, ".yaml");
+		completions =
+				getCompletionFor(languageServer, new Position(19, 32))
+						.get(1, TimeUnit.SECONDS).getLeft();
+		assertThat(completions).isNotEmpty();
+	}
 
 }

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/MultilineCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/MultilineCompletionTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+import com.github.cameltooling.lsp.internal.util.RouteTextBuilder;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MultilineCompletionTest extends AbstractCamelLanguageServerTest {
+
+
+	@Test
+	void testMultilineYaml() throws Exception {
+		String text = """
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: integration
+spec:
+  dependencies:
+  - mvn:something.something
+  flows:
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: 5000
+      steps:
+      - to:
+          uri: activemq:queue:myQueue
+      - to:
+          uri: >
+            aws2-athena:blabla?label=something
+                """;
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".yaml");
+		List<CompletionItem> completions =
+				getCompletionFor(languageServer, new Position(19, 32))
+						.get(1, TimeUnit.SECONDS).getLeft();
+		assertThat(completions).isNotEmpty();
+	}
+
+
+}

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/MultilineCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/MultilineCompletionTest.java
@@ -32,7 +32,7 @@ class MultilineCompletionTest extends AbstractCamelLanguageServerTest {
 
 
 	@Test
-	void testMultilineYaml() throws Exception {
+	void testMultilineYamlEndFile() throws Exception {
 		String text = """
 apiVersion: camel.apache.org/v1
 kind: Integration
@@ -58,6 +58,40 @@ spec:
 		CamelLanguageServer languageServer = initializeLanguageServer(text, ".yaml");
 		List<CompletionItem> completions =
 				getCompletionFor(languageServer, new Position(19, 32))
+						.get(1, TimeUnit.SECONDS).getLeft();
+		assertThat(completions).isNotEmpty();
+	}
+
+
+	@Test
+	void testMultilineYamlInBetweenLines() throws Exception {
+		String text = """
+apiVersion: camel.apache.org/v1
+kind: Integration
+metadata:
+  name: integration
+spec:
+  dependencies:
+  - mvn:something.something
+  flows:
+  - route:
+      id: timer-amq-log
+      from:
+        uri: timer:tick
+        parameters:
+          period: 5000
+      steps:
+      - to:
+          uri: activemq:queue:myQueue
+      - to:
+          uri: >
+            aws2-athena:blabla?label=something
+      - to:
+          uri: log:info
+                """;
+		CamelLanguageServer languageServer = initializeLanguageServer(text, ".yaml");
+		List<CompletionItem> completions =
+				getCompletionFor(languageServer, new Position(19, 17))
 						.get(1, TimeUnit.SECONDS).getLeft();
 		assertThat(completions).isNotEmpty();
 	}

--- a/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstanceTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/instancemodel/propertiesfile/CamelPropertyEntryInstanceTest.java
@@ -53,7 +53,8 @@ class CamelPropertyEntryInstanceTest {
 	}
 
 	private CamelPropertyEntryInstance createModel(String lineToTest) {
-		return new CamelPropertyEntryInstance(lineToTest, new Position(0,0), createTextDocumentItem(lineToTest));
+		return new CamelPropertyEntryInstance(lineToTest, new Position(0,0),
+				new Position(0, 0), createTextDocumentItem(lineToTest));
 	}
 
 	private TextDocumentItem createTextDocumentItem(String value) {

--- a/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOptionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineOptionTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 class CamelKModelineOptionTest {
 	
 	String modelineString = "// camel-k: language=groovy";
-	CamelKModeline basicModeline = new CamelKModeline(modelineString, null, 0);
+	CamelKModeline basicModeline = new CamelKModeline(modelineString, null, 0, 0);
 
 	@Test
 	void testOptionParsingBasic() throws Exception {
@@ -39,7 +39,7 @@ class CamelKModelineOptionTest {
 	@Test
 	void testOptionTraitWithIncompleteTraitContent() throws Exception {
 		String modelineWithMixedSeparator = "// camel-k: language=groovy trait=quarkus";
-		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0).getOptions();
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0, 0).getOptions();
 		assertThat(options).hasSize(2);
 	}
 	
@@ -58,14 +58,14 @@ class CamelKModelineOptionTest {
 	@Test
 	void testOptionsWithMixedSeparator() throws Exception {
 		String modelineWithMixedSeparator = "// camel-k:\tlanguage=groovy trait=quarkus.enabled=true\tdependency=mvn:org.my/application:1.0";
-		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0).getOptions();
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0, 0).getOptions();
 		assertThat(options).hasSize(3);
 	}
 	
 	@Test
 	void testOptionsWithIncompleteOptions() throws Exception {
 		String modelineWithMixedSeparator = "// camel-k: language=groovy trait";
-		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0).getOptions();
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0, 0).getOptions();
 		assertThat(options).hasSize(2);
 		CamelKModelineOption incompleteOption = options.get(1);
 		assertThat(incompleteOption.getOptionName()).isEqualTo("trait");
@@ -75,7 +75,7 @@ class CamelKModelineOptionTest {
 	}
 
 	private void checkFor2Options(String modelineWith2Options) {
-		List<CamelKModelineOption> options = new CamelKModeline(modelineWith2Options, null, 0).getOptions();
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWith2Options, null, 0, 0).getOptions();
 		assertThat(options).hasSize(2);
 		CamelKModelineOption languageGroovyOption = options.get(0);
 		assertThat(languageGroovyOption.getOptionName()).isEqualTo("language");

--- a/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTest.java
@@ -31,7 +31,7 @@ import com.github.cameltooling.lsp.internal.CamelLanguageServer;
 class CamelKModelineTest {
 	
 	String modelineString = "// camel-k: language=groovy";
-	CamelKModeline basicModeline = new CamelKModeline(modelineString, null, 0);
+	CamelKModeline basicModeline = new CamelKModeline(modelineString, null, 0, 0);
 	
 	public static Stream<Arguments> data() {
 		return Stream.of(
@@ -43,35 +43,37 @@ class CamelKModelineTest {
 	@ParameterizedTest
 	@MethodSource("data")
 	void testGetLine(String modelineString) throws Exception {
-		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0);
-		assertThat(modeline.getLine()).isZero();
+		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0, 0);
+		assertThat(modeline.getStartLine()).isZero();
+		assertThat(modeline.getEndLine()).isZero();
 	}
 
 	@ParameterizedTest
 	@MethodSource("data")
 	void testGetStartPositionInLine(String modelineString) throws Exception {
-		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0);
+		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0, 0);
 		assertThat(modeline.getStartPositionInLine()).isZero();
 	}
 
 	@ParameterizedTest
 	@MethodSource("data")
 	void testGetEndPositionInLine(String modelineString) throws Exception {
-		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0);
+		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0, 0);
 		assertThat(modeline.getEndPositionInLine()).isEqualTo(modelineString.length());
 	}
 	
 	@ParameterizedTest
 	@MethodSource("data")
 	void testGetNumberOfOptions(String modelineString) throws Exception {
-		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0);
+		CamelKModeline modeline = new CamelKModeline(modelineString, null, 0, 0);
 		assertThat(modeline.getOptions()).hasSize(1);
 	}
 	
 	@Test
 	void testWithXmlCommentWithoutSpaceWhenNoValue() {
 		String modelineText = "<!-- camel-k: dependency=-->";
-		CamelKModeline modeline = new CamelKModeline(modelineText, new TextDocumentItem("dummy.xml", CamelLanguageServer.LANGUAGE_ID, 0, modelineText), 0);
+		CamelKModeline modeline = new CamelKModeline(modelineText, new TextDocumentItem("dummy.xml",
+				CamelLanguageServer.LANGUAGE_ID, 0, modelineText), 0, 0);
 		int endPositionInLine = modeline.getOptions().get(0).getOptionValue().getEndPositionInLine();
 		assertThat(endPositionInLine).isEqualTo("<!-- camel-k: dependency=".length());
 	}
@@ -79,7 +81,8 @@ class CamelKModelineTest {
 	@Test
 	void testWithXmlCommentWithoutSpaceWithValue() {
 		String modelineText = "<!-- camel-k: dependency=test-->";
-		CamelKModeline modeline = new CamelKModeline(modelineText, new TextDocumentItem("dummy.xml", CamelLanguageServer.LANGUAGE_ID, 0, modelineText), 0);
+		CamelKModeline modeline = new CamelKModeline(modelineText, new TextDocumentItem("dummy.xml",
+				CamelLanguageServer.LANGUAGE_ID, 0, modelineText), 0, 0);
 		ICamelKModelineOptionValue optionValue = modeline.getOptions().get(0).getOptionValue();
 		int endPositionInLine = optionValue.getEndPositionInLine();
 		assertThat(endPositionInLine).isEqualTo("<!-- camel-k: dependency=test".length());

--- a/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOptionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/modelinemodel/CamelKModelineTraitOptionTest.java
@@ -49,7 +49,7 @@ class CamelKModelineTraitOptionTest {
 	}
 
 	private CamelKModelineTraitOption retrieveFirstTrait(String modelineWithMixedSeparator) {
-		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0).getOptions();
+		List<CamelKModelineOption> options = new CamelKModeline(modelineWithMixedSeparator, null, 0, 0).getOptions();
 		assertThat(options).hasSize(1);
 		return (CamelKModelineTraitOption) options.get(0).getOptionValue();
 	}


### PR DESCRIPTION
This refactor is able to handle multi-line selection in YAML. 


[Screencast from 2023-11-27 15-47-17.webm](https://github.com/camel-tooling/camel-language-server/assets/726590/c5db6f44-3053-4ecd-af70-14e118a028eb)


This is for preparation for https://github.com/camel-tooling/camel-language-server/pull/1001 which will require multiline. Still needs more features in-between before merging #1001 because we need to be able to give more context to camel uris. But now at least you can process whole YAML elements that are on different lines.