### PR TITLE
FUSETOOLS2-2529 - avoid NPE in FoldingRange

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/CamelTextDocumentService.java
@@ -280,7 +280,12 @@ public class CamelTextDocumentService implements TextDocumentService {
 		LOGGER.info("foldingRange: {}", textDocument);
 		String uri = textDocument.getUri();
 		TextDocumentItem textDocumentItem = openedDocuments.get(uri);
-		return new FoldingRangeProcessor().computeFoldingRanges(textDocumentItem);
+		if (textDocumentItem != null) {
+			// We support providing folding rages only when the document are opened. It doesn't make sense anyway when it is closed
+			return new FoldingRangeProcessor().computeFoldingRanges(textDocumentItem);
+		} else {
+			return CompletableFuture.completedFuture(Collections.emptyList());
+		}
 	}
 
 	@Override

--- a/src/test/java/com/github/cameltooling/lsp/internal/folding/FoldingRangeRouteTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/folding/FoldingRangeRouteTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.util.List;
 
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.FoldingRange;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.Test;
 
 import com.github.cameltooling.lsp.internal.AbstractCamelLanguageServerTest;
@@ -65,6 +67,19 @@ class FoldingRangeRouteTest extends AbstractCamelLanguageServerTest {
 	void testNoFoldingRangeOnInvalidJavaFile() throws Exception {
 		File file = new File("src/test/resources/workspace/AnInvalid.java");
 		CamelLanguageServer languageServer = initializeLanguageServer(file);
+		
+		List<FoldingRange> foldingRanges = getFoldingRanges(file, languageServer).get();
+		
+		assertThat(foldingRanges).isEmpty();
+	}
+	
+	@Test
+	void testNoFoldingRangeOnClosedJavaFile() throws Exception {
+		File file = new File("src/test/resources/workspace/AnInterface.java");
+		CamelLanguageServer languageServer = initializeLanguageServer(file);
+		
+		DidCloseTextDocumentParams params = new DidCloseTextDocumentParams(new TextDocumentIdentifier(file.toURI().toString()));
+		languageServer.getTextDocumentService().didClose(params );
 		
 		List<FoldingRange> foldingRanges = getFoldingRanges(file, languageServer).get();
 		


### PR DESCRIPTION
it sounds like the IDE is requesting a folding range (so places to place little +/- to fold a part of the text) on a not opened document. I do not understand what could be the purpose. Ignoring the request to avoid NPE until we have more information for another use case (uri provided in a different shape?). It will avoid the NPE and the missing functionalities won't be critical.
