### PR TITLE
FUSETOOLS2-2508 - Configure log to use a specific Camel LSP folder

### DIFF
--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -2,7 +2,7 @@ status = warn
 name= RollingFileLogConfigCamelLSP
 
 # Log files location
-property.basePath = ${sys:java.io.tmpdir}
+property.basePath = ${sys:java.io.tmpdir}/camel-lsp
 
 # RollingFileAppender name, pattern, path and rollover policy
 appender.rolling.type = RollingFile


### PR DESCRIPTION
otherwise when trying to walk files to delete old logs, depending on the content of /tmp and the rights, an exception can be thrown

It will also have the side effect to be more performant by not scanning the full /tmp folder everyday or every time the log reach 10MB

