### PR TITLE
FUSETOOLS2-2584 - workaround to publish SBom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
 								<goals>
 									<goal>makeAggregateBom</goal>
 								</goals>
+								<configuration>
+									<!-- to be removed when https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597 is fixed-->
+									<skipNotDeployed>false</skipNotDeployed>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
due to https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597

locally got the sbom built:
```
[INFO] CycloneDX: Creating BOM version 1.6 with 132 component(s)
[INFO] CycloneDX: Writing and validating BOM (XML): /home/apupier/git/camel-language-server/target/bom.xml
[INFO]            attaching as camel-lsp-server-1.32.0-SNAPSHOT-cyclonedx.xml
[INFO] CycloneDX: Writing and validating BOM (JSON): /home/apupier/git/camel-language-server/target/bom.json
[WARNING] Unknown keyword meta:enum - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword or if it should generate annotations AnnotationKeyword
[WARNING] Unknown keyword deprecated - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword or if it should generate annotations AnnotationKeyword
[INFO]            attaching as camel-lsp-server-1.32.0-SNAPSHOT-cyclonedx.json
[INFO] 
```

