### PR TITLE
Provide empty implementation for setTrace

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelLanguageServer.java
@@ -29,6 +29,7 @@ import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SetTraceParams;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -153,4 +154,8 @@ public class CamelLanguageServer extends AbstractLanguageServer implements Langu
 		return null;
 	}
 	
+	@Override
+	public void setTrace(SetTraceParams params) {
+		// Empty implementation to avoid error in VS Code
+	}
 }


### PR DESCRIPTION
it avoids having warning messages logged with stacktraces. It helps to clarify log and avoid misleading information.

other Langauge servers  used the same workaround: https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2893/files https://github.com/eclipse/lsp4mp/blob/f191f42ec1a311937ecadb198c7498194be2dac3/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/MicroProfileLanguageServer.java#L187

it will avoid this kind of message in the output:
```
Nov 19, 2024 12:10:14 PM org.eclipse.lsp4j.jsonrpc.RemoteEndpoint handleNotification
WARNING: Notification threw an exception: {
  “jsonrpc”: “2.0",
  “method”: “$/setTrace”,
  “params”: {
    “value”: “off”
  }
}
java.lang.UnsupportedOperationException
    at org.eclipse.lsp4j.services.LanguageServer.setTrace(LanguageServer.java:125)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$recursiveFindRpcMethods$0(GenericEndpoint.java:65)
    at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.notify(GenericEndpoint.java:160)
    at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleNotification(RemoteEndpoint.java:231)
    at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:198)
    at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:185)
    at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:97)
    at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:114)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.base/java.lang.Thread.run(Thread.java:1570)
 ```