### PR TITLE
Disabling 2 very flaky tests on Mac related to Websocket

### DIFF
--- a/src/test/java/com/github/cameltooling/lsp/internal/RunnerWebSocketTest.java
+++ b/src/test/java/com/github/cameltooling/lsp/internal/RunnerWebSocketTest.java
@@ -37,6 +37,8 @@ import jakarta.websocket.Session;
 import org.glassfish.tyrus.client.ClientManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 class RunnerWebSocketTest {
 	
@@ -74,6 +76,8 @@ class RunnerWebSocketTest {
 	}
 	
 	@Test
+	@DisabledOnOs(value = OS.MAC,
+		disabledReason = "On the GitHub CI, recently on Mac, the hostname is very often not resolved and return null, we need this information to start the test. Also, this websocket feature is not very used a lot.") 
 	void testWebsocketServerStartedWithHostnameSpecified() throws Exception {
 		String localHostname = retrieveLocalHostname();
 		String[] arguments = new String[] {"--websocket", "--hostname="+localHostname};
@@ -82,6 +86,8 @@ class RunnerWebSocketTest {
 	}
 
 	@Test
+	@DisabledOnOs(value = OS.MAC,
+		disabledReason = "On the GitHub CI, recently on Mac, the hostname is very often not resolved and return null, we need this information to start the test. Also, this websocket feature is not very used a lot.") 
 	void testWebsocketServerStartedWithHostnameAndPortAndContextPathSpecified() throws Exception {
 		String localHostname = retrieveLocalHostname();
 		String[] arguments = new String[] {"--websocket", "--hostname="+localHostname, "--port=8027", "--contextPath=/test"};


### PR DESCRIPTION
On the GitHub CI, recently on Mac, the hostname is very often not resolved and return null, we need this information to start the test. Also, this websocket feature is not very used a lot.

