### PR TITLE
FUSETOOLS2-2586 - Improve rendering in VS Code of documentation for

### DIFF
--- a/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelOptionNamesCompletionsFuture.java
+++ b/src/main/java/com/github/cameltooling/lsp/internal/completion/CamelOptionNamesCompletionsFuture.java
@@ -210,7 +210,7 @@ public class CamelOptionNamesCompletionsFuture implements Function<CamelCatalog,
 		if (defaultValue != null && !defaultValue.isEmpty() && !"null".equals(defaultValue)) {
 			addMarkdownIfNotEmpty(doc, "**Default value:** ", "*" + defaultValue + "*");
 		}
-		doc.append("<br>");
+		doc.append("\\\n");
 		doc.append(parameter.getDescription());
 		return new MarkupContent(MarkupKind.MARKDOWN, doc.toString());
 	}
@@ -242,7 +242,7 @@ public class CamelOptionNamesCompletionsFuture implements Function<CamelCatalog,
 		if (value != null && !value.isEmpty() && !"null".equals(value)) {
 			description.append(key);
 			description.append(value);
-			description.append("<br>");
+			description.append("\\\n");
 		}
 	}
 


### PR DESCRIPTION
completion

the line breaks were not rendered because <br > was used but it is <br /> which is the correct character
BUT `<br />` was not working, so using `\` with a new line as a hard-break of GitHub Flavored markdown. It is working both in VS COde and Eclipse

![image](https://github.com/user-attachments/assets/0cba48fb-d3ae-49d8-9adf-052ef8de1985)

