### PR TITLE
FUSETOOLS2-1419: Provide Twitter geography search snippet completion

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstance.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/CamelURIInstance.java
@@ -189,4 +189,8 @@ public class CamelURIInstance extends CamelUriElementInstance {
 		return new Range(startPositionInDocument, endPositionInDocument);
 	}
 
+	public DSLModelHelper getDslModelHelper() {
+		return dslModelHelper;
+	}
+
 }

--- a/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ComponentNameConstants.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/instancemodel/ComponentNameConstants.java
@@ -21,6 +21,7 @@ public class ComponentNameConstants {
 	public static final String COMPONENT_NAME_KAFKA = "kafka";
 	public static final String COMPONENT_NAME_KAMELET = "kamelet";
 	public static final String COMPONENT_NAME_KNATIVE = "knative";
+	public static final String COMPONENT_NAME_TWITTER_SEARCH = "twitter-search";
 	
 	private ComponentNameConstants() {}
 

--- a/src/test/java/com/github/cameltooling/lsp/internal/completion/TwitterGeographySearchCompletionTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/completion/TwitterGeographySearchCompletionTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.cameltooling.lsp.internal.completion;
+
+import static com.github.cameltooling.lsp.internal.util.RouteTextBuilder.createXMLBlueprintRoute;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+
+import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
+import com.github.cameltooling.lsp.internal.CamelLanguageServer;
+
+class TwitterGeographySearchCompletionTest extends AbstractCamelLanguageServerTest {
+	String sep = "&amp;";
+
+	@Test
+	void testCompletionHasAllExpectedOptions() throws Exception {
+		CamelLanguageServer languageServer = initializeLanguageServer(
+				createXMLBlueprintRoute("twitter-search:keywords?"), ".xml");
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 35)).get().getLeft();
+
+		assertThat(completions)
+				.isNotEmpty().anyMatch(item -> {
+					String insertText = item.getInsertText();
+					return insertText != null && insertText.contains("latitude=")
+							&& insertText.contains(sep + "longitude=")
+							&& insertText.contains(sep + "radius=") && insertText.contains(sep + "distanceMetric=");
+				});
+	}
+
+	@Test
+	void testCompletionHasAllExpectedOptionsAfterAnotherOption() throws Exception {
+		CamelLanguageServer languageServer = initializeLanguageServer(
+				createXMLBlueprintRoute("twitter-search:keywords?accessToken=token" + sep), ".xml");
+		List<CompletionItem> completions = getCompletionFor(languageServer, new Position(0, 57)).get().getLeft();
+
+		assertThat(completions)
+				.isNotEmpty().anyMatch(item -> {
+					String insertText = item.getInsertText();
+					return insertText != null && insertText.contains("latitude=")
+							&& insertText.contains(sep + "longitude=")
+							&& insertText.contains(sep + "radius=") && insertText.contains(sep + "distanceMetric=");
+				});
+	}
+}


### PR DESCRIPTION
Adds a snippet if trying to get completion for the twitter-search
component. The required query parameters (latitude, longitude, radius
and distanceMetric) are provided with placeholder values.

Signed-off-by: Marcelo Henrique Diniz de Araujo <mdinizde@redhat.com>

![Peek 2024-05-22 10-20](https://github.com/camel-tooling/camel-language-server/assets/51032022/bd2e8176-fdea-4011-bf01-cd9ba3e6350d)